### PR TITLE
Toggle line numbers

### DIFF
--- a/cmd/micro/settings.go
+++ b/cmd/micro/settings.go
@@ -21,6 +21,7 @@ type Settings struct {
 	AutoIndent   bool   `json:"autoindent"`
 	Syntax       bool   `json:"syntax"`
 	TabsToSpaces bool   `json:"tabsToSpaces"`
+	Ruler        bool   `json:"ruler"`
 }
 
 // InitSettings initializes the options map and sets all options to their default values
@@ -61,6 +62,7 @@ func DefaultSettings() Settings {
 		AutoIndent:   true,
 		Syntax:       true,
 		TabsToSpaces: false,
+		Ruler:        true,
 	}
 }
 
@@ -103,7 +105,17 @@ func SetOption(view *View, args []string) {
 					messenger.Error("Invalid value for " + option)
 					return
 				}
+			} else if option == "ruler" {
+				if value == "on" {
+					settings.Ruler = true
+				} else if value == "off" {
+					settings.Ruler = false
+				} else {
+					messenger.Error("Invalid value for " + option)
+					return
+				}
 			}
+
 			err := WriteSettings(filename)
 			if err != nil {
 				messenger.Error("Error writing to settings.json: " + err.Error())

--- a/cmd/micro/settings.go
+++ b/cmd/micro/settings.go
@@ -12,7 +12,7 @@ import (
 var settings Settings
 
 // All the possible settings
-var possibleSettings = []string{"colorscheme", "tabsize", "autoindent", "syntax", "tabsToSpaces"}
+var possibleSettings = []string{"colorscheme", "tabsize", "autoindent", "syntax", "tabsToSpaces", "ruler"}
 
 // The Settings struct contains the settings for micro
 type Settings struct {

--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -1,13 +1,14 @@
 package main
 
 import (
-	"github.com/atotto/clipboard"
-	"github.com/gdamore/tcell"
-	"github.com/mitchellh/go-homedir"
 	"io/ioutil"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/atotto/clipboard"
+	"github.com/gdamore/tcell"
+	"github.com/mitchellh/go-homedir"
 )
 
 // The View struct stores information about a view into a buffer.
@@ -509,6 +510,12 @@ func (v *View) HandleEvent(event tcell.Event) {
 		case tcell.KeyCtrlD:
 			v.HalfPageDown()
 			relocate = false
+		case tcell.KeyCtrlR:
+			if settings.Ruler == false {
+				settings.Ruler = true
+			} else {
+				settings.Ruler = false
+			}
 		case tcell.KeyRune:
 			// Insert a character
 			if v.cursor.HasSelection() {
@@ -620,8 +627,11 @@ func (v *View) DisplayView() {
 	// We are going to have to offset by that amount
 	maxLineLength := len(strconv.Itoa(len(v.buf.lines)))
 	// + 1 for the little space after the line number
-	v.lineNumOffset = maxLineLength + 1
-
+	if settings.Ruler == true {
+		v.lineNumOffset = maxLineLength + 1
+	} else {
+		v.lineNumOffset = 0
+	}
 	var highlightStyle tcell.Style
 
 	for lineN := 0; lineN < v.height; lineN++ {
@@ -639,20 +649,25 @@ func (v *View) DisplayView() {
 			lineNumStyle = style
 		}
 		// Write the spaces before the line number if necessary
-		lineNum := strconv.Itoa(lineN + v.topline + 1)
-		for i := 0; i < maxLineLength-len(lineNum); i++ {
-			screen.SetContent(x, lineN, ' ', nil, lineNumStyle)
-			x++
-		}
-		// Write the actual line number
-		for _, ch := range lineNum {
-			screen.SetContent(x, lineN, ch, nil, lineNumStyle)
-			x++
-		}
-		// Write the extra space
-		screen.SetContent(x, lineN, ' ', nil, lineNumStyle)
-		x++
+		var lineNum string
+		if settings.Ruler == true {
+			lineNum = strconv.Itoa(lineN + v.topline + 1)
+			for i := 0; i < maxLineLength-len(lineNum); i++ {
+				screen.SetContent(x, lineN, ' ', nil, lineNumStyle)
+				x++
+			}
+			// Write the actual line number
+			for _, ch := range lineNum {
+				screen.SetContent(x, lineN, ch, nil, lineNumStyle)
+				x++
+			}
 
+			if settings.Ruler == true {
+				// Write the extra space
+				screen.SetContent(x, lineN, ' ', nil, lineNumStyle)
+				x++
+			}
+		}
 		// Write the line
 		tabchars := 0
 		runes := []rune(line)


### PR DESCRIPTION
Ctrl+R for ruler

Example addition to settings.json to boot without ruler

```
{
    "colorscheme": "solarized",
    "tabsize": 4,
    "autoindent": true,
    "syntax": true,
    "tabsToSpaces": false,
    "ruler": false
}
```