### PR TITLE
ignore binary explicitly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-micro
+./micro
 !cmd/micro
 binaries/


### PR DESCRIPTION
fixes an issue where a go IDE was ignoring the entire cmd/micro directory (even with the !cmd/micro line)