### PR TITLE
gofmt on save

### DIFF
--- a/cmd/micro/command.go
+++ b/cmd/micro/command.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -30,7 +31,7 @@ func gofmt(file string) error {
 	cmd.Start()
 	err := cmd.Wait()
 	if err != nil {
-		return err
+		return errors.New("Check syntax ") //TODO: highlight or display locations
 	}
 	return nil
 }

--- a/cmd/micro/command.go
+++ b/cmd/micro/command.go
@@ -36,6 +36,17 @@ func gofmt(file string) error {
 	return nil
 }
 
+// goimports runs goimports on a file
+func goimports(file string) error {
+	cmd := exec.Command("goimports", "-w", file)
+	cmd.Start()
+	err := cmd.Wait()
+	if err != nil {
+		return errors.New("Check syntax ") //TODO: highlight or display locations
+	}
+	return nil
+}
+
 // HandleShellCommand runs the shell command and outputs to DisplayBlock
 func HandleShellCommand(input string, view *View, openTerm bool) {
 	inputCmd := strings.Split(input, " ")[0]

--- a/cmd/micro/command.go
+++ b/cmd/micro/command.go
@@ -24,6 +24,17 @@ func RunShellCommand(input string) (string, error) {
 	return outstring, err
 }
 
+// gofmt runs gofmt on a file
+func gofmt(file string) error {
+	cmd := exec.Command("gofmt", "-w", file)
+	cmd.Start()
+	err := cmd.Wait()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // HandleShellCommand runs the shell command and outputs to DisplayBlock
 func HandleShellCommand(input string, view *View, openTerm bool) {
 	inputCmd := strings.Split(input, " ")[0]

--- a/cmd/micro/settings.go
+++ b/cmd/micro/settings.go
@@ -12,7 +12,7 @@ import (
 var settings Settings
 
 // All the possible settings
-var possibleSettings = []string{"colorscheme", "tabsize", "autoindent", "syntax", "tabsToSpaces", "ruler"}
+var possibleSettings = []string{"colorscheme", "tabsize", "autoindent", "syntax", "tabsToSpaces", "ruler", "gofmt"}
 
 // The Settings struct contains the settings for micro
 type Settings struct {
@@ -22,6 +22,7 @@ type Settings struct {
 	Syntax       bool   `json:"syntax"`
 	TabsToSpaces bool   `json:"tabsToSpaces"`
 	Ruler        bool   `json:"ruler"`
+	Gofmt        bool   `json:"gofmt"`
 }
 
 // InitSettings initializes the options map and sets all options to their default values
@@ -119,6 +120,15 @@ func SetOption(view *View, args []string) {
 					settings.Ruler = true
 				} else if value == "off" {
 					settings.Ruler = false
+				} else {
+					messenger.Error("Invalid value for " + option)
+					return
+				}
+			} else if option == "gofmt" {
+				if value == "on" {
+					settings.Gofmt = true
+				} else if value == "off" {
+					settings.Gofmt = false
 				} else {
 					messenger.Error("Invalid value for " + option)
 					return

--- a/cmd/micro/settings.go
+++ b/cmd/micro/settings.go
@@ -12,7 +12,7 @@ import (
 var settings Settings
 
 // All the possible settings
-var possibleSettings = []string{"colorscheme", "tabsize", "autoindent", "syntax", "tabsToSpaces", "ruler", "gofmt"}
+var possibleSettings = []string{"colorscheme", "tabsize", "autoindent", "syntax", "tabsToSpaces", "ruler", "gofmt", "goimports"}
 
 // The Settings struct contains the settings for micro
 type Settings struct {
@@ -23,6 +23,7 @@ type Settings struct {
 	TabsToSpaces bool   `json:"tabsToSpaces"`
 	Ruler        bool   `json:"ruler"`
 	Gofmt        bool   `json:"gofmt"`
+	Goimports    bool   `json:"goimports"`
 }
 
 // InitSettings initializes the options map and sets all options to their default values
@@ -64,6 +65,8 @@ func DefaultSettings() Settings {
 		Syntax:       true,
 		TabsToSpaces: false,
 		Ruler:        true,
+		Gofmt:        false,
+		Goimports:    false,
 	}
 }
 
@@ -127,6 +130,16 @@ func SetOption(view *View, args []string) {
 			} else if option == "gofmt" {
 				if value == "on" {
 					settings.Gofmt = true
+				} else if value == "off" {
+					settings.Gofmt = false
+				} else {
+					messenger.Error("Invalid value for " + option)
+					return
+				}
+			} else if option == "goimports" {
+				if value == "on" {
+					settings.Gofmt = false // goimports does gofmt
+					settings.Goimports = true
 				} else if value == "off" {
 					settings.Gofmt = false
 				} else {

--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -200,18 +200,36 @@ func (v *View) Save() {
 	} else {
 		messenger.Message("Saved " + v.buf.path)
 		if v.buf.filetype == "Go" {
-			if settings.Gofmt == true {
-				messenger.Message("Running gofmt...")
-				err := gofmt(v.buf.path)
-				if err != nil {
-					messenger.Error(err)
-				} else {
-					messenger.Message("gofmt complete")
-				}
-				v.reOpen()
-			}
+			v.goSave()
 		}
 	}
+}
+
+// goSave() runs after saving .go files
+func (v *View) goSave() {
+	if settings.Gofmt == true {
+		messenger.Message("Running gofmt...")
+		err := gofmt(v.buf.path)
+		if err != nil {
+			messenger.Error(err)
+		} else {
+			messenger.Message("Saved " + v.buf.path)
+		}
+		v.reOpen()
+		return
+	}
+
+	if settings.Goimports == true {
+		messenger.Message("Running goimports...")
+		err := goimports(v.buf.path)
+		if err != nil {
+			messenger.Error(err)
+		} else {
+			messenger.Message("Saved " + v.buf.path)
+		}
+		v.reOpen()
+	}
+	return
 }
 
 // Close and Re-open the current file.

--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -243,7 +243,9 @@ func (v *View) reOpen() {
 			return
 		}
 		buf := NewBuffer(string(file), filename)
-		v.OpenBuffer(buf)
+		v.buf = buf
+		v.matches = Match(v)
+		v.Relocate()
 	}
 }
 

--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -200,13 +200,16 @@ func (v *View) Save() {
 	} else {
 		messenger.Message("Saved " + v.buf.path)
 		if v.buf.filetype == "Go" {
-			messenger.Message("Running gofmt...")
-			err := gofmt(v.buf.path)
-			if err != nil {
-				messenger.Error("Syntax Error")
+			if settings.Gofmt == true {
+				messenger.Message("Running gofmt...")
+				err := gofmt(v.buf.path)
+				if err != nil {
+					messenger.Error(err)
+				} else {
+					messenger.Message("gofmt complete")
+				}
+				v.reOpen()
 			}
-			v.reOpen()
-
 		}
 	}
 }

--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -199,6 +199,30 @@ func (v *View) Save() {
 		messenger.Error(err.Error())
 	} else {
 		messenger.Message("Saved " + v.buf.path)
+		if v.buf.filetype == "Go" {
+			messenger.Message("Running gofmt...")
+			err := gofmt(v.buf.path)
+			if err != nil {
+				messenger.Error("Syntax Error")
+			}
+			v.reOpen()
+
+		}
+	}
+}
+
+// Close and Re-open the current file.
+func (v *View) reOpen() {
+	if v.CanClose("Continue? (yes, no, save) ") {
+		file, err := ioutil.ReadFile(v.buf.path)
+		filename := v.buf.name
+
+		if err != nil {
+			messenger.Error(err.Error())
+			return
+		}
+		buf := NewBuffer(string(file), filename)
+		v.OpenBuffer(buf)
 	}
 }
 


### PR DESCRIPTION
This pull requests introduces a setting for `goimports` or `gofmt` on save when dealing with Go files.

 [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports) is a drop-in replacement for `gofmt` that automatically adds the import lines at the top of .go files.