### PR TITLE
gofmt-on-save redone for new bindings

### DIFF
--- a/cmd/micro/bindings.go
+++ b/cmd/micro/bindings.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/gdamore/tcell"
@@ -380,8 +382,37 @@ func Save(v *View) bool {
 		messenger.Error(err.Error())
 	} else {
 		messenger.Message("Saved " + v.buf.path)
+		switch v.buf.filetype {
+		case "Go":
+			GoSave(v)
+		}
 	}
 	return true
+}
+
+func GoSave(v *View) {
+	if settings.GoImports == true {
+		messenger.Message("Running goimports...")
+		err := goimports(v.buf.path)
+		if err != nil {
+			messenger.Error(err)
+		} else {
+			messenger.Message("Saved " + v.buf.path)
+		}
+		v.reOpen()
+	} else if settings.GoFmt == true {
+		messenger.Message("Running gofmt...")
+		err := gofmt(v.buf.path)
+		if err != nil {
+			messenger.Error(err)
+		} else {
+			messenger.Message("Saved " + v.buf.path)
+		}
+		v.reOpen()
+		return
+	}
+
+	return
 }
 
 // Find opens a prompt and searches forward for the input
@@ -566,4 +597,26 @@ func ToggleRuler(v *View) bool {
 // None is no action
 func None() bool {
 	return false
+}
+
+// gofmt runs gofmt on a file
+func gofmt(file string) error {
+	cmd := exec.Command("gofmt", "-w", file)
+	cmd.Start()
+	err := cmd.Wait()
+	if err != nil {
+		return errors.New("Check syntax ") //TODO: highlight or display locations
+	}
+	return nil
+}
+
+// goimports runs goimports on a file
+func goimports(file string) error {
+	cmd := exec.Command("goimports", "-w", file)
+	cmd.Start()
+	err := cmd.Wait()
+	if err != nil {
+		return errors.New("Check syntax ") //TODO: highlight or display locations
+	}
+	return nil
 }

--- a/cmd/micro/settings.go
+++ b/cmd/micro/settings.go
@@ -12,7 +12,7 @@ import (
 var settings Settings
 
 // All the possible settings
-var possibleSettings = []string{"colorscheme", "tabsize", "autoindent", "syntax", "tabsToSpaces", "ruler"}
+var possibleSettings = []string{"colorscheme", "tabsize", "autoindent", "syntax", "tabsToSpaces", "ruler", "gofmt", "goimports"}
 
 // The Settings struct contains the settings for micro
 type Settings struct {
@@ -22,6 +22,8 @@ type Settings struct {
 	Syntax       bool   `json:"syntax"`
 	TabsToSpaces bool   `json:"tabsToSpaces"`
 	Ruler        bool   `json:"ruler"`
+	GoFmt        bool   `json:"gofmt"`
+	GoImports    bool   `json:"goimports"`
 }
 
 // InitSettings initializes the options map and sets all options to their default values
@@ -63,6 +65,8 @@ func DefaultSettings() Settings {
 		Syntax:       true,
 		TabsToSpaces: false,
 		Ruler:        true,
+		GoFmt:        false,
+		GoImports:    false,
 	}
 }
 
@@ -119,6 +123,25 @@ func SetOption(view *View, args []string) {
 					settings.Ruler = true
 				} else if value == "off" {
 					settings.Ruler = false
+				} else {
+					messenger.Error("Invalid value for " + option)
+					return
+				}
+			} else if option == "gofmt" {
+				if value == "on" {
+					settings.GoFmt = true
+				} else if value == "off" {
+					settings.GoFmt = false
+				} else {
+					messenger.Error("Invalid value for " + option)
+					return
+				}
+			} else if option == "goimports" {
+				if value == "on" {
+					settings.GoFmt = false // goimports does gofmt
+					settings.GoImports = true
+				} else if value == "off" {
+					settings.GoFmt = false
 				} else {
 					messenger.Error("Invalid value for " + option)
 					return

--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io/ioutil"
 	"strconv"
 	"strings"
 	"time"
@@ -160,6 +161,23 @@ func (v *View) OpenBuffer(buf *Buffer) {
 	// the editor is opened
 	v.mouseReleased = true
 	v.lastClickTime = time.Time{}
+}
+
+// Close and Re-open the current file.
+func (v *View) reOpen() {
+	if v.CanClose("Continue? (yes, no, save) ") {
+		file, err := ioutil.ReadFile(v.buf.path)
+		filename := v.buf.name
+
+		if err != nil {
+			messenger.Error(err.Error())
+			return
+		}
+		buf := NewBuffer(string(file), filename)
+		v.buf = buf
+		v.matches = Match(v)
+		v.Relocate()
+	}
 }
 
 // OpenFile opens a new file in the current view


### PR DESCRIPTION
This pull requests introduces a setting for goimports or gofmt on save when dealing with Go files.

goimports is a drop-in replacement for gofmt that automatically adds the import lines at the top of .go files.
