### PR TITLE
[WIP] Ctrl, Alt, Shift + arrow keys

### DIFF
--- a/cmd/micro/bindings.go
+++ b/cmd/micro/bindings.go
@@ -298,6 +298,17 @@ func (v *View) CursorLeft() bool {
 	return true
 }
 
+// CursorRight moves the cursor right
+func (v *View) CursorRight() bool {
+	if v.cursor.HasSelection() {
+		v.cursor.SetLoc(v.cursor.curSelection[1] - 1)
+		v.cursor.ResetSelection()
+	} else {
+		v.cursor.Right()
+	}
+	return true
+}
+
 func (v *View) WordRight() bool {
 	v.cursor.WordRight()
 	return true
@@ -334,7 +345,7 @@ func (v *View) SelectWordRight() bool {
 		v.cursor.origSelection[0] = loc
 	}
 	v.cursor.WordRight()
-	v.cursor.SelectTo(v.cursor.Loc() - 1)
+	v.cursor.SelectTo(v.cursor.Loc())
 	return true
 }
 
@@ -345,17 +356,6 @@ func (v *View) SelectWordLeft() bool {
 	}
 	v.cursor.WordLeft()
 	v.cursor.SelectTo(v.cursor.Loc())
-	return true
-}
-
-// CursorRight moves the cursor right
-func (v *View) CursorRight() bool {
-	if v.cursor.HasSelection() {
-		v.cursor.SetLoc(v.cursor.curSelection[1] - 1)
-		v.cursor.ResetSelection()
-	} else {
-		v.cursor.Right()
-	}
 	return true
 }
 

--- a/cmd/micro/bindings.go
+++ b/cmd/micro/bindings.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gdamore/tcell"
 	"github.com/mitchellh/go-homedir"
 	"github.com/zyedidia/clipboard"
+	"github.com/zyedidia/tcell"
 )
 
 var bindings map[tcell.Key]func(*View) bool
@@ -21,36 +21,42 @@ func InitBindings() {
 	bindings = make(map[tcell.Key]func(*View) bool)
 
 	actions := map[string]func(*View) bool{
-		"CursorUp":     (*View).CursorUp,
-		"CursorDown":   (*View).CursorDown,
-		"CursorLeft":   (*View).CursorLeft,
-		"CursorRight":  (*View).CursorRight,
-		"InsertEnter":  (*View).InsertEnter,
-		"InsertSpace":  (*View).InsertSpace,
-		"Backspace":    (*View).Backspace,
-		"Delete":       (*View).Delete,
-		"InsertTab":    (*View).InsertTab,
-		"Save":         (*View).Save,
-		"Find":         (*View).Find,
-		"FindNext":     (*View).FindNext,
-		"FindPrevious": (*View).FindPrevious,
-		"Undo":         (*View).Undo,
-		"Redo":         (*View).Redo,
-		"Copy":         (*View).Copy,
-		"Cut":          (*View).Cut,
-		"CutLine":      (*View).CutLine,
-		"Paste":        (*View).Paste,
-		"SelectAll":    (*View).SelectAll,
-		"OpenFile":     (*View).OpenFile,
-		"Beginning":    (*View).Beginning,
-		"End":          (*View).End,
-		"PageUp":       (*View).PageUp,
-		"PageDown":     (*View).PageDown,
-		"HalfPageUp":   (*View).HalfPageUp,
-		"HalfPageDown": (*View).HalfPageDown,
-		"StartOfLine":  (*View).StartOfLine,
-		"EndOfLine":    (*View).EndOfLine,
-		"ToggleRuler":  (*View).ToggleRuler,
+		"CursorUp":        (*View).CursorUp,
+		"CursorDown":      (*View).CursorDown,
+		"CursorLeft":      (*View).CursorLeft,
+		"CursorRight":     (*View).CursorRight,
+		"SelectLeft":      (*View).SelectLeft,
+		"SelectRight":     (*View).SelectRight,
+		"WordRight":       (*View).WordRight,
+		"WordLeft":        (*View).WordLeft,
+		"SelectWordRight": (*View).SelectWordRight,
+		"SelectWordLeft":  (*View).SelectWordLeft,
+		"InsertEnter":     (*View).InsertEnter,
+		"InsertSpace":     (*View).InsertSpace,
+		"Backspace":       (*View).Backspace,
+		"Delete":          (*View).Delete,
+		"InsertTab":       (*View).InsertTab,
+		"Save":            (*View).Save,
+		"Find":            (*View).Find,
+		"FindNext":        (*View).FindNext,
+		"FindPrevious":    (*View).FindPrevious,
+		"Undo":            (*View).Undo,
+		"Redo":            (*View).Redo,
+		"Copy":            (*View).Copy,
+		"Cut":             (*View).Cut,
+		"CutLine":         (*View).CutLine,
+		"Paste":           (*View).Paste,
+		"SelectAll":       (*View).SelectAll,
+		"OpenFile":        (*View).OpenFile,
+		"Beginning":       (*View).Beginning,
+		"End":             (*View).End,
+		"PageUp":          (*View).PageUp,
+		"PageDown":        (*View).PageDown,
+		"HalfPageUp":      (*View).HalfPageUp,
+		"HalfPageDown":    (*View).HalfPageDown,
+		"StartOfLine":     (*View).StartOfLine,
+		"EndOfLine":       (*View).EndOfLine,
+		"ToggleRuler":     (*View).ToggleRuler,
 	}
 
 	keys := map[string]tcell.Key{
@@ -58,6 +64,26 @@ func InitBindings() {
 		"Down":           tcell.KeyDown,
 		"Right":          tcell.KeyRight,
 		"Left":           tcell.KeyLeft,
+		"AltUp":          tcell.KeyAltUp,
+		"AltDown":        tcell.KeyAltDown,
+		"AltLeft":        tcell.KeyAltLeft,
+		"AltRight":       tcell.KeyAltRight,
+		"CtrlUp":         tcell.KeyCtrlUp,
+		"CtrlDown":       tcell.KeyCtrlDown,
+		"CtrlLeft":       tcell.KeyCtrlLeft,
+		"CtrlRight":      tcell.KeyCtrlRight,
+		"ShiftUp":        tcell.KeyShiftUp,
+		"ShiftDown":      tcell.KeyShiftDown,
+		"ShiftLeft":      tcell.KeyShiftLeft,
+		"ShiftRight":     tcell.KeyShiftRight,
+		"AltShiftUp":     tcell.KeyAltShiftUp,
+		"AltShiftDown":   tcell.KeyAltShiftDown,
+		"AltShiftLeft":   tcell.KeyAltShiftLeft,
+		"AltShiftRight":  tcell.KeyAltShiftRight,
+		"CtrlShiftUp":    tcell.KeyCtrlShiftUp,
+		"CtrlShiftDown":  tcell.KeyCtrlShiftDown,
+		"CtrlShiftLeft":  tcell.KeyCtrlShiftLeft,
+		"CtrlShiftRight": tcell.KeyCtrlShiftRight,
 		"UpLeft":         tcell.KeyUpLeft,
 		"UpRight":        tcell.KeyUpRight,
 		"DownLeft":       tcell.KeyDownLeft,
@@ -209,35 +235,41 @@ func InitBindings() {
 // DefaultBindings returns a map containing micro's default keybindings
 func DefaultBindings() map[string]string {
 	return map[string]string{
-		"Up":         "CursorUp",
-		"Down":       "CursorDown",
-		"Right":      "CursorRight",
-		"Left":       "CursorLeft",
-		"Enter":      "InsertEnter",
-		"Space":      "InsertSpace",
-		"Backspace":  "Backspace",
-		"Backspace2": "Backspace",
-		"Tab":        "InsertTab",
-		"CtrlO":      "OpenFile",
-		"CtrlS":      "Save",
-		"CtrlF":      "Find",
-		"CtrlN":      "FindNext",
-		"CtrlP":      "FindPrevious",
-		"CtrlZ":      "Undo",
-		"CtrlY":      "Redo",
-		"CtrlC":      "Copy",
-		"CtrlX":      "Cut",
-		"CtrlK":      "CutLine",
-		"CtrlV":      "Paste",
-		"CtrlA":      "SelectAll",
-		"Home":       "Beginning",
-		"End":        "End",
-		"PgUp":       "PageUp",
-		"PgDn":       "PageDown",
-		"CtrlU":      "HalfPageUp",
-		"CtrlD":      "HalfPageDown",
-		"CtrlR":      "ToggleRuler",
-		"Delete":     "Delete",
+		"Up":            "CursorUp",
+		"Down":          "CursorDown",
+		"Right":         "CursorRight",
+		"Left":          "CursorLeft",
+		"ShiftLeft":     "SelectLeft",
+		"ShiftRight":    "SelectRight",
+		"AltLeft":       "WordLeft",
+		"AltRight":      "WordRight",
+		"AltShiftRight": "SelectWordRight",
+		"AltShiftLeft":  "SelectWordLeft",
+		"Enter":         "InsertEnter",
+		"Space":         "InsertSpace",
+		"Backspace":     "Backspace",
+		"Backspace2":    "Backspace",
+		"Tab":           "InsertTab",
+		"CtrlO":         "OpenFile",
+		"CtrlS":         "Save",
+		"CtrlF":         "Find",
+		"CtrlN":         "FindNext",
+		"CtrlP":         "FindPrevious",
+		"CtrlZ":         "Undo",
+		"CtrlY":         "Redo",
+		"CtrlC":         "Copy",
+		"CtrlX":         "Cut",
+		"CtrlK":         "CutLine",
+		"CtrlV":         "Paste",
+		"CtrlA":         "SelectAll",
+		"Home":          "Beginning",
+		"End":           "End",
+		"PgUp":          "PageUp",
+		"PgDn":          "PageDown",
+		"CtrlU":         "HalfPageUp",
+		"CtrlD":         "HalfPageDown",
+		"CtrlR":         "ToggleRuler",
+		"Delete":        "Delete",
 	}
 }
 
@@ -259,6 +291,56 @@ func (v *View) CursorDown() bool {
 func (v *View) CursorLeft() bool {
 	v.cursor.ResetSelection()
 	v.cursor.Left()
+	return true
+}
+
+func (v *View) WordRight() bool {
+	v.cursor.WordRight()
+	return true
+}
+
+func (v *View) WordLeft() bool {
+	v.cursor.WordLeft()
+	return true
+}
+
+func (v *View) SelectLeft() bool {
+	loc := v.cursor.Loc()
+	if !v.cursor.HasSelection() {
+		v.cursor.origSelection[0] = loc
+	}
+	v.cursor.SelectTo(loc - 1)
+	v.cursor.Left()
+	return true
+}
+
+func (v *View) SelectRight() bool {
+	loc := v.cursor.Loc()
+	if !v.cursor.HasSelection() {
+		v.cursor.origSelection[0] = loc
+	}
+	v.cursor.SelectTo(loc + 1)
+	v.cursor.Right()
+	return true
+}
+
+func (v *View) SelectWordRight() bool {
+	loc := v.cursor.Loc()
+	if !v.cursor.HasSelection() {
+		v.cursor.origSelection[0] = loc
+	}
+	v.cursor.WordRight()
+	v.cursor.SelectTo(v.cursor.Loc())
+	return true
+}
+
+func (v *View) SelectWordLeft() bool {
+	loc := v.cursor.Loc()
+	if !v.cursor.HasSelection() {
+		v.cursor.origSelection[0] = loc
+	}
+	v.cursor.WordLeft()
+	v.cursor.SelectTo(v.cursor.Loc())
 	return true
 }
 

--- a/cmd/micro/bindings.go
+++ b/cmd/micro/bindings.go
@@ -54,7 +54,7 @@ func InitBindings() {
 		"Paste":               (*View).Paste,
 		"SelectAll":           (*View).SelectAll,
 		"OpenFile":            (*View).OpenFile,
-		"Beginning":           (*View).Beginning,
+		"Start":               (*View).Start,
 		"End":                 (*View).End,
 		"PageUp":              (*View).PageUp,
 		"PageDown":            (*View).PageDown,
@@ -276,7 +276,7 @@ func DefaultBindings() map[string]string {
 		"CtrlK":          "CutLine",
 		"CtrlV":          "Paste",
 		"CtrlA":          "SelectAll",
-		"Home":           "Beginning",
+		"Home":           "Start",
 		"End":            "End",
 		"PgUp":           "PageUp",
 		"PgDn":           "PageDown",
@@ -323,16 +323,19 @@ func (v *View) CursorRight() bool {
 	return true
 }
 
+// WordRight moves the cursor one word to the right
 func (v *View) WordRight() bool {
 	v.cursor.WordRight()
 	return true
 }
 
+// WordLeft moves the cursor one word to the left
 func (v *View) WordLeft() bool {
 	v.cursor.WordLeft()
 	return true
 }
 
+// SelectLeft selects the character to the left of the cursor
 func (v *View) SelectLeft() bool {
 	loc := v.cursor.Loc()
 	if !v.cursor.HasSelection() {
@@ -343,6 +346,7 @@ func (v *View) SelectLeft() bool {
 	return true
 }
 
+// SelectRight selects the character to the right of the cursor
 func (v *View) SelectRight() bool {
 	loc := v.cursor.Loc()
 	if !v.cursor.HasSelection() {
@@ -353,6 +357,7 @@ func (v *View) SelectRight() bool {
 	return true
 }
 
+// SelectWordRight selects the word to the right of the cursor
 func (v *View) SelectWordRight() bool {
 	loc := v.cursor.Loc()
 	if !v.cursor.HasSelection() {
@@ -363,6 +368,7 @@ func (v *View) SelectWordRight() bool {
 	return true
 }
 
+// SelectWordLeft selects the word to the left of the cursor
 func (v *View) SelectWordLeft() bool {
 	loc := v.cursor.Loc()
 	if !v.cursor.HasSelection() {
@@ -370,6 +376,75 @@ func (v *View) SelectWordLeft() bool {
 	}
 	v.cursor.WordLeft()
 	v.cursor.SelectTo(v.cursor.Loc())
+	return true
+}
+
+// StartOfLine moves the cursor to the start of the line
+func (v *View) StartOfLine() bool {
+	v.cursor.Start()
+	return true
+}
+
+// EndOfLine moves the cursor to the end of the line
+func (v *View) EndOfLine() bool {
+	v.cursor.End()
+	return true
+}
+
+// SelectToStartOfLine selects to the start of the current line
+func (v *View) SelectToStartOfLine() bool {
+	loc := v.cursor.Loc()
+	if !v.cursor.HasSelection() {
+		v.cursor.origSelection[0] = loc
+	}
+	v.cursor.Start()
+	v.cursor.SelectTo(v.cursor.Loc())
+	return true
+}
+
+// SelectToEndOfLine selects to the end of the current line
+func (v *View) SelectToEndOfLine() bool {
+	loc := v.cursor.Loc()
+	if !v.cursor.HasSelection() {
+		v.cursor.origSelection[0] = loc
+	}
+	v.cursor.End()
+	v.cursor.SelectTo(v.cursor.Loc())
+	return true
+}
+
+// CursorStart moves the cursor to the start of the buffer
+func (v *View) CursorStart() bool {
+	v.cursor.x = 0
+	v.cursor.y = 0
+	return true
+}
+
+// CursorEnd moves the cursor to the end of the buffer
+func (v *View) CursorEnd() bool {
+	v.cursor.SetLoc(len(v.buf.text))
+	return true
+}
+
+// SelectToStart selects the text from the cursor to the start of the buffer
+func (v *View) SelectToStart() bool {
+	loc := v.cursor.Loc()
+	if !v.cursor.HasSelection() {
+		v.cursor.origSelection[0] = loc
+	}
+	v.CursorStart()
+	v.cursor.SelectTo(0)
+	return true
+}
+
+// SelectToEnd selects the text from the cursor to the end of the buffer
+func (v *View) SelectToEnd() bool {
+	loc := v.cursor.Loc()
+	if !v.cursor.HasSelection() {
+		v.cursor.origSelection[0] = loc
+	}
+	v.CursorEnd()
+	v.cursor.SelectTo(len(v.buf.text))
 	return true
 }
 
@@ -663,8 +738,8 @@ func (v *View) OpenFile() bool {
 	return true
 }
 
-// Beginning moves the viewport to the start of the buffer
-func (v *View) Beginning() bool {
+// Start moves the viewport to the start of the buffer
+func (v *View) Start() bool {
 	v.topline = 0
 	return false
 }
@@ -729,69 +804,6 @@ func (v *View) ToggleRuler() bool {
 		settings.Ruler = false
 	}
 	return false
-}
-
-// StartOfLine moves the cursor to the start of the line
-func (v *View) StartOfLine() bool {
-	v.cursor.Start()
-	return true
-}
-
-// EndOfLine moves the cursor to the end of the line
-func (v *View) EndOfLine() bool {
-	v.cursor.End()
-	return true
-}
-
-func (v *View) SelectToStartOfLine() bool {
-	loc := v.cursor.Loc()
-	if !v.cursor.HasSelection() {
-		v.cursor.origSelection[0] = loc
-	}
-	v.cursor.Start()
-	v.cursor.SelectTo(v.cursor.Loc())
-	return true
-}
-
-func (v *View) SelectToEndOfLine() bool {
-	loc := v.cursor.Loc()
-	if !v.cursor.HasSelection() {
-		v.cursor.origSelection[0] = loc
-	}
-	v.cursor.End()
-	v.cursor.SelectTo(v.cursor.Loc())
-	return true
-}
-
-func (v *View) CursorStart() bool {
-	v.cursor.x = 0
-	v.cursor.y = 0
-	return true
-}
-
-func (v *View) CursorEnd() bool {
-	v.cursor.SetLoc(len(v.buf.text))
-	return true
-}
-
-func (v *View) SelectToStart() bool {
-	loc := v.cursor.Loc()
-	if !v.cursor.HasSelection() {
-		v.cursor.origSelection[0] = loc
-	}
-	v.CursorStart()
-	v.cursor.SelectTo(0)
-	return true
-}
-
-func (v *View) SelectToEnd() bool {
-	loc := v.cursor.Loc()
-	if !v.cursor.HasSelection() {
-		v.cursor.origSelection[0] = loc
-	}
-	v.CursorEnd()
-	v.cursor.SelectTo(len(v.buf.text))
-	return true
 }
 
 // None is no action

--- a/cmd/micro/bindings.go
+++ b/cmd/micro/bindings.go
@@ -289,8 +289,12 @@ func (v *View) CursorDown() bool {
 
 // CursorLeft moves the cursor left
 func (v *View) CursorLeft() bool {
-	v.cursor.ResetSelection()
-	v.cursor.Left()
+	if v.cursor.HasSelection() {
+		v.cursor.SetLoc(v.cursor.curSelection[0])
+		v.cursor.ResetSelection()
+	} else {
+		v.cursor.Left()
+	}
 	return true
 }
 
@@ -330,7 +334,7 @@ func (v *View) SelectWordRight() bool {
 		v.cursor.origSelection[0] = loc
 	}
 	v.cursor.WordRight()
-	v.cursor.SelectTo(v.cursor.Loc())
+	v.cursor.SelectTo(v.cursor.Loc() - 1)
 	return true
 }
 
@@ -346,8 +350,12 @@ func (v *View) SelectWordLeft() bool {
 
 // CursorRight moves the cursor right
 func (v *View) CursorRight() bool {
-	v.cursor.ResetSelection()
-	v.cursor.Right()
+	if v.cursor.HasSelection() {
+		v.cursor.SetLoc(v.cursor.curSelection[1] - 1)
+		v.cursor.ResetSelection()
+	} else {
+		v.cursor.Right()
+	}
 	return true
 }
 

--- a/cmd/micro/bindings.go
+++ b/cmd/micro/bindings.go
@@ -21,42 +21,48 @@ func InitBindings() {
 	bindings = make(map[tcell.Key]func(*View) bool)
 
 	actions := map[string]func(*View) bool{
-		"CursorUp":        (*View).CursorUp,
-		"CursorDown":      (*View).CursorDown,
-		"CursorLeft":      (*View).CursorLeft,
-		"CursorRight":     (*View).CursorRight,
-		"SelectLeft":      (*View).SelectLeft,
-		"SelectRight":     (*View).SelectRight,
-		"WordRight":       (*View).WordRight,
-		"WordLeft":        (*View).WordLeft,
-		"SelectWordRight": (*View).SelectWordRight,
-		"SelectWordLeft":  (*View).SelectWordLeft,
-		"InsertEnter":     (*View).InsertEnter,
-		"InsertSpace":     (*View).InsertSpace,
-		"Backspace":       (*View).Backspace,
-		"Delete":          (*View).Delete,
-		"InsertTab":       (*View).InsertTab,
-		"Save":            (*View).Save,
-		"Find":            (*View).Find,
-		"FindNext":        (*View).FindNext,
-		"FindPrevious":    (*View).FindPrevious,
-		"Undo":            (*View).Undo,
-		"Redo":            (*View).Redo,
-		"Copy":            (*View).Copy,
-		"Cut":             (*View).Cut,
-		"CutLine":         (*View).CutLine,
-		"Paste":           (*View).Paste,
-		"SelectAll":       (*View).SelectAll,
-		"OpenFile":        (*View).OpenFile,
-		"Beginning":       (*View).Beginning,
-		"End":             (*View).End,
-		"PageUp":          (*View).PageUp,
-		"PageDown":        (*View).PageDown,
-		"HalfPageUp":      (*View).HalfPageUp,
-		"HalfPageDown":    (*View).HalfPageDown,
-		"StartOfLine":     (*View).StartOfLine,
-		"EndOfLine":       (*View).EndOfLine,
-		"ToggleRuler":     (*View).ToggleRuler,
+		"CursorUp":            (*View).CursorUp,
+		"CursorDown":          (*View).CursorDown,
+		"CursorLeft":          (*View).CursorLeft,
+		"CursorRight":         (*View).CursorRight,
+		"CursorStart":         (*View).CursorStart,
+		"CursorEnd":           (*View).CursorEnd,
+		"SelectToStart":       (*View).SelectToStart,
+		"SelectToEnd":         (*View).SelectToEnd,
+		"SelectLeft":          (*View).SelectLeft,
+		"SelectRight":         (*View).SelectRight,
+		"WordRight":           (*View).WordRight,
+		"WordLeft":            (*View).WordLeft,
+		"SelectWordRight":     (*View).SelectWordRight,
+		"SelectWordLeft":      (*View).SelectWordLeft,
+		"SelectToStartOfLine": (*View).SelectToStartOfLine,
+		"SelectToEndOfLine":   (*View).SelectToEndOfLine,
+		"InsertEnter":         (*View).InsertEnter,
+		"InsertSpace":         (*View).InsertSpace,
+		"Backspace":           (*View).Backspace,
+		"Delete":              (*View).Delete,
+		"InsertTab":           (*View).InsertTab,
+		"Save":                (*View).Save,
+		"Find":                (*View).Find,
+		"FindNext":            (*View).FindNext,
+		"FindPrevious":        (*View).FindPrevious,
+		"Undo":                (*View).Undo,
+		"Redo":                (*View).Redo,
+		"Copy":                (*View).Copy,
+		"Cut":                 (*View).Cut,
+		"CutLine":             (*View).CutLine,
+		"Paste":               (*View).Paste,
+		"SelectAll":           (*View).SelectAll,
+		"OpenFile":            (*View).OpenFile,
+		"Beginning":           (*View).Beginning,
+		"End":                 (*View).End,
+		"PageUp":              (*View).PageUp,
+		"PageDown":            (*View).PageDown,
+		"HalfPageUp":          (*View).HalfPageUp,
+		"HalfPageDown":        (*View).HalfPageDown,
+		"StartOfLine":         (*View).StartOfLine,
+		"EndOfLine":           (*View).EndOfLine,
+		"ToggleRuler":         (*View).ToggleRuler,
 	}
 
 	keys := map[string]tcell.Key{
@@ -235,41 +241,49 @@ func InitBindings() {
 // DefaultBindings returns a map containing micro's default keybindings
 func DefaultBindings() map[string]string {
 	return map[string]string{
-		"Up":            "CursorUp",
-		"Down":          "CursorDown",
-		"Right":         "CursorRight",
-		"Left":          "CursorLeft",
-		"ShiftLeft":     "SelectLeft",
-		"ShiftRight":    "SelectRight",
-		"AltLeft":       "WordLeft",
-		"AltRight":      "WordRight",
-		"AltShiftRight": "SelectWordRight",
-		"AltShiftLeft":  "SelectWordLeft",
-		"Enter":         "InsertEnter",
-		"Space":         "InsertSpace",
-		"Backspace":     "Backspace",
-		"Backspace2":    "Backspace",
-		"Tab":           "InsertTab",
-		"CtrlO":         "OpenFile",
-		"CtrlS":         "Save",
-		"CtrlF":         "Find",
-		"CtrlN":         "FindNext",
-		"CtrlP":         "FindPrevious",
-		"CtrlZ":         "Undo",
-		"CtrlY":         "Redo",
-		"CtrlC":         "Copy",
-		"CtrlX":         "Cut",
-		"CtrlK":         "CutLine",
-		"CtrlV":         "Paste",
-		"CtrlA":         "SelectAll",
-		"Home":          "Beginning",
-		"End":           "End",
-		"PgUp":          "PageUp",
-		"PgDn":          "PageDown",
-		"CtrlU":         "HalfPageUp",
-		"CtrlD":         "HalfPageDown",
-		"CtrlR":         "ToggleRuler",
-		"Delete":        "Delete",
+		"Up":             "CursorUp",
+		"Down":           "CursorDown",
+		"Right":          "CursorRight",
+		"Left":           "CursorLeft",
+		"ShiftLeft":      "SelectLeft",
+		"ShiftRight":     "SelectRight",
+		"AltLeft":        "WordLeft",
+		"AltRight":       "WordRight",
+		"AltShiftRight":  "SelectWordRight",
+		"AltShiftLeft":   "SelectWordLeft",
+		"CtrlLeft":       "StartOfLine",
+		"CtrlRight":      "EndOfLine",
+		"CtrlShiftLeft":  "SelectToStartOfLine",
+		"CtrlShiftRight": "SelectToEndOfLine",
+		"CtrlUp":         "CursorStart",
+		"CtrlDown":       "CursorEnd",
+		"CtrlShiftUp":    "SelectToStart",
+		"CtrlShiftDown":  "SelectToEnd",
+		"Enter":          "InsertEnter",
+		"Space":          "InsertSpace",
+		"Backspace":      "Backspace",
+		"Backspace2":     "Backspace",
+		"Tab":            "InsertTab",
+		"CtrlO":          "OpenFile",
+		"CtrlS":          "Save",
+		"CtrlF":          "Find",
+		"CtrlN":          "FindNext",
+		"CtrlP":          "FindPrevious",
+		"CtrlZ":          "Undo",
+		"CtrlY":          "Redo",
+		"CtrlC":          "Copy",
+		"CtrlX":          "Cut",
+		"CtrlK":          "CutLine",
+		"CtrlV":          "Paste",
+		"CtrlA":          "SelectAll",
+		"Home":           "Beginning",
+		"End":            "End",
+		"PgUp":           "PageUp",
+		"PgDn":           "PageDown",
+		"CtrlU":          "HalfPageUp",
+		"CtrlD":          "HalfPageDown",
+		"CtrlR":          "ToggleRuler",
+		"Delete":         "Delete",
 	}
 }
 
@@ -726,6 +740,57 @@ func (v *View) StartOfLine() bool {
 // EndOfLine moves the cursor to the end of the line
 func (v *View) EndOfLine() bool {
 	v.cursor.End()
+	return true
+}
+
+func (v *View) SelectToStartOfLine() bool {
+	loc := v.cursor.Loc()
+	if !v.cursor.HasSelection() {
+		v.cursor.origSelection[0] = loc
+	}
+	v.cursor.Start()
+	v.cursor.SelectTo(v.cursor.Loc())
+	return true
+}
+
+func (v *View) SelectToEndOfLine() bool {
+	loc := v.cursor.Loc()
+	if !v.cursor.HasSelection() {
+		v.cursor.origSelection[0] = loc
+	}
+	v.cursor.End()
+	v.cursor.SelectTo(v.cursor.Loc())
+	return true
+}
+
+func (v *View) CursorStart() bool {
+	v.cursor.x = 0
+	v.cursor.y = 0
+	return true
+}
+
+func (v *View) CursorEnd() bool {
+	v.cursor.SetLoc(len(v.buf.text))
+	return true
+}
+
+func (v *View) SelectToStart() bool {
+	loc := v.cursor.Loc()
+	if !v.cursor.HasSelection() {
+		v.cursor.origSelection[0] = loc
+	}
+	v.CursorStart()
+	v.cursor.SelectTo(0)
+	return true
+}
+
+func (v *View) SelectToEnd() bool {
+	loc := v.cursor.Loc()
+	if !v.cursor.HasSelection() {
+		v.cursor.origSelection[0] = loc
+	}
+	v.CursorEnd()
+	v.cursor.SelectTo(len(v.buf.text))
 	return true
 }
 

--- a/cmd/micro/colorscheme.go
+++ b/cmd/micro/colorscheme.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"github.com/gdamore/tcell"
+	"github.com/zyedidia/tcell"
 	"io/ioutil"
 	"regexp"
 	"strconv"

--- a/cmd/micro/cursor.go
+++ b/cmd/micro/cursor.go
@@ -204,6 +204,7 @@ func (c *Cursor) AddWordToSelection() {
 	}
 }
 
+// SelectTo selects from the current cursor location to the given location
 func (c *Cursor) SelectTo(loc int) {
 	if loc > c.origSelection[0] {
 		c.curSelection[0] = c.origSelection[0]
@@ -214,6 +215,7 @@ func (c *Cursor) SelectTo(loc int) {
 	}
 }
 
+// WordRight moves the cursor one word to the right
 func (c *Cursor) WordRight() {
 	c.Right()
 	for !IsWordChar(string(c.RuneUnder(c.x))) {
@@ -224,6 +226,7 @@ func (c *Cursor) WordRight() {
 	}
 }
 
+// WordLeft moves the cursor one word to the left
 func (c *Cursor) WordLeft() {
 	c.Left()
 	for !IsWordChar(string(c.RuneUnder(c.x))) {

--- a/cmd/micro/cursor.go
+++ b/cmd/micro/cursor.go
@@ -204,9 +204,36 @@ func (c *Cursor) AddWordToSelection() {
 	}
 }
 
+func (c *Cursor) SelectTo(loc int) {
+	if loc > c.origSelection[0] {
+		c.curSelection[0] = c.origSelection[0]
+		c.curSelection[1] = loc + 1
+	} else {
+		c.curSelection[0] = loc
+		c.curSelection[1] = c.origSelection[0] + 1
+	}
+}
+
+func (c *Cursor) WordRight() {
+	for IsWordChar(string(c.RuneUnder(c.x))) {
+		c.Right()
+	}
+	c.Right()
+}
+
+func (c *Cursor) WordLeft() {
+	for IsWordChar(string(c.RuneUnder(c.x))) {
+		c.Left()
+	}
+	c.Left()
+}
+
 // RuneUnder returns the rune under the given x position
 func (c *Cursor) RuneUnder(x int) rune {
 	line := []rune(c.v.buf.lines[c.y])
+	if len(line) == 0 {
+		return '\n'
+	}
 	if x >= len(line) {
 		x = len(line) - 1
 	} else if x < 0 {

--- a/cmd/micro/cursor.go
+++ b/cmd/micro/cursor.go
@@ -215,17 +215,24 @@ func (c *Cursor) SelectTo(loc int) {
 }
 
 func (c *Cursor) WordRight() {
+	c.Right()
+	for !IsWordChar(string(c.RuneUnder(c.x))) {
+		c.Right()
+	}
 	for IsWordChar(string(c.RuneUnder(c.x))) {
 		c.Right()
 	}
-	c.Right()
 }
 
 func (c *Cursor) WordLeft() {
+	c.Left()
+	for !IsWordChar(string(c.RuneUnder(c.x))) {
+		c.Left()
+	}
 	for IsWordChar(string(c.RuneUnder(c.x))) {
 		c.Left()
 	}
-	c.Left()
+	c.Right()
 }
 
 // RuneUnder returns the rune under the given x position

--- a/cmd/micro/cursor.go
+++ b/cmd/micro/cursor.go
@@ -207,7 +207,7 @@ func (c *Cursor) AddWordToSelection() {
 func (c *Cursor) SelectTo(loc int) {
 	if loc > c.origSelection[0] {
 		c.curSelection[0] = c.origSelection[0]
-		c.curSelection[1] = loc + 1
+		c.curSelection[1] = loc
 	} else {
 		c.curSelection[0] = loc
 		c.curSelection[1] = c.origSelection[0] + 1
@@ -242,7 +242,7 @@ func (c *Cursor) RuneUnder(x int) rune {
 		return '\n'
 	}
 	if x >= len(line) {
-		x = len(line) - 1
+		return '\n'
 	} else if x < 0 {
 		x = 0
 	}

--- a/cmd/micro/highlighter.go
+++ b/cmd/micro/highlighter.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/gdamore/tcell"
+	"github.com/zyedidia/tcell"
 	"io/ioutil"
 	"path/filepath"
 	"regexp"

--- a/cmd/micro/messenger.go
+++ b/cmd/micro/messenger.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strconv"
 
-	"github.com/gdamore/tcell"
+	"github.com/zyedidia/tcell"
 )
 
 // TermMessage sends a message to the user in the terminal. This usually occurs before

--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -6,8 +6,8 @@ import (
 	"io/ioutil"
 	"os"
 
-	"github.com/gdamore/tcell"
-	"github.com/gdamore/tcell/encoding"
+	"github.com/zyedidia/tcell"
+	"github.com/zyedidia/tcell/encoding"
 	"github.com/go-errors/errors"
 	"github.com/mattn/go-isatty"
 	"github.com/mitchellh/go-homedir"

--- a/cmd/micro/search.go
+++ b/cmd/micro/search.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/gdamore/tcell"
+	"github.com/zyedidia/tcell"
 	"regexp"
 )
 

--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gdamore/tcell"
+	"github.com/zyedidia/tcell"
 )
 
 // The View struct stores information about a view into a buffer.


### PR DESCRIPTION
This pull request adds bindings for ctrl, alt, and shift + arrows. Here are the current bindings I plan on using.

shift+arrows: select
alt+arrows (left and right): move by word
alt+shift+arrows: select by word
ctrl+arrows (left and right): move to beginning and end of lines
ctrl+arrows (up and down): move to beginning and end of file
ctrl+shift+arrows: select according to movement

Let me know if you think the keybindings should be different.