### PR TITLE
fixing ismodified in while saving [WIP]

### DIFF
--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -79,7 +79,7 @@ func (b *Buffer) SaveAs(filename string) error {
 	data := []byte(b.String())
 	err := ioutil.WriteFile(filename, data, 0644)
 	if err == nil {
-		b.IsModified = true
+		b.IsModified = false
 	}
 	return err
 }


### PR DESCRIPTION
This first commit is a quick fix because saving does not reset Buffer.IsModified variable to false.