### PR TITLE
Fix jumping in rxvt-unicode when switching focus

### DIFF
--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -298,7 +298,7 @@ func (v *View) HandleEvent(event tcell.Event) {
 		x, y := e.Position()
 		x -= v.lineNumOffset - v.leftCol
 		y += v.Topline
-		relocate = true
+		relocate = false
 
 		button := e.Buttons()
 

--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -298,6 +298,7 @@ func (v *View) HandleEvent(event tcell.Event) {
 		x, y := e.Position()
 		x -= v.lineNumOffset - v.leftCol
 		y += v.Topline
+		relocate = true
 
 		button := e.Buttons()
 


### PR DESCRIPTION
I don't really know *why* this works, but it works.

Before when using rxvt-unicode with openbox the following would happen:

* open a file in micro
* Scroll down 80 lines
* move cursor to another window (switching focus)
* micro would jump the "view" to line 40 for some reason