### PR TITLE
Hide messages after a few seconds

### DIFF
--- a/cmd/micro/messenger.go
+++ b/cmd/micro/messenger.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/zyedidia/tcell"
 )
@@ -205,6 +206,11 @@ func (m *Messenger) Display() {
 		for x := 0; x < len(runes); x++ {
 			screen.SetContent(x, h-1, runes[x], nil, m.style)
 		}
+		go func() {
+			time.Sleep(4 * time.Second)
+			messenger.Clear()
+			messenger.Reset()
+		}()
 	}
 	if m.hasPrompt {
 		screen.ShowCursor(Count(m.message)+m.cursorx, h-1)


### PR DESCRIPTION
So this does not work really consistent as of yet, for example sometimes when doing lots of actions (scrolling, clicking around, typing) the message already hides after 1 or so second, and when doing nothing it it displays for longer. My go skills are *really* limited (this is my first time hacking around in go actually), so if you have interest in this feature you may need to fix a few things :)