### PR TITLE
add binding for ClearStatus

### DIFF
--- a/cmd/micro/bindings.go
+++ b/cmd/micro/bindings.go
@@ -65,6 +65,7 @@ func InitBindings() {
 		"EndOfLine":           (*View).EndOfLine,
 		"ToggleRuler":         (*View).ToggleRuler,
 		"JumpLine":            (*View).JumpLine,
+		"ClearStatus":         (*View).ClearStatus,
 	}
 
 	keys := map[string]tcell.Key{
@@ -289,6 +290,7 @@ func DefaultBindings() map[string]string {
 		"CtrlR":          "ToggleRuler",
 		"CtrlL":          "JumpLine",
 		"Delete":         "Delete",
+		"Esc":            "ClearStatus",
 	}
 }
 
@@ -839,6 +841,12 @@ func (v *View) JumpLine() bool {
 		return true
 	}
 	messenger.Error("Only ", v.Buf.NumLines, " lines to jump")
+	return false
+}
+
+// ClearStatus clears the messenger bar
+func (v *View) ClearStatus() bool {
+	messenger.Message("")
 	return false
 }
 


### PR DESCRIPTION
This adds a binding (default ESC) to send a blank message to the status bar.