### PR TITLE
Syntax [makefile] - fix invisible "$()" issue

### DIFF
--- a/runtime/syntax/makefile.micro
+++ b/runtime/syntax/makefile.micro
@@ -10,13 +10,13 @@ color brightblue "\$\((error|eval|filter|filter-out|findstring|firstword)[[:spac
 color brightblue "\$\((flavor|foreach|if|info|join|lastword|notdir|or)[[:space:]]"
 color brightblue "\$\((origin|patsubst|realpath|shell|sort|strip|suffix)[[:space:]]"
 color brightblue "\$\((value|warning|wildcard|word|wordlist|words)[[:space:]]"
-color black    "[()$]"
+color green    "[()$]"
 color yellow ""(\\.|[^"])*"|'(\\.|[^'])*'"
 color brightyellow "\$+(\{[^} ]+\}|\([^) ]+\))"
 color brightyellow "\$[@^<*?%|+]|\$\([@^<*?%+-][DF]\)"
 color magenta   "\$\$|\\.?"
-color brightblack "(^|[[:space:]])#([^{].*)?$"
-color brightblack  "^	@#.*"
+color green "(^|[[:space:]])#([^{].*)?$"
+color green  "^	@#.*"
 
 # Show trailing whitespace
 color ,green "[[:space:]]+$"


### PR DESCRIPTION
When typing `$(`, which is often, the color was the same as the background, which makes it difficult to see the first letters of the variable being used.

:smile: 