### PR TITLE
Remove "go build -o /dev/null" to speed up saving .go files

### DIFF
--- a/runtime/plugins/linter/linter.lua
+++ b/runtime/plugins/linter/linter.lua
@@ -11,7 +11,6 @@ function linter_onSave()
             devnull = "NUL"
         end
         if ft == "Go" then
-            linter_lint("gobuild", "go build -o " .. devnull, "%f:%l: %m")
             linter_lint("golint", "golint " .. views[mainView+1].Buf.Path, "%f:%l:%d+: %m")
         elseif ft == "Lua" then
             linter_lint("luacheck", "luacheck --no-color " .. file, "%f:%l:%d+: %m")


### PR DESCRIPTION
I noticed saving .go files are getting kind of slow (on big projects) 

A look at htop shows an actual go build going on, output to /dev/null. It blocks quitting, typing, etc

On large projects it takes a while and seems like micro freezes (it just waits for the build)

As a workaround, I have been using Ctrl+Q to quit and type "save" or Ctrl+O and type save and ESC to get back into file. (avoiding the linting all together)

Seems like the `build -o /dev/null`, `golint`, and `go fmt` and `goimports` is excessive, so I `set goimports off` and `set gofmt off` temporarily and it still takes a long time to save the file.

With this **one line** removed, saving is quick. Even with `set goimports on` `set gofmt on` and `set linter on` it only takes a second or two on a large project.

I am not *at all* sure what building to /dev/null even does... 

Maybe a ctrl+shift+s for linting and ctrl+s for regular save would be the right thing?

:question: 
