### PR TITLE
Add GDScript syntax file

### DIFF
--- a/runtime/syntax/gdscript.micro
+++ b/runtime/syntax/gdscript.micro
@@ -1,0 +1,43 @@
+## GDScript syntax file, based on Python syntax file.
+##
+syntax "GDScript" "\.gd$"
+
+## built-in objects
+color constant "\b(null|self|true|false)\b"
+## built-in attributes
+# color constant "\b()\b"
+## built-in functions
+color identifier "\b(abs|acos|asin|atan|atan2|ceil|clamp|convert|cos|cosh|db2linear|decimals|deg2rad|ease|exp|float|floor|fmod|fposmod|hash|int|isinf|isnan|lerp|linear2db|load|log|max|min|nearest_po2|pow|preload|print|printerr|printraw|prints|printt|rad2deg|rand_range|rand_seed|randomize|randi|randf|range|round|seed|sin|slerp|sqrt|str|str2var|tan|typeof|var2str|weakref)\b"
+## special method names
+color identifier "\b(AnimationPlayer|AnimationTreePlayer|Button|Control|HTTPClient|HTTPRequest|Input|InputEvent|MainLoop|Node|Node2D|SceneTree|Spatial|SteamPeer|PacketPeer|PacketPeerUDP|Timer|Tween)\b"
+## types
+color type "\b(Vector2|Vector3)\b"
+## definitions
+color identifier "func [a-zA-Z_0-9]+" 
+## keywords
+color statement "\b(and|as|assert|break|breakpoint|class|const|continue|elif|else|export|extends|for|func|if|in|map|not|onready|or|pass|return|signal|var|while|yield)\b" 
+
+## decorators
+color brightgreen "@.*[(]"
+
+## operators
+color statement "[.:;,+*|=!\%@]" "<" ">" "/" "-" "&"
+
+## parentheses
+color statement "[(){}]" "\[" "\]"
+
+## numbers
+color constant "\b[0-9]+\b"
+
+## strings
+color constant.number "\b([0-9]+|0x[0-9a-fA-F]*)\b|'.'"
+color constant.string ""(\\.|[^"])*"|'(\\.|[^'])*'"
+color constant.specialChar "\\([0-7]{3}|x[A-Fa-f0-9]{2}|u[A-Fa-f0-9]{4}|U[A-Fa-f0-9]{8})"
+color constant.string "`[^`]*`"
+
+## brightblacks
+color comment "#.*$"
+
+## block brightblacks
+color comment start=""""([^"]|$)" end="""""
+color comment start="'''([^']|$)" end="'''"


### PR DESCRIPTION
This pull request adds basic support for GDScript, which is the scripting language the open source [Godot Engine](http://godotengine.org/) uses.

Not all built-in types and objects are highlighted yet, but it works quite well.

![gdscript-syntax](https://cloud.githubusercontent.com/assets/180032/16299557/425a4198-393b-11e6-86cf-720863578115.png)
