### PR TITLE
Flag to start at specified line/column number (#224)

### DIFF
--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 	"unicode/utf8"
 )
@@ -85,10 +87,36 @@ func NewBuffer(txt []byte, path string) *Buffer {
 	}
 
 	// Put the cursor at the first spot
+	cursorStartX := 0
+	cursorStartY := 0
+	// If -cursor LINE,COL was passed, use start position LINE,COL
+	if len(*flagLineColumn) > 0 {
+		positions := strings.Split(*flagLineColumn, ",")
+		if len(positions) == 2 {
+			lineNum, errPos1 := strconv.Atoi(positions[0])
+			colNum, errPos2 := strconv.Atoi(positions[1])
+			if errPos1 == nil && errPos2 == nil {
+				cursorStartX = colNum
+				cursorStartY = lineNum - 1
+				// Check to avoid line overflow
+				if cursorStartY > b.NumLines {
+					cursorStartY = b.NumLines - 1
+				} else if cursorStartY < 0 {
+					cursorStartY = 0
+				}
+				// Check to avoid column overflow
+				if cursorStartX > len(b.Line(cursorStartY)) {
+					cursorStartX = len(b.Line(cursorStartY))
+				} else if cursorStartX < 0 {
+					cursorStartX = 0
+				}
+			}
+		}
+	}
 	b.Cursor = Cursor{
 		Loc: Loc{
-			X: 0,
-			Y: 0,
+			X: cursorStartX,
+			Y: cursorStartY,
 		},
 		buf: b,
 	}

--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -89,9 +89,9 @@ func NewBuffer(txt []byte, path string) *Buffer {
 	// Put the cursor at the first spot
 	cursorStartX := 0
 	cursorStartY := 0
-	// If -cursor LINE,COL was passed, use start position LINE,COL
-	if len(*flagLineColumn) > 0 {
-		positions := strings.Split(*flagLineColumn, ",")
+	// If +LINE,COL was passed, use start position LINE,COL
+	if len(flagLineColumn) > 0 {
+		positions := strings.Split(flagLineColumn[1:], ",")
 		if len(positions) == 2 {
 			lineNum, errPos1 := strconv.Atoi(positions[0])
 			colNum, errPos2 := strconv.Atoi(positions[1])

--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -87,6 +87,13 @@ func LoadInput() []*Buffer {
 		// We go through each file and load it
 		for i := 1; i < len(os.Args); i++ {
 			filename = os.Args[i]
+
+			// Need to skip arguments that are not filenames
+			if filename == "-cursor" {
+				i++ // also skip the LINE,COL for -cursor
+				continue
+			}
+
 			// Check that the file exists
 			if _, e := os.Stat(filename); e == nil {
 				// If it exists we load it into a buffer
@@ -196,6 +203,9 @@ func RedrawAll() {
 
 // Passing -version as a flag will have micro print out the version number
 var flagVersion = flag.Bool("version", false, "Show the version number")
+
+// Passing -cursor LINE,COL will start the cursor at position LINE,COL
+var flagLineColumn = flag.String("cursor", "", "Start the cursor at position `LINE,COL`")
 
 func main() {
 	flag.Parse()

--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -88,9 +88,9 @@ func LoadInput() []*Buffer {
 		for i := 1; i < len(os.Args); i++ {
 			filename = os.Args[i]
 
-			// Need to skip arguments that are not filenames
-			if filename == "-cursor" {
-				i++ // also skip the LINE,COL for -cursor
+			// Check if +LINE,COL was passed, and send this to the flagLineColumn
+			if string(filename[0]) == "+" && strings.Contains(filename, ",") {
+				flagLineColumn = filename
 				continue
 			}
 
@@ -204,8 +204,8 @@ func RedrawAll() {
 // Passing -version as a flag will have micro print out the version number
 var flagVersion = flag.Bool("version", false, "Show the version number")
 
-// Passing -cursor LINE,COL will start the cursor at position LINE,COL
-var flagLineColumn = flag.String("cursor", "", "Start the cursor at position `LINE,COL`")
+// Passing +LINE,COL will start the cursor at position LINE,COL
+var flagLineColumn = ""
 
 func main() {
 	flag.Parse()


### PR DESCRIPTION
I've noticed you don't have flags implemented in a way that avoids opening filenames for each flag component. I [did something very hacky](https://github.com/zyedidia/micro/pull/233/commits/4499228cdbe68690d0ff23aeb70adc1d3ad83fc6#diff-5be7079a47efa4d236c89844d843bbd3R92) to get around this...please let me know how I could revise this!
Otherwise it seems to work for me for #224 