### PR TITLE
Add Caddyfile syntax

### DIFF
--- a/runtime/syntax/caddyfile.micro
+++ b/runtime/syntax/caddyfile.micro
@@ -1,0 +1,13 @@
+syntax "caddyfile" "Caddyfile"
+
+color identifier "^\s*\S+(\s|$)"
+color type "^([\w.:/-]+,? ?)+[,{]$"
+color constant.specialChar "\s{$"
+color constant.specialChar "^\s*}$"
+color constant.string start="\"" end="\""
+color preproc "\{(\w+|\$\w+|%\w+%)\}"
+color comment "#.*"
+
+# extra and trailing spaces
+color ,red "([[:space:]]{2,}|\t){$"
+color ,red "[[:space:]]+$"


### PR DESCRIPTION
I've been wanting my favorite editors to support Caddyfile syntax for a while now, but never could really figure it out with the time I had. But I love micro so I spent a few hours hacking on this. I don't know if you're accepting new syntax formats but I'd love to see this accepted!

The Caddyfile has a very simple, generic syntax. But it's still nice to see the colors. :smile:

This PR should be compatible with various color schemes.