### PR TITLE
Add an LFE syntax file

### DIFF
--- a/runtime/syntax/lfe.micro
+++ b/runtime/syntax/lfe.micro
@@ -1,0 +1,21 @@
+syntax "lfe" "lfe$" "\.lfe$"
+
+# Parens are everywhere!
+color statement "\("
+color statement "\)"
+
+# Good overrides for LFE in particular
+color type "defun|define-syntax|define|defmacro|defmodule|export"
+
+# Dirty base cases stolen from the generic lisp syntax
+color constant "\ [A-Za-z][A-Za-z0-9_-]+\ "
+color statement "\(([-+*/<>]|<=|>=)|'"
+color constant.number "\<[0-9]+\>"
+color constant.string "\"(\\.|[^"])*\""
+color special "['|`][A-Za-z][A-Za-z0-9_-]+"
+color constant.string "\\.?"
+color comment "(^|[[:space:]]);.*"
+
+# Some warning colors because our indents are wrong.
+color ,green "[[:space:]]+$"
+color ,red "	+ +| +	+"


### PR DESCRIPTION
Aside from cleaning up a lot of the mess in the generalized Lisp syntax file, this adds support for Lisp Flavored Erlang.

Feel free to let me know if you prefer generalized changes to the lisp.syntax file or you'd rather not change the defaults at all.