### PR TITLE
Windows-compatible Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 VERSION = $(shell git describe --tags --abbrev=0)
 HASH = $(shell git rev-parse --short HEAD)
-DATE = $(shell python -c 'import time; print(time.strftime("%B %d, %Y"))')
+DATE = $(shell go run tools/build-date.go)
 
 # Builds micro after checking dependencies but without updating the runtime
 build: deps tcell

--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,18 @@
 
 VERSION = $(shell git describe --tags --abbrev=0)
 HASH = $(shell git rev-parse --short HEAD)
+DATE = $(shell python -c 'import time; print(time.strftime("%B %d, %Y"))')
 
 # Builds micro after checking dependencies but without updating the runtime
 build: deps tcell
-	go build -ldflags "-X main.Version=$(VERSION) -X main.CommitHash=$(HASH) -X 'main.CompileDate=$(shell date -u '+%B %d, %Y')'" -o micro ./cmd/micro
+	go build -ldflags "-X main.Version=$(VERSION) -X main.CommitHash=$(HASH) -X 'main.CompileDate=$(DATE)'" -o micro ./cmd/micro
 
 # Builds micro after building the runtime and checking dependencies
 build-all: runtime build
 
 # Builds micro without checking for dependencies
 build-quick:
-	go build -ldflags "-X main.Version=$(VERSION) -X main.CommitHash=$(HASH) -X 'main.CompileDate=$(shell date -u '+%B %d, %Y')'" -o micro ./cmd/micro
+	go build -ldflags "-X main.Version=$(VERSION) -X main.CommitHash=$(HASH) -X 'main.CompileDate=$(DATE)'" -o micro ./cmd/micro
 
 # Same as 'build' but installs to $GOPATH/bin afterward
 install: build

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@ DATE = $(shell python -c 'import time; print(time.strftime("%B %d, %Y"))')
 
 # Builds micro after checking dependencies but without updating the runtime
 build: deps tcell
-	go build -ldflags "-X main.Version=$(VERSION) -X main.CommitHash=$(HASH) -X 'main.CompileDate=$(DATE)'" -o micro ./cmd/micro
+	go build -ldflags "-X main.Version=$(VERSION) -X main.CommitHash=$(HASH) -X 'main.CompileDate=$(DATE)'" ./cmd/micro
 
 # Builds micro after building the runtime and checking dependencies
 build-all: runtime build
 
 # Builds micro without checking for dependencies
 build-quick:
-	go build -ldflags "-X main.Version=$(VERSION) -X main.CommitHash=$(HASH) -X 'main.CompileDate=$(DATE)'" -o micro ./cmd/micro
+	go build -ldflags "-X main.Version=$(VERSION) -X main.CommitHash=$(HASH) -X 'main.CompileDate=$(DATE)'" ./cmd/micro
 
 # Same as 'build' but installs to $GOPATH/bin afterward
 install: build

--- a/tools/build-date.go
+++ b/tools/build-date.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+func main() {
+	fmt.Println(time.Now().Local().Format("January 02, 2006"))
+}


### PR DESCRIPTION
Windows has its own date command, which doesn't understand POSIX format, so using Python, which is more common everythere.

And also let go choose right extension for executable.