### PR TITLE
Add the packaging metadata to build the micro snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,19 @@
+name: micro
+version: master
+summary: A modern and intuitive terminal-based text editor
+description: |
+  Micro is a terminal-based text editor that aims to be easy to use and
+  intuitive, while also taking advantage of the full capabilities of modern
+  terminals.
+confinement: strict
+
+apps:
+  micro:
+    command: bin/micro
+    plugs: [home]
+
+parts:
+  micro:
+    source: .
+    plugin: go
+    go-importpath: github.com/zyedidia/micro


### PR DESCRIPTION
This is a package for the secure installation of apps that works in most Linux distributions.
Landing it upstream will enable builds for adventurous users.