### PR TITLE
Consider all multi-byte characters a "wordchar", fixes #329

### DIFF
--- a/cmd/micro/util.go
+++ b/cmd/micro/util.go
@@ -65,7 +65,7 @@ func Max(a, b int) int {
 func IsWordChar(str string) bool {
 	if len(str) > 1 {
 		// Unicode
-		return false
+		return true
 	}
 	c := str[0]
 	return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c == '_')

--- a/cmd/micro/util_test.go
+++ b/cmd/micro/util_test.go
@@ -50,14 +50,14 @@ func TestIsWordChar(t *testing.T) {
 	if IsWordChar("_") == false {
 		t.Errorf("IsWordChar(_) = false")
 	}
+	if IsWordChar("ß") == false {
+		t.Errorf("IsWordChar(ß) = false")
+	}
 	if IsWordChar("~") == true {
 		t.Errorf("IsWordChar(~) = true")
 	}
 	if IsWordChar(" ") == true {
 		t.Errorf("IsWordChar( ) = true")
-	}
-	if IsWordChar("ß") == true {
-		t.Errorf("IsWordChar(ß) = true")
 	}
 	if IsWordChar(")") == true {
 		t.Errorf("IsWordChar()) = true")


### PR DESCRIPTION
Now all multi-byte characters are considered a "word char".
This seems to be the way this is handled by vim, see http://unix.stackexchange.com/questions/60637/what-does-vim-consider-to-be-a-word, but I didn't check the code.