### PR TITLE
Usability integration with file managers

### DIFF
--- a/cmd/micro/bindings.go
+++ b/cmd/micro/bindings.go
@@ -405,7 +405,6 @@ func DefaultBindings() map[string]string {
 		"CtrlR":          "ToggleRuler",
 		"CtrlL":          "JumpLine",
 		"Delete":         "Delete",
-		"Esc":            "ClearStatus",
 		"CtrlB":          "ShellMode",
 		"CtrlQ":          "Quit",
 		"CtrlE":          "CommandMode",
@@ -420,5 +419,13 @@ func DefaultBindings() map[string]string {
 		"Alt-e": "EndOfLine",
 		"Alt-p": "CursorUp",
 		"Alt-n": "CursorDown",
+
+		// Integration with file managers
+                "F1": "ToggleHelp",
+                "F2": "Save",
+                "F4": "Quit",
+                "F7": "Find",
+                "F10": "Quit",
+                "Esc": "Quit",
 	}
 }

--- a/runtime/help/keybindings.md
+++ b/runtime/help/keybindings.md
@@ -72,15 +72,15 @@ you can rebind them to your liking.
 	"Alt-a": "StartOfLine",
 	"Alt-e": "EndOfLine",
 	"Alt-p": "CursorUp",
-	"Alt-n": "CursorDown"
+	"Alt-n": "CursorDown",
 
 	// Integration with file managers
-        "F1": "ToggleHelp",
-        "F2": "Save",
-        "F4": "Quit",
-        "F7": "Find",
-        "F10": "Quit",
-        "Esc": "Quit",
+	"F1": "ToggleHelp",
+	"F2": "Save",
+	"F4": "Quit",
+	"F7": "Find",
+	"F10": "Quit",
+	"Esc": "Quit",
 }
 ```
 

--- a/runtime/help/keybindings.md
+++ b/runtime/help/keybindings.md
@@ -73,6 +73,14 @@ you can rebind them to your liking.
 	"Alt-e": "EndOfLine",
 	"Alt-p": "CursorUp",
 	"Alt-n": "CursorDown"
+
+	// Integration with file managers
+        "F1": "ToggleHelp",
+        "F2": "Save",
+        "F4": "Quit",
+        "F7": "Find",
+        "F10": "Quit",
+        "Esc": "Quit",
 }
 ```
 


### PR DESCRIPTION
Bindings to make seamless interaction with (orthodox) file managers and create flowing user experience. F4 launches editor (FarManager, mc), so the same button was used to exit, Esc usually closes windows, dialogs and panels, so it was remapped to quit micro as well, F7 is a common search button in editor (FarManager).