### PR TITLE
doco: grammar and formatting tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To see more screenshots of micro, showcasing all of the default colorschemes, se
 * Small and simple
 * Easily configurable
 * Macros
-* Common editor things such as undo/redo, line numbers, unicode support...
+* Common editor things such as undo/redo, line numbers, Unicode support...
 
 Although not yet implemented, I hope to add more features such as autocompletion ([#174](https://github.com/zyedidia/micro/issues/174)), and multiple cursors ([#5](https://github.com/zyedidia/micro/issues/5)) in the future.
 
@@ -49,7 +49,7 @@ Although not yet implemented, I hope to add more features such as autocompletion
 
 To install micro, you can download a [prebuilt binary](https://github.com/zyedidia/micro/releases), or you can build it from source.
 
-If you want more information about ways to install micro, see this [wiki page](https://github.com/zyedidia/micro/wiki/Installing-Micro)
+If you want more information about ways to install micro, see this [wiki page](https://github.com/zyedidia/micro/wiki/Installing-Micro).
 
 ### Prebuilt binaries
 
@@ -83,7 +83,7 @@ go get -u github.com/zyedidia/micro/...
 
 ### Linux clipboard support
 
-On Linux, clipboard support requires 'xclip' or 'xsel' command to be installed.
+On Linux, clipboard support requires the 'xclip' or 'xsel' commands to be installed.
 
 For Ubuntu:
 
@@ -99,7 +99,7 @@ If you open micro and it doesn't seem like syntax highlighting is working, this 
 you are using a terminal which does not support 256 color. Try changing the colorscheme to `simple`
 by running `> set colorscheme simple`.
 
-If you are using the default ubuntu terminal, to enable 256 make sure your `TERM` variable is set
+If you are using the default Ubuntu terminal, to enable 256 make sure your `TERM` variable is set
 to `xterm-256color`.
 
 Many of the Windows terminals don't support more than 16 colors, which means
@@ -131,7 +131,7 @@ click to enable line selection.
 
 # Documentation and Help
 
-Micro has a built-in help system which you can access by pressing `CtrlE` and typing `help`. Additionally, you can
+Micro has a built-in help system which you can access by pressing `Ctrl-E` and typing `help`. Additionally, you can
 view the help files here:
 
 * [main help](https://github.com/zyedidia/micro/tree/master/runtime/help/help.md)
@@ -148,6 +148,6 @@ a brief introduction to the more powerful configuration features micro offers.
 
 If you find any bugs, please report them! I am also happy to accept pull requests from anyone.
 
-You can use the Github issue tracker to report bugs, ask questions, or suggest new features.
+You can use the [GitHub issue tracker](https://github.com/zyedidia/micro/issues) to report bugs, ask questions, or suggest new features.
 
 For a more informal setting to discuss the editor, you can join the [Gitter chat](https://gitter.im/zyedidia/micro).

--- a/runtime/help/colors.md
+++ b/runtime/help/colors.md
@@ -19,12 +19,12 @@ Micro comes with a number of colorschemes by default. Here is the list:
 * solarized: this is the solarized colorscheme. 
   You should have the solarized color palette in your terminal to use it.
 
-* solarized-tc: this is the solarized colorscheme for true color, just 
+* solarized-tc: this is the solarized colorscheme for true color; just 
   make sure your terminal supports true color before using it and that the 
   MICRO_TRUECOLOR environment variable is set to 1 before starting micro.
 
-* monokai: this is the monokai colorscheme, you may recognize it as 
-  sublime text's default colorscheme. It requires true color to
+* monokai: this is the monokai colorscheme; you may recognize it as 
+  Sublime Text's default colorscheme. It requires true color to
   look perfect, but the 256 color approximation looks very good as well.
 
 * atom-dark-tc: this colorscheme is based off of Atom's "dark" colorscheme.

--- a/runtime/help/help.md
+++ b/runtime/help/help.md
@@ -13,8 +13,8 @@ See the next section for more information about documentation and help.
 
 Micro has a built-in help system much like Vim's (although less extensive).
 
-To use it, press CtrlE to access command mode and type in help followed by a topic.
-Typing help followed by nothing will open this page.
+To use it, press CtrlE to access command mode and type in `help` followed by a topic.
+Typing `help` followed by nothing will open this page.
 
 Here are the possible help topics that you can read:
 
@@ -26,7 +26,7 @@ Here are the possible help topics that you can read:
 * colors: Explains micro's colorscheme and syntax highlighting engine and how to create your
   own colorschemes or add new languages to the engine
 
-For example to open the help page on plugins you would press CtrlE and type `help plugins`.
+For example, to open the help page on plugins you would press CtrlE and type `help plugins`.
 
 I recommend looking at the `tutorial` help file because it is short for each section and
 gives concrete examples of how to use the various configuration options in micro. However,

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -14,7 +14,7 @@ Here are the options that you can set:
 
 	default value: `default`
 	Note that the default colorschemes (default, solarized, and solarized-tc)
-	are not located in configDir, because they are embedded in the micro binary
+	are not located in configDir, because they are embedded in the micro binary.
 
 	The colorscheme can be selected from all the files in the 
 	~/.config/micro/colorschemes/ directory. Micro comes by default with three
@@ -102,7 +102,7 @@ Default plugin options:
 
 	default value: `on`
 
-* `autoclose`: Automatically close `{}` `()` `[]` `""` `''`. Provided by the autoclose plugin
+* `autoclose`: Automatically close `{}` `()` `[]` `""` `''`. Provided by the `autoclose` plugin
 
 	default value: `on`
 

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -52,22 +52,22 @@ as Go's GOOS variable, so `darwin`, `windows`, `linux`, `freebsd`...)
 * `GetOption(name string)`: returns the value of the requested option
 
 * `AddOption(name string, value interface{})`: sets the given option with the given
-   value (`interface{}` means any type in Go).
+   value (`interface{}` means any type in Go)
 
 * `SetOption(option, value string)`: sets the given option to the value. This will
    set the option globally, unless it is a local only option.
 
 * `SetLocalOption(option, value string, buffer *Buffer)`: sets the given option to
-   the value locally in the given buffer.
+   the value locally in the given buffer
 
-* `BindKey(key, action string)`: binds `key` to `action`.
+* `BindKey(key, action string)`: binds `key` to `action`
 
 * `MakeCommand(name, function string, completions ...Completion)`: 
    creates a command with `name` which will call `function` when executed.
    Use 0 for completions to get NoCompletion.
 
 * `MakeCompletion(function string)`:
-   creates a `Completion` to use with `MakeCommand`.
+   creates a `Completion` to use with `MakeCommand`
 
 * `CurView()`: returns the current view
 
@@ -142,4 +142,4 @@ MakeCommand("foo", "example.foo", MakeCompletion("example.complete"))
 # Default plugins
 
 For examples of plugins, see the default plugins `linter`, `go`, and `autoclose`.
-They are stored in Micro's github repository [here](https://github.com/zyedidia/micro/tree/master/runtime/plugins).
+They are stored in Micro's GitHub repository [here](https://github.com/zyedidia/micro/tree/master/runtime/plugins).


### PR DESCRIPTION
This PR is just some suggestions for grammar and formatting adjustments to the documentation files.

* Regularizes capitalization of some proper nouns
* Regularizes formatting in some series items
* Adds a link to the GitHub issue tracker where it is mentioned in the text

See line comments for details.