### PR TITLE
Params

### DIFF
--- a/cmd/micro/autocomplete.go
+++ b/cmd/micro/autocomplete.go
@@ -18,12 +18,14 @@ var pluginCompletions []func(string) []string
 func FileComplete(input string) (string, []string) {
 	var sep string = string(os.PathSeparator)
 	dirs := strings.Split(input, sep)
+
 	var files []os.FileInfo
 	var err error
 	if len(dirs) > 1 {
 		home, _ := homedir.Dir()
 
-		directories := strings.Join(dirs[:len(dirs)-1], sep)
+		directories := strings.Join(dirs[:len(dirs)-1], sep) + sep
+
 		if strings.HasPrefix(directories, "~") {
 			directories = strings.Replace(directories, "~", home, 1)
 		}
@@ -31,6 +33,7 @@ func FileComplete(input string) (string, []string) {
 	} else {
 		files, err = ioutil.ReadDir(".")
 	}
+
 	var suggestions []string
 	if err != nil {
 		return "", suggestions

--- a/cmd/micro/util_test.go
+++ b/cmd/micro/util_test.go
@@ -100,9 +100,14 @@ func TestJoinAndSplitCommandArgs(t *testing.T) {
 		Query  string
 		Wanted []string
 	}{
-		{`"hallo""Welt"`, []string{`"hallo""Welt"`}},
+		{`"hallo""Welt"`, []string{`halloWelt`}},
+		{`"hallo" "Welt"`, []string{`hallo`, `Welt`}},
 		{`\"`, []string{`\"`}},
+		{`"foo`, []string{`"foo`}},
+		{`"foo"`, []string{`foo`}},
 		{`"\"`, []string{`"\"`}},
+		{`"C:\\"foo.txt`, []string{`C:\foo.txt`}},
+		{`"\n"new"\n"line`, []string{"\nnew\nline"}},
 	}
 
 	for i, test := range splitTests {


### PR DESCRIPTION
Hi,

I've tested once more the directory completion on windows.
Test results were:
Input `C:\temp` was set to `"C:\\temp"`
I thought that I could continue with entering `\blah` (resulting in `"C:\\Temp"\blah` but due to the current quoting logic the parameter was finished after the quote.
After this changes I had the expected behavior.

The second commit fixes the problem that the content of the root directory could not be listed on windows since it requires `c:\` as input not only `c:`


Remark: This changes the quoting logic on things like `"hello""world"` now results in `helloworld` instead of `"hello""world"`