### PR TITLE
fixes #379

### DIFF
--- a/cmd/micro/util.go
+++ b/cmd/micro/util.go
@@ -157,7 +157,18 @@ func GetModTime(path string) (time.Time, bool) {
 // StringWidth returns the width of a string where tabs count as `tabsize` width
 func StringWidth(str string, tabsize int) int {
 	sw := runewidth.StringWidth(str)
-	sw += NumOccurrences(str, '\t') * (tabsize - 1)
+	lineIdx := 0
+	for _, ch := range str {
+		switch ch {
+		case '\t':
+			ts := tabsize - (lineIdx % tabsize)
+			sw += ts - 1
+		case '\n':
+			lineIdx = 0
+		default:
+			lineIdx++
+		}
+	}
 	return sw
 }
 
@@ -165,15 +176,21 @@ func StringWidth(str string, tabsize int) int {
 // that have a width larger than 1 (this also counts tabs as `tabsize` width)
 func WidthOfLargeRunes(str string, tabsize int) int {
 	count := 0
+	lineIdx := 0
 	for _, ch := range str {
 		var w int
 		if ch == '\t' {
-			w = tabsize
+			w = tabsize - (lineIdx % tabsize)
 		} else {
 			w = runewidth.RuneWidth(ch)
 		}
 		if w > 1 {
 			count += (w - 1)
+		}
+		if ch == '\n' {
+			lineIdx = 0
+		} else {
+			lineIdx++
 		}
 	}
 	return count

--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -771,7 +771,8 @@ func (v *View) DisplayView() {
 				}
 				// Now the tab has to be displayed as a bunch of spaces
 				tabSize := int(v.Buf.Settings["tabsize"].(float64))
-				for i := 0; i < tabSize-1; i++ {
+				remainder := tabSize - (colN % tabSize)
+				for i := 0; i < remainder-1; i++ {
 					screenX++
 					if screenX-v.x-v.leftCol >= v.lineNumOffset {
 						v.drawCell(screenX-v.leftCol, screenY, ' ', nil, lineStyle)


### PR DESCRIPTION
when tabstospaces is off tabs were always treated as as a number of spaces not as tabs with tabstops.