### PR TITLE
don't use undo / redo history for log buffer.

### DIFF
--- a/cmd/micro/messenger.go
+++ b/cmd/micro/messenger.go
@@ -71,7 +71,7 @@ type Messenger struct {
 
 func (m *Messenger) AddLog(msg string) {
 	buffer := m.getBuffer()
-	buffer.Insert(buffer.End(), msg+"\n")
+	buffer.insert(buffer.End(), []byte(msg+"\n"))
 	buffer.Cursor.Loc = buffer.End()
 	buffer.Cursor.Relocate()
 }


### PR DESCRIPTION
I noticed in my snippet plugin that I got text events from the log buffer. that should not be the case...