### PR TITLE
Fixes in last PR: MoveLinesUp and MoveLinesDown

### DIFF
--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -346,6 +346,9 @@ func (b *Buffer) End() Loc {
 
 // Line returns a single line
 func (b *Buffer) Line(n int) string {
+	if n >= len(b.lines) {
+		return ""
+	}
 	return string(b.lines[n])
 }
 

--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -369,10 +369,20 @@ func (b *Buffer) MoveLinesUp(start int, end int) {
     if start < 1 || start >= end || end > len(b.lines) {
         return // what to do? FIXME
     }
-    b.Insert(
-        Loc{0, end},
-        b.Line(start - 1) + "\n",
-    )
+    if end == len(b.lines) {
+        b.Insert(
+            Loc{
+                utf8.RuneCount(b.lines[end-1]),
+                end - 1,
+            },
+            "\n" + b.Line(start - 1),
+        )
+    } else {
+        b.Insert(
+            Loc{0, end},
+            b.Line(start - 1) + "\n",
+        )
+    }
     b.Remove(
         Loc{0, start - 1},
         Loc{0, start},

--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -394,7 +394,9 @@ func (b *Buffer) MoveLinesUp(start int, end int) {
 
 func (b *Buffer) MoveLinesDown(start int, end int) {
     // 0 <= start < end < len(b.lines)
-    if start < 0 || start >= end || end >= len(b.lines) {
+    // if end == len(b.lines), we can't do anything here because the
+    // last line is unaccessible, FIXME
+    if start < 0 || start >= end || end >= len(b.lines)-1 {
         return // what to do? FIXME
     }
     b.Insert(
@@ -402,15 +404,8 @@ func (b *Buffer) MoveLinesDown(start int, end int) {
         b.Line(end) + "\n",
     )
     end += 1
-    rmEndLoc := Loc{0, end + 1}
-    if end >= len(b.lines)-1 {
-        rmEndLoc = Loc{
-            utf8.RuneCount(b.lines[end]) - 1,
-            end,
-        }
-    }
     b.Remove(
         Loc{0, end},
-        rmEndLoc,
+        Loc{0, end + 1},
     )
 }

--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -368,44 +368,44 @@ func (b *Buffer) Len() int {
 }
 
 func (b *Buffer) MoveLinesUp(start int, end int) {
-    // 0 < start < end <= len(b.lines)
-    if start < 1 || start >= end || end > len(b.lines) {
-        return // what to do? FIXME
-    }
-    if end == len(b.lines) {
-        b.Insert(
-            Loc{
-                utf8.RuneCount(b.lines[end-1]),
-                end - 1,
-            },
-            "\n" + b.Line(start - 1),
-        )
-    } else {
-        b.Insert(
-            Loc{0, end},
-            b.Line(start - 1) + "\n",
-        )
-    }
-    b.Remove(
-        Loc{0, start - 1},
-        Loc{0, start},
-    )
+	// 0 < start < end <= len(b.lines)
+	if start < 1 || start >= end || end > len(b.lines) {
+		return // what to do? FIXME
+	}
+	if end == len(b.lines) {
+		b.Insert(
+			Loc{
+				utf8.RuneCount(b.lines[end-1]),
+				end - 1,
+			},
+			"\n" + b.Line(start - 1),
+		)
+	} else {
+		b.Insert(
+			Loc{0, end},
+			b.Line(start - 1) + "\n",
+		)
+	}
+	b.Remove(
+		Loc{0, start - 1},
+		Loc{0, start},
+	)
 }
 
 func (b *Buffer) MoveLinesDown(start int, end int) {
-    // 0 <= start < end < len(b.lines)
-    // if end == len(b.lines), we can't do anything here because the
-    // last line is unaccessible, FIXME
-    if start < 0 || start >= end || end >= len(b.lines)-1 {
-        return // what to do? FIXME
-    }
-    b.Insert(
-        Loc{0, start},
-        b.Line(end) + "\n",
-    )
-    end += 1
-    b.Remove(
-        Loc{0, end},
-        Loc{0, end + 1},
-    )
+	// 0 <= start < end < len(b.lines)
+	// if end == len(b.lines), we can't do anything here because the
+	// last line is unaccessible, FIXME
+	if start < 0 || start >= end || end >= len(b.lines)-1 {
+		return // what to do? FIXME
+	}
+	b.Insert(
+		Loc{0, start},
+		b.Line(end) + "\n",
+	)
+	end += 1
+	b.Remove(
+		Loc{0, end},
+		Loc{0, end + 1},
+	)
 }


### PR DESCRIPTION
- Fix panic when moving up last line
- Avoid panic in Buffer.Line in case index was out of range (fixes potential panics)
- Fix unexpected behaviour when moving down the line before last line (I couldn't get it to work, looks like a global bug, so we just ignore and return)
- Replace spaces with tabs