### PR TITLE
Improve Search behaviour, and Escape key behaviour

### DIFF
--- a/cmd/micro/bindings.go
+++ b/cmd/micro/bindings.go
@@ -74,6 +74,7 @@ var bindingActions = map[string]func(*View, bool) bool{
 	"ClearStatus":         (*View).ClearStatus,
 	"ShellMode":           (*View).ShellMode,
 	"CommandMode":         (*View).CommandMode,
+	"Escape":              (*View).Escape,
 	"Quit":                (*View).Quit,
 	"QuitAll":             (*View).QuitAll,
 	"AddTab":              (*View).AddTab,
@@ -433,6 +434,6 @@ func DefaultBindings() map[string]string {
 		"F4":  "Quit",
 		"F7":  "Find",
 		"F10": "Quit",
-		"Esc": "Quit",
+		"Esc": "Escape",
 	}
 }

--- a/cmd/micro/search.go
+++ b/cmd/micro/search.go
@@ -21,10 +21,12 @@ var (
 )
 
 // BeginSearch starts a search
-func BeginSearch() {
+func BeginSearch(searchStr string) {
 	searchHistory = append(searchHistory, "")
 	messenger.historyNum = len(searchHistory) - 1
 	searching = true
+	messenger.response = searchStr
+	messenger.cursorx = Count(searchStr)
 	messenger.hasPrompt = true
 	messenger.Message("Find: ")
 }
@@ -41,13 +43,27 @@ func EndSearch() {
 	}
 }
 
+// exit the search mode, reset active search phrase, and clear status bar
+func ExitSearch(v *View) {
+	lastSearch = ""
+	searching = false
+	messenger.hasPrompt = false
+	messenger.Clear()
+	messenger.Reset()
+	v.Cursor.ResetSelection()
+}
+
 // HandleSearchEvent takes an event and a view and will do a real time match from the messenger's output
 // to the current buffer. It searches down the buffer.
 func HandleSearchEvent(event tcell.Event, v *View) {
 	switch e := event.(type) {
 	case *tcell.EventKey:
 		switch e.Key() {
-		case tcell.KeyCtrlQ, tcell.KeyCtrlC, tcell.KeyEscape, tcell.KeyEnter:
+		case tcell.KeyEscape:
+			// Exit the search mode
+			ExitSearch(v)
+			return
+		case tcell.KeyCtrlQ, tcell.KeyCtrlC, tcell.KeyEnter:
 			// Done
 			EndSearch()
 			return


### PR DESCRIPTION
- On Escape key press, while a search prompt is shown, hide and reset search instead of exiting editor
- On Escape key press, while a search is active (status bar shows `Finding:` or `^P Previous ^N Next`), exit/reset search mode instead of exiting editor
- When selecting a text and pressing Control + F, show the selected text as default search phrase
- Enable quicker search when there is no active search, just select a text and press Control + N or P, no prompt
