### PR TITLE
Refactored IndentSelection and OutdentSelection to remove duplicate code

### DIFF
--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -587,24 +587,24 @@ func (v *View) IndentSelection(usePlugin bool) bool {
 	}
 
 	if v.Cursor.HasSelection() {
-		start := v.Cursor.CurSelection[0].Y
-		end := v.Cursor.CurSelection[1].Move(-1, v.Buf).Y
+		startY := v.Cursor.CurSelection[0].Y
+		endY := v.Cursor.CurSelection[1].Move(-1, v.Buf).Y
 		endX := v.Cursor.CurSelection[1].Move(-1, v.Buf).X
-		for line := start; line <= end; line++ {
+		for y := startY; y <= endY; y++ {
 			tabsize := 1
 			tab := "\t"
 			if v.Buf.Settings["tabstospaces"].(bool) {
 				tabsize = int(v.Buf.Settings["tabsize"].(float64))
 				tab = Spaces(tabsize)
 			}
-			v.Buf.Insert(Loc{0, line}, tab)
-			if line == start {
+			v.Buf.Insert(Loc{0, y}, tab)
+			if y == startY {
 				if v.Cursor.CurSelection[0].X > 0 {
 					v.Cursor.SetSelectionStart(v.Cursor.CurSelection[0].Move(tabsize, v.Buf))
 				}
 			}
-			if line == end {
-				v.Cursor.SetSelectionEnd(Loc{endX + tabsize + 1, end})
+			if y == endY {
+				v.Cursor.SetSelectionEnd(Loc{endX + tabsize + 1, endY})
 			}
 		}
 		v.Cursor.Relocate()
@@ -624,27 +624,27 @@ func (v *View) OutdentSelection(usePlugin bool) bool {
 	}
 
 	if v.Cursor.HasSelection() {
-		start := v.Cursor.CurSelection[0].Y
-		end := v.Cursor.CurSelection[1].Move(-1, v.Buf).Y
+		startY := v.Cursor.CurSelection[0].Y
+		endY := v.Cursor.CurSelection[1].Move(-1, v.Buf).Y
 		endX := v.Cursor.CurSelection[1].Move(-1, v.Buf).X
-		for line := start; line <= end; line++ {
-			if len(GetLeadingWhitespace(v.Buf.Line(line))) > 0 {
+		for y := startY; y <= endY; y++ {
+			if len(GetLeadingWhitespace(v.Buf.Line(y))) > 0 {
 				tabsize := 1
 				if v.Buf.Settings["tabstospaces"].(bool) {
 					tabsize = int(v.Buf.Settings["tabsize"].(float64))
 				}
-				for j := 0; j < tabsize; j++ {
-					if len(GetLeadingWhitespace(v.Buf.Line(line))) == 0 {
+				for x := 0; x < tabsize; x++ {
+					if len(GetLeadingWhitespace(v.Buf.Line(y))) == 0 {
 						break
 					}
-					v.Buf.Remove(Loc{0, line}, Loc{1, line})
-					if line == start {
+					v.Buf.Remove(Loc{0, y}, Loc{1, y})
+					if y == startY {
 						if v.Cursor.CurSelection[0].X > 0 {
 							v.Cursor.SetSelectionStart(v.Cursor.CurSelection[0].Move(-1, v.Buf))
 						}
 					}
-					if line == end {
-						v.Cursor.SetSelectionEnd(Loc{endX - j, end})
+					if y == endY {
+						v.Cursor.SetSelectionEnd(Loc{endX - x, endY})
 					}
 				}
 			}

--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -627,33 +627,24 @@ func (v *View) OutdentSelection(usePlugin bool) bool {
 		start := v.Cursor.CurSelection[0].Y
 		end := v.Cursor.CurSelection[1].Move(-1, v.Buf).Y
 		endX := v.Cursor.CurSelection[1].Move(-1, v.Buf).X
-		for i := start; i <= end; i++ {
-			if len(GetLeadingWhitespace(v.Buf.Line(i))) > 0 {
+		for line := start; line <= end; line++ {
+			if len(GetLeadingWhitespace(v.Buf.Line(line))) > 0 {
+				tabsize := 1
 				if v.Buf.Settings["tabstospaces"].(bool) {
-					tabsize := int(v.Buf.Settings["tabsize"].(float64))
-					for j := 0; j < tabsize; j++ {
-						if len(GetLeadingWhitespace(v.Buf.Line(i))) == 0 {
-							break
-						}
-						v.Buf.Remove(Loc{0, i}, Loc{1, i})
-						if i == start {
-							if v.Cursor.CurSelection[0].X > 0 {
-								v.Cursor.SetSelectionStart(v.Cursor.CurSelection[0].Move(-1, v.Buf))
-							}
-						}
-						if i == end {
-							v.Cursor.SetSelectionEnd(Loc{endX - j, end})
-						}
+					tabsize = int(v.Buf.Settings["tabsize"].(float64))
+				}
+				for j := 0; j < tabsize; j++ {
+					if len(GetLeadingWhitespace(v.Buf.Line(line))) == 0 {
+						break
 					}
-				} else {
-					v.Buf.Remove(Loc{0, i}, Loc{1, i})
-					if i == start {
+					v.Buf.Remove(Loc{0, line}, Loc{1, line})
+					if line == start {
 						if v.Cursor.CurSelection[0].X > 0 {
 							v.Cursor.SetSelectionStart(v.Cursor.CurSelection[0].Move(-1, v.Buf))
 						}
 					}
-					if i == end {
-						v.Cursor.SetSelectionEnd(Loc{endX, end})
+					if line == end {
+						v.Cursor.SetSelectionEnd(Loc{endX - j, end})
 					}
 				}
 			}

--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -590,28 +590,21 @@ func (v *View) IndentSelection(usePlugin bool) bool {
 		start := v.Cursor.CurSelection[0].Y
 		end := v.Cursor.CurSelection[1].Move(-1, v.Buf).Y
 		endX := v.Cursor.CurSelection[1].Move(-1, v.Buf).X
-		for i := start; i <= end; i++ {
+		for line := start; line <= end; line++ {
+			tabsize := 1
+			tab := "\t"
 			if v.Buf.Settings["tabstospaces"].(bool) {
-				tabsize := int(v.Buf.Settings["tabsize"].(float64))
-				v.Buf.Insert(Loc{0, i}, Spaces(tabsize))
-				if i == start {
-					if v.Cursor.CurSelection[0].X > 0 {
-						v.Cursor.SetSelectionStart(v.Cursor.CurSelection[0].Move(tabsize, v.Buf))
-					}
+				tabsize = int(v.Buf.Settings["tabsize"].(float64))
+				tab = Spaces(tabsize)
+			}
+			v.Buf.Insert(Loc{0, line}, tab)
+			if line == start {
+				if v.Cursor.CurSelection[0].X > 0 {
+					v.Cursor.SetSelectionStart(v.Cursor.CurSelection[0].Move(tabsize, v.Buf))
 				}
-				if i == end {
-					v.Cursor.SetSelectionEnd(Loc{endX + tabsize + 1, end})
-				}
-			} else {
-				v.Buf.Insert(Loc{0, i}, "\t")
-				if i == start {
-					if v.Cursor.CurSelection[0].X > 0 {
-						v.Cursor.SetSelectionStart(v.Cursor.CurSelection[0].Move(1, v.Buf))
-					}
-				}
-				if i == end {
-					v.Cursor.SetSelectionEnd(Loc{endX + 2, end})
-				}
+			}
+			if line == end {
+				v.Cursor.SetSelectionEnd(Loc{endX + tabsize + 1, end})
 			}
 		}
 		v.Cursor.Relocate()


### PR DESCRIPTION
Previously, these functions had two branches, one that looped when spaces are used and another that didn't need to loop when using regular tabs. The inside of the space loop and the inside of the tab branch were nearly the same, so I removed the simpler branch and ran the more complicated one using only a single loop iteration.

I also use `x` and `y` for loop variables as they make more sense to me than `i` and `j` in this case since they represent lines and columns.