### PR TITLE
Added IndentString method on Buffer

### DIFF
--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -591,13 +591,8 @@ func (v *View) IndentSelection(usePlugin bool) bool {
 		endY := v.Cursor.CurSelection[1].Move(-1, v.Buf).Y
 		endX := v.Cursor.CurSelection[1].Move(-1, v.Buf).X
 		for y := startY; y <= endY; y++ {
-			tabsize := 1
-			tab := "\t"
-			if v.Buf.Settings["tabstospaces"].(bool) {
-				tabsize = int(v.Buf.Settings["tabsize"].(float64))
-				tab = Spaces(tabsize)
-			}
-			v.Buf.Insert(Loc{0, y}, tab)
+			tabsize := len(v.Buf.IndentString())
+			v.Buf.Insert(Loc{0, y}, v.Buf.IndentString())
 			if y == startY {
 				if v.Cursor.CurSelection[0].X > 0 {
 					v.Cursor.SetSelectionStart(v.Cursor.CurSelection[0].Move(tabsize, v.Buf))
@@ -629,11 +624,7 @@ func (v *View) OutdentSelection(usePlugin bool) bool {
 		endX := v.Cursor.CurSelection[1].Move(-1, v.Buf).X
 		for y := startY; y <= endY; y++ {
 			if len(GetLeadingWhitespace(v.Buf.Line(y))) > 0 {
-				tabsize := 1
-				if v.Buf.Settings["tabstospaces"].(bool) {
-					tabsize = int(v.Buf.Settings["tabsize"].(float64))
-				}
-				for x := 0; x < tabsize; x++ {
+				for x := 0; x < len(v.Buf.IndentString()); x++ {
 					if len(GetLeadingWhitespace(v.Buf.Line(y))) == 0 {
 						break
 					}
@@ -668,18 +659,13 @@ func (v *View) InsertTab(usePlugin bool) bool {
 	if v.Cursor.HasSelection() {
 		return false
 	}
-	// Insert a tab
-	if v.Buf.Settings["tabstospaces"].(bool) {
-		tabSize := int(v.Buf.Settings["tabsize"].(float64))
-		if remainder := v.Cursor.GetVisualX() % tabSize; remainder != 0 {
-			tabSize = tabSize - remainder
-		}
-		v.Buf.Insert(v.Cursor.Loc, Spaces(tabSize))
-		for i := 0; i < tabSize; i++ {
-			v.Cursor.Right()
-		}
-	} else {
-		v.Buf.Insert(v.Cursor.Loc, "\t")
+	
+	tabSize := int(v.Buf.Settings["tabsize"].(float64))
+	if remainder := v.Cursor.GetVisualX() % tabSize; remainder != 0 {
+		tabSize = tabSize - remainder
+	}
+	v.Buf.Insert(v.Cursor.Loc, v.Buf.IndentString())
+	for i := 0; i < len(v.Buf.IndentString()); i++ {
 		v.Cursor.Right()
 	}
 

--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -621,18 +621,16 @@ func (v *View) OutdentSelection(usePlugin bool) bool {
 		endY := v.Cursor.CurSelection[1].Move(-1, v.Buf).Y
 		endX := v.Cursor.CurSelection[1].Move(-1, v.Buf).X
 		for y := startY; y <= endY; y++ {
-			if len(GetLeadingWhitespace(v.Buf.Line(y))) > 0 {
-				for x := 0; x < len(v.Buf.IndentString()); x++ {
-					if len(GetLeadingWhitespace(v.Buf.Line(y))) == 0 {
-						break
-					}
-					v.Buf.Remove(Loc{0, y}, Loc{1, y})
-					if y == startY && v.Cursor.CurSelection[0].X > 0 {
-						v.Cursor.SetSelectionStart(v.Cursor.CurSelection[0].Move(-1, v.Buf))
-					}
-					if y == endY {
-						v.Cursor.SetSelectionEnd(Loc{endX - x, endY})
-					}
+			for x := 0; x < len(v.Buf.IndentString()); x++ {
+				if len(GetLeadingWhitespace(v.Buf.Line(y))) == 0 {
+					break
+				}
+				v.Buf.Remove(Loc{0, y}, Loc{1, y})
+				if y == startY && v.Cursor.CurSelection[0].X > 0 {
+					v.Cursor.SetSelectionStart(v.Cursor.CurSelection[0].Move(-1, v.Buf))
+				}
+				if y == endY {
+					v.Cursor.SetSelectionEnd(Loc{endX - x, endY})
 				}
 			}
 		}

--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -654,12 +654,10 @@ func (v *View) InsertTab(usePlugin bool) bool {
 		return false
 	}
 	
-	tabSize := int(v.Buf.Settings["tabsize"].(float64))
-	if remainder := v.Cursor.GetVisualX() % tabSize; remainder != 0 {
-		tabSize = tabSize - remainder
-	}
-	v.Buf.Insert(v.Cursor.Loc, v.Buf.IndentString())
-	for i := 0; i < len(v.Buf.IndentString()); i++ {
+	tabBytes := len(v.Buf.IndentString())
+	bytesUntilIndent := tabBytes - (v.Cursor.GetVisualX() % tabBytes)
+	v.Buf.Insert(v.Cursor.Loc, v.Buf.IndentString()[:bytesUntilIndent])
+	for i := 0; i < bytesUntilIndent; i++ {
 		v.Cursor.Right()
 	}
 

--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -593,10 +593,8 @@ func (v *View) IndentSelection(usePlugin bool) bool {
 		for y := startY; y <= endY; y++ {
 			tabsize := len(v.Buf.IndentString())
 			v.Buf.Insert(Loc{0, y}, v.Buf.IndentString())
-			if y == startY {
-				if v.Cursor.CurSelection[0].X > 0 {
-					v.Cursor.SetSelectionStart(v.Cursor.CurSelection[0].Move(tabsize, v.Buf))
-				}
+			if y == startY && v.Cursor.CurSelection[0].X > 0 {
+				v.Cursor.SetSelectionStart(v.Cursor.CurSelection[0].Move(tabsize, v.Buf))
 			}
 			if y == endY {
 				v.Cursor.SetSelectionEnd(Loc{endX + tabsize + 1, endY})
@@ -629,10 +627,8 @@ func (v *View) OutdentSelection(usePlugin bool) bool {
 						break
 					}
 					v.Buf.Remove(Loc{0, y}, Loc{1, y})
-					if y == startY {
-						if v.Cursor.CurSelection[0].X > 0 {
-							v.Cursor.SetSelectionStart(v.Cursor.CurSelection[0].Move(-1, v.Buf))
-						}
+					if y == startY && v.Cursor.CurSelection[0].X > 0 {
+						v.Cursor.SetSelectionStart(v.Cursor.CurSelection[0].Move(-1, v.Buf))
 					}
 					if y == endY {
 						v.Cursor.SetSelectionEnd(Loc{endX - x, endY})

--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -182,6 +182,16 @@ func (b *Buffer) FileType() string {
 	return b.Settings["filetype"].(string)
 }
 
+// IndentString returns the sting used to produce an indent based on
+// this buffer's settings
+func (b *Buffer) IndentString() string {
+	if b.Settings["tabstospaces"].(bool) {
+		return Spaces(int(b.Settings["tabsize"].(float64)))
+	} else {
+		return "\t"
+	}
+}
+
 // CheckModTime makes sure that the file this buffer points to hasn't been updated
 // by an external program since it was last read
 // If it has, we ask the user if they would like to reload the file

--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -182,8 +182,7 @@ func (b *Buffer) FileType() string {
 	return b.Settings["filetype"].(string)
 }
 
-// IndentString returns the sting used to produce an indent based on
-// this buffer's settings
+// IndentString returns a string representing one level of indentation
 func (b *Buffer) IndentString() string {
 	if b.Settings["tabstospaces"].(bool) {
 		return Spaces(int(b.Settings["tabsize"].(float64)))


### PR DESCRIPTION
I noticed several places where a string was being built to represent one level of indentation based on `Settings["tabstospaces"]` and `Settings["tabsize"]`. I created a separate `IndentString` method on `Buffer` to return this value and reused this method instead.

This makes the indentation logic simpler to understand and is also more DRY.