### PR TITLE
DuplicateLine duplicates current selection if there is text selected

### DIFF
--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -922,15 +922,20 @@ func (v *View) Cut(usePlugin bool) bool {
 	return false
 }
 
-// DuplicateLine duplicates the current line
+// DuplicateLine duplicates the current line or selection
 func (v *View) DuplicateLine(usePlugin bool) bool {
 	if usePlugin && !PreActionCall("DuplicateLine", v) {
 		return false
 	}
 
-	v.Cursor.End()
-	v.Buf.Insert(v.Cursor.Loc, "\n"+v.Buf.Line(v.Cursor.Y))
-	v.Cursor.Right()
+	if v.Cursor.HasSelection() {
+		v.Buf.Insert(v.Cursor.CurSelection[1], v.Cursor.GetSelection())
+	} else {
+		v.Cursor.End()
+		v.Buf.Insert(v.Cursor.Loc, "\n"+v.Buf.Line(v.Cursor.Y))
+		v.Cursor.Right()
+	}
+
 	messenger.Message("Duplicated line")
 
 	if usePlugin {


### PR DESCRIPTION
I'd love to see this functionality merged, but if there is a better place for it, I'm open to suggestions.

I thought about creating a separate action for this (perhaps a `DuplicateSelection` that works on selections or lines), but that seemed wasteful given that the current `DuplicateLine` behavior doesn't really make sense when text is selected anyhow and duplicating the selected text seems like the logical thing to do.