### PR TITLE
Search entire file for soft wrap location instead of line 1 to the number of lines in view

### DIFF
--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -291,7 +291,7 @@ func (v *View) GetSoftWrapLocation(vx, vy int) (int, int) {
 	}
 
 	screenX, screenY := 0, v.Topline
-	for lineN := v.Topline; lineN < v.height; lineN++ {
+	for lineN := v.Topline; lineN < v.Bottomline(); lineN++ {
 		line := v.Buf.Line(lineN)
 
 		colN := 0


### PR DESCRIPTION
This should fix #434 and doesn't appear to cause a regression of #432 in my testing.