### PR TITLE
adding hexidecimal numbers to the existing C syntax rules

### DIFF
--- a/runtime/syntax/c.micro
+++ b/runtime/syntax/c.micro
@@ -21,7 +21,7 @@ color statement "[.:;,+*|=!\%]" "<" ">" "/" "-" "&"
 #Parenthetical Color
 # color magenta "[(){}]" "\[" "\]"
 
-color constant.number "\b[0-9]+\b"
+color constant.number "\b[0-9]+\b" "\b0x[0-9A-Fa-f]+\b"
 
 ##
 ## String highlighting.  You will in general want your brightblacks and


### PR DESCRIPTION
simple change, adding syntax highlighting support for hexadecimal numbers as "constants" for C style languages. I took a stab at getting negatives and floating point numbers to be caught as well but I cannot seem to get that syntax correct here. Would be happy to amend the PR with those changes if someone can suggest correct regex for those.