### PR TITLE
Objective-C syntax rules

### DIFF
--- a/runtime/syntax/objc.micro
+++ b/runtime/syntax/objc.micro
@@ -1,8 +1,8 @@
-## Here is an example for C/C++/Obj-C.
+## Here is an example for Obj-C.
 ##
 syntax "Objective-C" "\.(m|mm|h)$"
 
-color type "\b(float|double|CGFloat|id|bool|BOOL|char|int|short|long|sizeof|enum|void|static|const|struct|union|typedef|extern|(un)?signed|inline|Class|SEL|IMP)\b"
+color type "\b(float|double|CGFloat|id|bool|BOOL|Boolean|char|int|short|long|sizeof|enum|void|static|const|struct|union|typedef|extern|(un)?signed|inline|Class|SEL|IMP|NS(U)?Integer)\b"
 color type "\b((s?size)|((u_?)?int(8|16|32|64|ptr)))_t\b"
 color type "\b[A-Z][A-Z][[:alnum:]]*\b"
 color type "\b[A-Za-z0-9_]*_t\b"

--- a/runtime/syntax/objc.micro
+++ b/runtime/syntax/objc.micro
@@ -1,0 +1,37 @@
+## Here is an example for C/C++/Obj-C.
+##
+syntax "Objective-C" "\.(m|mm|h)$"
+
+color type "\b(float|double|CGFloat|id|bool|BOOL|char|int|short|long|sizeof|enum|void|static|const|struct|union|typedef|extern|(un)?signed|inline|Class|SEL|IMP)\b"
+color type "\b((s?size)|((u_?)?int(8|16|32|64|ptr)))_t\b"
+color type "\b[A-Z][A-Z][[:alnum:]]*\b"
+color type "\b[A-Za-z0-9_]*_t\b"
+color type "\bdispatch_[a-zA-Z0-9_]*_t\b"
+
+color statement "__attribute__[[:space:]]*\(\([^)]*\)\)" "__(aligned|asm|builtin|hidden|inline|packed|restrict|section|typeof|weak)__" "__unused" "_Nonnull" "_Nullable" "__block" "__builtin.*"
+color statement "\b(class|namespace|template|public|protected|private|typename|this|friend|virtual|using|mutable|volatile|register|explicit)\b"
+color statement "\b(for|if|while|do|else|case|default|switch)\b"
+color statement "\b(try|throw|catch|operator|new|delete)\b"
+color statement "\b(goto|continue|break|return)\b"
+color statement "\b(nonatomic|atomic|readonly|readwrite|strong|weak|assign)\b"
+color statement "@(encode|end|interface|implementation|class|selector|protocol|synchronized|try|catch|finally|property|optional|required|import|autoreleasepool)"
+
+color preproc "^[[:space:]]*#[[:space:]]*(define|include|import|(un|ifn?)def|endif|el(if|se)|if|warning|error|pragma).*$"
+color preproc "__[A-Z0-9_]*__"
+
+color special "^[[:space:]]*[#|@][[:space:]]*(import|include)[[:space:]]*[\"|<].*\/?[>|\"][[:space:]]*$"
+
+color statement "[.:;,+*|=!\%\[\]]" "<" ">" "/" "-" "&" 
+
+color constant.number "\b(-?)?[0-9]+\b" "\b\[0-9]+\.[0-9]+\b" "\b0x[0-9A-F]+\b"
+color constant "@\[(\\.|[^\]])*\]" "@\{(\\.|[^\}])*\}" "@\((\\.|[^\)])*\)"
+color constant "\b<(\\.[^\>])*\>\b"
+color constant "\b(nil|NULL|YES|NO|TRUE|true|FALSE|false|self)\b"
+color constant "\bk[[:alnum]]*\b"
+color constant.string "\"(\\.|[^\"])*\"" "@\"(\\.|[^\"])*\"" "'.'"
+
+
+color comment "//.*"
+color comment start="/\*" end="\*/"
+
+


### PR DESCRIPTION
Adding syntax file for supporting Objective-C.

(semi-related, is there any sort of resource for creating the syntax rules? I have been trying to find an official guide as to what some of the tokens mean (I am unfamiliar with `\b ... \b` and `\< ... \>` as part of the syntactic regex), but been coming up short. I think what I have created is mostly correct (at least it looks that way from within micro), but i would like to feel more confident in making changes or creating new syntax highlighting rules if there was an official guide.)