### PR TITLE
Add `JobSpawn()` function for plugin interface

### DIFF
--- a/cmd/micro/job.go
+++ b/cmd/micro/job.go
@@ -40,15 +40,20 @@ func (f *CallbackFile) Write(data []byte) (int, error) {
 	return f.Writer.Write(data)
 }
 
-// JobStart starts a process in the background with the given callbacks
+// JobStart starts a shell command in the background with the given callbacks
 // It returns an *exec.Cmd as the job id
 func JobStart(cmd string, onStdout, onStderr, onExit string, userargs ...string) *exec.Cmd {
 	split := strings.Split(cmd, " ")
-	args := split[1:]
+	cmdArgs := split[1:]
 	cmdName := split[0]
+	return JobSpawn(cmdName, cmdArgs, onStdout, onStderr, onExit, userargs...)
+}
 
+// JobSpawn starts a process with args in the background with the given callbacks
+// It returns an *exec.Cmd as the job id
+func JobSpawn(cmdName string, cmdArgs []string, onStdout, onStderr, onExit string, userargs ...string) *exec.Cmd {
 	// Set up everything correctly if the functions have been provided
-	proc := exec.Command(cmdName, args...)
+	proc := exec.Command(cmdName, cmdArgs...)
 	var outbuf bytes.Buffer
 	if onStdout != "" {
 		proc.Stdout = &CallbackFile{&outbuf, LuaFunctionJob(onStdout), userargs}

--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -340,6 +340,7 @@ func main() {
 
 	// Used for asynchronous jobs
 	L.SetGlobal("JobStart", luar.New(L, JobStart))
+	L.SetGlobal("JobSpawn", luar.New(L, JobSpawn))
 	L.SetGlobal("JobSend", luar.New(L, JobSend))
 	L.SetGlobal("JobStop", luar.New(L, JobStop))
 

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -90,11 +90,15 @@ as Go's GOOS variable, so `darwin`, `windows`, `linux`, `freebsd`...)
 
 * `ByteOffset(loc Loc, buf *Buffer) int`: exactly like `ToCharPos` except it it counts bytes instead of runes.
 
-* `JobStart(cmd string, onStdout, onStderr, onExit string, userargs ...string)`:
-   Starts running the given shell command in the background. `onStdout` `onStderr` and `onExit`
+* `JobSpawn(cmdName string, cmdArgs []string, onStdout, onStderr, onExit string, userargs ...string)`:
+   Starts running the given process in the background. `onStdout` `onStderr` and `onExit`
    are callbacks to lua functions which will be called when the given actions happen
    to the background process.
    `userargs` are the arguments which will get passed to the callback functions
+
+* `JobStart(cmd string, onStdout, onStderr, onExit string, userargs ...string)`:
+   Starts running the given shell command in the background.
+   This function is a shorthand for `JobSpawn`.
 
 * `JobSend(cmd *exec.Cmd, data string)`: send a string into the stdin of the job process
 


### PR DESCRIPTION
Accepting shell command as string can cause problems for some cases, so I think it is nice to have an interface to invode external programs with argument lists.

For example, when one of installed plugins has a line like  `JobStart("./compile.sh " .. buf.Path)`, and open a file which has a name like `a b c.txt` in micro, then an unexpected command will be executed.
`JobSpawn` can avoid cases like this.