### PR TITLE
Add Buffer.AbsPath and a plugin function DirectoryName

### DIFF
--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -27,6 +27,8 @@ type Buffer struct {
 
 	// Path to the file on disk
 	Path string
+	// Absolute path to the file on disk
+	AbsPath string
 	// Name of the buffer on the status line
 	Name string
 
@@ -75,7 +77,10 @@ func NewBuffer(txt []byte, path string) *Buffer {
 		}
 	}
 
+	absPath, _ := filepath.Abs(path)
+
 	b.Path = path
+	b.AbsPath = absPath
 	b.Name = path
 
 	// If the file doesn't have a path to disk then we give it no name
@@ -136,8 +141,7 @@ func NewBuffer(txt []byte, path string) *Buffer {
 	if b.Settings["savecursor"].(bool) || b.Settings["saveundo"].(bool) {
 		// If either savecursor or saveundo is turned on, we need to load the serialized information
 		// from ~/.config/micro/buffers
-		absPath, _ := filepath.Abs(b.Path)
-		file, err := os.Open(configDir + "/buffers/" + EscapePath(absPath))
+		file, err := os.Open(configDir + "/buffers/" + EscapePath(b.AbsPath))
 		if err == nil {
 			var buffer SerializedBuffer
 			decoder := gob.NewDecoder(file)
@@ -246,8 +250,7 @@ func (b *Buffer) SaveWithSudo() error {
 // Serialize serializes the buffer to configDir/buffers
 func (b *Buffer) Serialize() error {
 	if b.Settings["savecursor"].(bool) || b.Settings["saveundo"].(bool) {
-		absPath, _ := filepath.Abs(b.Path)
-		file, err := os.Create(configDir + "/buffers/" + EscapePath(absPath))
+		file, err := os.Create(configDir + "/buffers/" + EscapePath(b.AbsPath))
 		if err == nil {
 			enc := gob.NewEncoder(file)
 			gob.Register(TextEvent{})

--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -333,6 +333,7 @@ func main() {
 		return Loc{x, y}
 	}))
 	L.SetGlobal("JoinPaths", luar.New(L, filepath.Join))
+	L.SetGlobal("DirectoryName", luar.New(L, filepath.Dir))
 	L.SetGlobal("configDir", luar.New(L, configDir))
 	L.SetGlobal("Reload", luar.New(L, LoadAll))
 	L.SetGlobal("ByteOffset", luar.New(L, ByteOffset))

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -57,6 +57,8 @@ as Go's GOOS variable, so `darwin`, `windows`, `linux`, `freebsd`...)
 
 * `JoinPaths(dir... string) string` combines multiple directories to a full path
 
+* `DirectoryName(path string)` returns all but the last element of path ,typically the path's directory
+
 * `GetOption(name string)`: returns the value of the requested option
 
 * `AddOption(name string, value interface{})`: sets the given option with the given


### PR DESCRIPTION
Makes it easier for plugins to get full path of current buffer and directory where the file is!

* `Buffer.AbsPath`
  * Absolute path of current buffer
* `DirectoryName`
  * a plugin function that calls `filepath/Dir` golang function
  * Returns directory name of given path