### PR TITLE
Enable plugins even when they are symlinks

### DIFF
--- a/cmd/micro/rtfiles.go
+++ b/cmd/micro/rtfiles.go
@@ -126,7 +126,9 @@ func InitRuntimeFiles() {
 	// Search configDir for plugin-scripts
 	files, _ := ioutil.ReadDir(filepath.Join(configDir, "plugins"))
 	for _, f := range files {
-		if f.IsDir() {
+		realpath, _ := filepath.EvalSymlinks(filepath.Join(configDir, "plugins", f.Name()))
+		realpathStat, _ := os.Stat(realpath)
+		if realpathStat.IsDir() {
 			scriptPath := filepath.Join(configDir, "plugins", f.Name(), f.Name()+".lua")
 			if _, err := os.Stat(scriptPath); err == nil {
 				AddRuntimeFile(RTPlugin, realFile(scriptPath))


### PR DESCRIPTION
This is just a proposal, but I think it would be useful if micro loads plugins that actually are symlinks to some other paths, especially when developing plugins.
Currently, for example, when `$HOME/.config/plugins/fooplugin/` exists but it is a symlink to `$HOME/fooplugin-micro`, micro won't try to load `$HOME/fooplugin-micro/fooplugin.lua`.

Also, I'm not so familiar with golang, so please point out if there is a better way to do this!