### PR TITLE
Update tex.micro and vhdl.micro

### DIFF
--- a/runtime/syntax/README.md
+++ b/runtime/syntax/README.md
@@ -32,6 +32,7 @@ Here is a list of the files that have been converted to properly use colorscheme
 * ruby
 * sh
 * git
+* tex
 
 # License
 

--- a/runtime/syntax/tex.micro
+++ b/runtime/syntax/tex.micro
@@ -1,8 +1,21 @@
-## Here is a short example for TeX files.
-##
+## TeX
 syntax "tex" "\.tex$" "bib" "\.bib$" "cls" "\.cls$"
-color yellow "\$[^$]*\$"
-green (i) "\\.|\\[A-Z]*"
-color magenta "[{}]"
-color blue "%.*"
-color blue start="\\begin\{comment\}" end="\\end\{comment\}"
+
+## colorize the identifiers of {<identifier>} and [<identifier>]
+color identifier start="\{" end="\}"
+color identifier start="\[" end="\]"
+
+## numbers
+color constant.number "\b[0-9]+(\.[0-9]+)?([[:space:]](pt|mm|cm|in|ex|em|bp|pc|dd|cc|nd|nc|sp))?\b"
+
+## let brackets have the default color again
+color default "[{}\[\]]"
+
+color special "[&\\]"
+
+## macros
+color statement "\\@?[a-zA-Z_]+"
+
+## commments
+color comment "%.*"
+color comment start="\\begin\{comment\}" end="\\end\{comment\}"

--- a/runtime/syntax/vhdl.micro
+++ b/runtime/syntax/vhdl.micro
@@ -5,12 +5,12 @@ syntax "vhdl" "\.vhdl?$"
 color type (i) "\b(string|integer|natural|positive|(un)?signed|std_u?logic(_vector)?|bit(_vector)?|boolean|u?x01z?|array|range)\b"
 
 ## identifiers (component-, library-names etc.)
-color identifier (i) "library[ 	]+[a-zA-Z_0-9]+"
-color identifier (i) "use[ 	]+[a-zA-Z_0-9\.]+"
-color identifier (i) "component[ 	]+[a-zA-Z_0-9]+"
-color identifier (i) "(architecture|configuration)[ 	]+[a-zA-Z_0-9]+[ 	]+of[ 	]+[a-zA-Z_0-9]+"
-color identifier (i) "(entity|package)[ 	]+[a-zA-Z_0-9]+[ 	]+is"
-color identifier (i) "end[ 	]+((architecture|entity|component|process|package|generate)[ 	]+)?[a-zA-Z_0-9]+"
+color identifier (i) "library[[:space:]]+[a-zA-Z_0-9]+"
+color identifier (i) "use[[:space:]]+[a-zA-Z_0-9\.]+"
+color identifier (i) "component[[:space:]]+[a-zA-Z_0-9]+"
+color identifier (i) "(architecture|configuration)[[:space:]]+[a-zA-Z_0-9]+[[:space:]]+of[[:space:]]+[a-zA-Z_0-9]+"
+color identifier (i) "(entity|package)[[:space:]]+[a-zA-Z_0-9]+[[:space:]]+is"
+color identifier (i) "end[[:space:]]+((architecture|entity|component|process|package|generate)[[:space:]]+)?[a-zA-Z_0-9]+"
 
 ## reserved words
 color statement (i) "\b(abs|access|after|alias|all|and|architecture|assert|attribute)\b"


### PR DESCRIPTION
* convert tex.micro to use micro's colorscheme feature
* replace space and tab characters in vhdl.micro with [:space:]

I've also tried to update the runtime with `make runtime`, but with that I get many many changes in cmd/micro/runtime.go (see [buildruntime.diff.txt](https://github.com/zyedidia/micro/files/625667/buildruntime.diff.txt)). Therefore I have not committed the changes in *runtime.go*
