### PR TITLE
Log erroneous keybindings

### DIFF
--- a/cmd/micro/bindings.go
+++ b/cmd/micro/bindings.go
@@ -340,6 +340,7 @@ func findAction(v string) (action func(*View, bool) bool) {
 func BindKey(k, v string) {
 	key, ok := findKey(k)
 	if !ok {
+		TermMessage("Unknown keybinding: " + k)
 		return
 	}
 	if v == "ToggleHelp" {
@@ -381,7 +382,6 @@ func DefaultBindings() map[string]string {
 		"CtrlShiftUp":    "SelectToStart",
 		"CtrlShiftDown":  "SelectToEnd",
 		"Enter":          "InsertNewline",
-		"Space":          "InsertSpace",
 		"CtrlH":          "Backspace",
 		"Backspace":      "Backspace",
 		"Alt-CtrlH":      "DeleteWordLeft",


### PR DESCRIPTION
Makes it easier to spot errors in custom keybindings.

The `"Space":          "InsertSpace",`-rule doesn't seem to work anymore?