### PR TITLE
Enable human-friendly plugin name

### DIFF
--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -13,7 +13,7 @@ import (
 // PreActionCall executes the lua pre callback if possible
 func PreActionCall(funcName string, view *View) bool {
 	executeAction := true
-	for _, pl := range loadedPlugins {
+	for pl := range loadedPlugins {
 		ret, err := Call(pl+".pre"+funcName, view)
 		if err != nil && !strings.HasPrefix(err.Error(), "function does not exist") {
 			TermMessage(err)
@@ -29,7 +29,7 @@ func PreActionCall(funcName string, view *View) bool {
 // PostActionCall executes the lua plugin callback if possible
 func PostActionCall(funcName string, view *View) bool {
 	relocate := true
-	for _, pl := range loadedPlugins {
+	for pl := range loadedPlugins {
 		ret, err := Call(pl+".on"+funcName, view)
 		if err != nil && !strings.HasPrefix(err.Error(), "function does not exist") {
 			TermMessage(err)
@@ -1651,7 +1651,7 @@ func (v *View) PlayMacro(usePlugin bool) bool {
 			v.Buf.Insert(v.Cursor.Loc, string(t))
 			v.Cursor.Right()
 
-			for _, pl := range loadedPlugins {
+			for pl := range loadedPlugins {
 				_, err := Call(pl+".onRune", string(t), v)
 				if err != nil && !strings.HasPrefix(err.Error(), "function does not exist") {
 					TermMessage(err)

--- a/cmd/micro/command.go
+++ b/cmd/micro/command.go
@@ -133,12 +133,10 @@ func PluginCmd(args []string) {
 			removed := ""
 			for _, plugin := range args[1:] {
 				// check if the plugin exists.
-				for _, lp := range loadedPlugins {
-					if lp == plugin {
-						UninstallPlugin(plugin)
-						removed += plugin + " "
-						continue
-					}
+				if _, ok := loadedPlugins[plugin]; ok {
+					UninstallPlugin(plugin)
+					removed += plugin + " "
+					continue
 				}
 			}
 			if !IsSpaces(removed) {

--- a/cmd/micro/eventhandler.go
+++ b/cmd/micro/eventhandler.go
@@ -117,7 +117,7 @@ func (eh *EventHandler) Execute(t *TextEvent) {
 	}
 	eh.UndoStack.Push(t)
 
-	for _, pl := range loadedPlugins {
+	for pl := range loadedPlugins {
 		ret, err := Call(pl+".onBeforeTextEvent", t)
 		if err != nil && !strings.HasPrefix(err.Error(), "function does not exist") {
 			TermMessage(err)

--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -385,7 +385,7 @@ func main() {
 		for _, v := range t.views {
 			v.Buf.FindFileType()
 			v.Buf.UpdateRules()
-			for _, pl := range loadedPlugins {
+			for pl := range loadedPlugins {
 				_, err := Call(pl+".onViewOpen", v)
 				if err != nil && !strings.HasPrefix(err.Error(), "function does not exist") {
 					TermMessage(err)

--- a/cmd/micro/plugin.go
+++ b/cmd/micro/plugin.go
@@ -10,7 +10,7 @@ import (
 	"github.com/yuin/gopher-lua"
 )
 
-var loadedPlugins []string
+var loadedPlugins map[string]string
 
 // Call calls the lua function 'function'
 // If it does not exist nothing happens, if there is an error,
@@ -112,32 +112,39 @@ func LuaFunctionJob(function string) func(string, ...string) {
 	}
 }
 
+// luaPluginName convert a human-friendly plugin name into a valid lua variable name.
+func luaPluginName(name string) string {
+	return strings.Replace(name, "-", "_", -1)
+}
+
 // LoadPlugins loads the pre-installed plugins and the plugins located in ~/.config/micro/plugins
 func LoadPlugins() {
+
+	loadedPlugins = make(map[string]string)
+
 	for _, plugin := range ListRuntimeFiles(RTPlugin) {
-		alreadyExists := false
+
 		pluginName := plugin.Name()
-		for _, pl := range loadedPlugins {
-			if pl == pluginName {
-				alreadyExists = true
-				break
-			}
+		if _, ok := loadedPlugins[pluginName]; ok {
+			continue
 		}
 
-		if !alreadyExists {
-			data, err := plugin.Data()
-			if err != nil {
-				TermMessage("Error loading plugin: " + pluginName)
-				continue
-			}
-			pluginDef := "\nlocal P = {}\n" + pluginName + " = P\nsetmetatable(" + pluginName + ", {__index = _G})\nsetfenv(1, P)\n"
-
-			if err := L.DoString(pluginDef + string(data)); err != nil {
-				TermMessage(err)
-				continue
-			}
-			loadedPlugins = append(loadedPlugins, pluginName)
+		data, err := plugin.Data()
+		if err != nil {
+			TermMessage("Error loading plugin: " + pluginName)
+			continue
 		}
+
+		pluginLuaName := luaPluginName(pluginName)
+		pluginDef := "\nlocal P = {}\n" + pluginLuaName + " = P\nsetmetatable(" + pluginLuaName + ", {__index = _G})\nsetfenv(1, P)\n"
+
+		if err := L.DoString(pluginDef + string(data)); err != nil {
+			TermMessage(err)
+			continue
+		}
+
+		loadedPlugins[pluginName] = pluginLuaName
+
 	}
 
 	if _, err := os.Stat(configDir + "/init.lua"); err == nil {
@@ -146,6 +153,6 @@ func LoadPlugins() {
 		if err := L.DoString(pluginDef + string(data)); err != nil {
 			TermMessage(err)
 		}
-		loadedPlugins = append(loadedPlugins, "init")
+		loadedPlugins["init"] = "init"
 	}
 }

--- a/cmd/micro/pluginmanager.go
+++ b/cmd/micro/pluginmanager.go
@@ -358,8 +358,8 @@ func GetInstalledVersions(withCore bool) PluginVersions {
 		result = append(result, newStaticPluginVersion(CorePluginName, Version))
 	}
 
-	for _, name := range loadedPlugins {
-		version := GetInstalledPluginVersion(name)
+	for name, lpname := range loadedPlugins {
+		version := GetInstalledPluginVersion(lpname)
 		if pv := newStaticPluginVersion(name, version); pv != nil {
 			result = append(result, pv)
 		}
@@ -561,7 +561,9 @@ func (pv PluginVersions) install() {
 func UninstallPlugin(name string) {
 	if err := os.RemoveAll(filepath.Join(configDir, "plugins", name)); err != nil {
 		messenger.Error(err)
+		return
 	}
+	delete(loadedPlugins, name)
 }
 
 // Install installs the plugin
@@ -582,7 +584,9 @@ func (pl PluginPackage) Install() {
 func UpdatePlugins(plugins []string) {
 	// if no plugins are specified, update all installed plugins.
 	if len(plugins) == 0 {
-		plugins = loadedPlugins
+		for name := range loadedPlugins {
+			plugins = append(plugins, name)
+		}
 	}
 
 	messenger.AddLog("Checking for plugin updates")

--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -120,7 +120,7 @@ func NewViewWidthHeight(buf *Buffer, w, h int) *View {
 		v.Height--
 	}
 
-	for _, pl := range loadedPlugins {
+	for pl := range loadedPlugins {
 		_, err := Call(pl+".onViewOpen", v)
 		if err != nil && !strings.HasPrefix(err.Error(), "function does not exist") {
 			TermMessage(err)
@@ -487,7 +487,7 @@ func (v *View) HandleEvent(event tcell.Event) {
 			v.Buf.Insert(v.Cursor.Loc, string(e.Rune()))
 			v.Cursor.Right()
 
-			for _, pl := range loadedPlugins {
+			for pl := range loadedPlugins {
 				_, err := Call(pl+".onRune", string(e.Rune()), v)
 				if err != nil && !strings.HasPrefix(err.Error(), "function does not exist") {
 					TermMessage(err)


### PR DESCRIPTION
This pull request allow developers to create human-friendly plugin name with the lua runtime.

**Example:**

If I want to create a plugin named `gotham-colors`, due to the specification of  the lua runtime, micro cannot create a variable with the name `gotham-colors` because an error is raised with the following message: 

```
<string> line:3(column:7) near '-':   parse error
```

In order to resolve this issue, I had to change the type of loadedPlugins to a map which contains the human-friendly name as key and the lua variable name as value.

Also, as a side effect, we improve the complexity of searching if a plugin is loaded in micro.
