### PR TITLE
Move to new tab when created

### DIFF
--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -1472,7 +1472,7 @@ func (v *View) AddTab(usePlugin bool) bool {
 	tab := NewTabFromView(NewView(NewBuffer(strings.NewReader(""), "")))
 	tab.SetNum(len(tabs))
 	tabs = append(tabs, tab)
-	curTab++
+	curTab = len(tabs) - 1
 	if len(tabs) == 2 {
 		for _, t := range tabs {
 			for _, v := range t.views {

--- a/cmd/micro/command.go
+++ b/cmd/micro/command.go
@@ -333,7 +333,7 @@ func NewTab(args []string) {
 		tab := NewTabFromView(NewView(NewBuffer(file, filename)))
 		tab.SetNum(len(tabs))
 		tabs = append(tabs, tab)
-		curTab++
+		curTab = len(tabs) - 1
 		if len(tabs) == 2 {
 			for _, t := range tabs {
 				for _, v := range t.views {


### PR DESCRIPTION
This PR fixes a behavior that changed the current tab to the next tab rather than the new tab when one is created. Previously, the wrong tab would be shown when creating a new one from any tab that was not the last.