### PR TITLE
Fix: mouse clicking with softwrap

### DIFF
--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -418,9 +418,6 @@ func (v *View) MoveToMouseClick(x, y int) {
 		v.ScrollDown(1)
 		y = v.Height + v.Topline - 1
 	}
-	if y >= v.Buf.NumLines {
-		y = v.Buf.NumLines - 1
-	}
 	if y < 0 {
 		y = 0
 	}


### PR DESCRIPTION
When clicking on a long line with softwrap turned on, the cursor will show up in the wrong location (`screenY` will be wrong in `GetSoftWrapLocation`). This seems to fix it.