### PR TITLE
preventing messages from over-writing the current prompt text

### DIFF
--- a/cmd/micro/messenger.go
+++ b/cmd/micro/messenger.go
@@ -87,7 +87,7 @@ func (m *Messenger) getBuffer() *Buffer {
 
 // Message sends a message to the user
 func (m *Messenger) Message(msg ...interface{}) {
-	displayMessage = fmt.Sprint(msg...)
+	displayMessage := fmt.Sprint(msg...)
 	// only display a new message if there isn't an active prompt
 	// this is to prevent overwriting an existing prompt to the user
 	if m.hasPrompt == false {

--- a/cmd/micro/messenger.go
+++ b/cmd/micro/messenger.go
@@ -87,30 +87,46 @@ func (m *Messenger) getBuffer() *Buffer {
 
 // Message sends a message to the user
 func (m *Messenger) Message(msg ...interface{}) {
-	m.message = fmt.Sprint(msg...)
-	m.style = defStyle
+	displayMessage = fmt.Sprint(msg...)
+	// only display a new message if there isn't an active prompt
+	// this is to prevent overwriting an existing prompt to the user
+	if m.hasPrompt == false {
+		// if there is no active prompt then style and display the message as normal
+		m.message = displayMessage
 
-	if _, ok := colorscheme["message"]; ok {
-		m.style = colorscheme["message"]
+		m.style = defStyle
+
+		if _, ok := colorscheme["message"]; ok {
+			m.style = colorscheme["message"]
+		}
+
+		m.hasMessage = true
 	}
-	m.AddLog(m.message)
-	m.hasMessage = true
+	// add the message to the log regardless of active prompts
+	m.AddLog(displayMessage)
 }
 
 // Error sends an error message to the user
 func (m *Messenger) Error(msg ...interface{}) {
 	buf := new(bytes.Buffer)
 	fmt.Fprint(buf, msg...)
-	m.message = buf.String()
-	m.style = defStyle.
-		Foreground(tcell.ColorBlack).
-		Background(tcell.ColorMaroon)
 
-	if _, ok := colorscheme["error-message"]; ok {
-		m.style = colorscheme["error-message"]
+	// only display a new message if there isn't an active prompt
+	// this is to prevent overwriting an existing prompt to the user
+	if m.hasPrompt == false {
+		// if there is no active prompt then style and display the message as normal
+		m.message = buf.String()
+		m.style = defStyle.
+			Foreground(tcell.ColorBlack).
+			Background(tcell.ColorMaroon)
+		
+		if _, ok := colorscheme["error-message"]; ok {
+			m.style = colorscheme["error-message"]
+		}
+		m.hasMessage = true
 	}
-	m.AddLog(m.message)
-	m.hasMessage = true
+	// add the message to the log regardless of active prompts
+	m.AddLog(buf.String())
 }
 
 // YesNoPrompt asks the user a yes or no question (waits for y or n) and returns the result

--- a/cmd/micro/search.go
+++ b/cmd/micro/search.go
@@ -27,8 +27,8 @@ func BeginSearch(searchStr string) {
 	searching = true
 	messenger.response = searchStr
 	messenger.cursorx = Count(searchStr)
-	messenger.hasPrompt = true
 	messenger.Message("Find: ")
+	messenger.hasPrompt = true
 }
 
 // EndSearch stops the current search


### PR DESCRIPTION
This is a small change (and my first foray into Go) that prevents new messages and errors that get sent to be displayed from over-writing an active prompt. I was noticing an issue where if the `Find: ` prompt was left open that it would get occasionally overwritten by the "Saved ..." message. This stops that from happening while still logging the events into micro's log buffer. 