### PR TITLE
Adding embedded Info.plist to OS X builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,30 +3,31 @@
 VERSION = $(shell go run tools/build-version.go)
 HASH = $(shell git rev-parse --short HEAD)
 DATE = $(shell go run tools/build-date.go)
+ADDITIONAL_GO_LINKER_FLAGS = $(shell go run tools/info-plist.go "$(VERSION)")
 
 GOBIN ?= $(GOPATH)/bin
 
 # Builds micro after checking dependencies but without updating the runtime
 build: deps
-	go build -ldflags "-s -w -X main.Version=$(VERSION) -X main.CommitHash=$(HASH) -X 'main.CompileDate=$(DATE)'" ./cmd/micro
+	go build -ldflags "-s -w -X main.Version=$(VERSION) -X main.CommitHash=$(HASH) -X 'main.CompileDate=$(DATE)' $(ADDITIONAL_GO_LINKER_FLAGS)" ./cmd/micro
 
 # Builds micro after building the runtime and checking dependencies
 build-all: runtime build
 
 # Builds micro without checking for dependencies
 build-quick:
-	go build -ldflags "-s -w -X main.Version=$(VERSION) -X main.CommitHash=$(HASH) -X 'main.CompileDate=$(DATE)'" ./cmd/micro
+	go build -ldflags "-s -w -X main.Version=$(VERSION) -X main.CommitHash=$(HASH) -X 'main.CompileDate=$(DATE)' $(ADDITIONAL_GO_LINKER_FLAGS)" ./cmd/micro
 
 # Same as 'build' but installs to $GOBIN afterward
 install: deps
-	go install -ldflags "-s -w -X main.Version=$(VERSION) -X main.CommitHash=$(HASH) -X 'main.CompileDate=$(DATE)'" ./cmd/micro
+	go install -ldflags "-s -w -X main.Version=$(VERSION) -X main.CommitHash=$(HASH) -X 'main.CompileDate=$(DATE)' $(ADDITIONAL_GO_LINKER_FLAGS)" ./cmd/micro
 
 # Same as 'build-all' but installs to $GOBIN afterward
 install-all: runtime install
 
 # Same as 'build-quick' but installs to $GOBIN afterward
 install-quick:
-	go install -ldflags "-s -w -X main.Version=$(VERSION) -X main.CommitHash=$(HASH) -X 'main.CompileDate=$(DATE)'" ./cmd/micro
+	go install -ldflags "-s -w -X main.Version=$(VERSION) -X main.CommitHash=$(HASH) -X 'main.CompileDate=$(DATE)' $(ADDITIONAL_GO_LINKER_FLAGS)"  ./cmd/micro
 
 # Checks for dependencies
 deps:

--- a/tools/cross-compile.sh
+++ b/tools/cross-compile.sh
@@ -15,10 +15,11 @@ cp README.md micro-$1
 HASH="$(git rev-parse --short HEAD)"
 VERSION="$(go run tools/build-version.go)"
 DATE="$(go run tools/build-date.go)"
+ADDITIONAL_GO_LINKER_FLAGS="$(go run tools/info-plist.go $VERSION)"
 
 # Mac
 echo "OSX 64"
-GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w -X main.Version=$1 -X main.CommitHash=$HASH -X 'main.CompileDate=$DATE'" -o micro-$1/micro ./cmd/micro
+GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w -X main.Version=$1 -X main.CommitHash=$HASH -X 'main.CompileDate=$DATE' $ADDITIONAL_GO_LINKER_FLAGS" -o micro-$1/micro ./cmd/micro
 tar -czf micro-$1-osx.tar.gz micro-$1
 mv micro-$1-osx.tar.gz binaries
 

--- a/tools/info-plist.go
+++ b/tools/info-plist.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+    "os"
+    "fmt"
+    "runtime"
+    "io/ioutil"
+)
+
+func check(e error) {
+    if e != nil {
+        panic(e)
+    }
+}
+
+func main() {
+    if runtime.GOOS == "darwin" {
+        if len(os.Args) == 2 {
+            raw_info_plist_string := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleIdentifier</key>
+    <string>io.github.micro-editor</string>
+    <key>CFBundleName</key>
+    <string>micro</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>` + os.Args[1] + `</string>
+</dict>
+</plist>
+`
+            info_plist_data := []byte(raw_info_plist_string)
+            
+            err := ioutil.WriteFile("/tmp/micro-info.plist", info_plist_data, 0644)
+            check(err)
+            fmt.Println("-linkmode external -extldflags -Wl,-sectcreate,__TEXT,__info_plist,/tmp/micro-info.plist")
+        } else {
+            panic("missing argument for version number!")
+        }
+    }
+}


### PR DESCRIPTION
This adds a metadata file to the binary as part of the build for OS X. This gives the binary a way to be identified by the system (using an info.plist). I followed the pattern of using a golang file as part of the `tools/` directory to generate that file and the appropriate flags that need to be provided to the go linker for this to be properly added.

If you would prefer some of this be changed or re-organized in any way, i'd be happy to make any changes.