### PR TITLE
Key unbinding

### DIFF
--- a/cmd/micro/bindings.go
+++ b/cmd/micro/bindings.go
@@ -346,14 +346,21 @@ func BindKey(k, v string) {
 	if v == "ToggleHelp" {
 		helpBinding = k
 	}
-
-	actionNames := strings.Split(v, ",")
-	actions := make([]func(*View, bool) bool, 0, len(actionNames))
-	for _, actionName := range actionNames {
-		actions = append(actions, findAction(actionName))
+	if helpBinding == k && v != "ToggleHelp" {
+		helpBinding = ""
 	}
+	
+	if v == "UnbindKey" {
+		delete(bindings, key)
+	} else {
+		actionNames := strings.Split(v, ",")
+		actions := make([]func(*View, bool) bool, 0, len(actionNames))
+		for _, actionName := range actionNames {
+			actions = append(actions, findAction(actionName))
+		}
 
-	bindings[key] = actions
+		bindings[key] = actions
+	}
 }
 
 // DefaultBindings returns a map containing micro's default keybindings

--- a/cmd/micro/bindings.go
+++ b/cmd/micro/bindings.go
@@ -350,17 +350,21 @@ func BindKey(k, v string) {
 		helpBinding = ""
 	}
 	
-	if v == "UnbindKey" {
+	actionNames := strings.Split(v, ",")
+	if actionNames[0] == "UnbindKey" {
 		delete(bindings, key)
-	} else {
-		actionNames := strings.Split(v, ",")
-		actions := make([]func(*View, bool) bool, 0, len(actionNames))
-		for _, actionName := range actionNames {
-			actions = append(actions, findAction(actionName))
+		if len(actionNames) == 1 {
+			actionNames = make([]string, 0, 0)
+		} else {
+			actionNames = append(actionNames[:0], actionNames[1:]...)
 		}
-
-		bindings[key] = actions
 	}
+	actions := make([]func(*View, bool) bool, 0, len(actionNames))
+	for _, actionName := range actionNames {
+		actions = append(actions, findAction(actionName))
+	}
+
+	bindings[key] = actions
 }
 
 // DefaultBindings returns a map containing micro's default keybindings

--- a/cmd/micro/statusline.go
+++ b/cmd/micro/statusline.go
@@ -36,9 +36,12 @@ func (sline *Statusline) Display() {
 	// Add the filetype
 	file += " " + sline.view.Buf.FileType()
 
-	rightText := helpBinding + " for help "
-	if sline.view.Type == vtHelp {
-		rightText = helpBinding + " to close help "
+	rightText := ""
+	if len(helpBinding) > 0 {
+		rightText = helpBinding + " for help "
+		if sline.view.Type == vtHelp {
+			rightText = helpBinding + " to close help "
+		}
 	}
 
 	statusLineStyle := defStyle.Reverse(true)

--- a/runtime/help/keybindings.md
+++ b/runtime/help/keybindings.md
@@ -115,6 +115,11 @@ and quit you can bind it like so:
 }
 ```
 
+# Unbinding keys
+
+It is also possible to disable any of the default key bindings by use of the 
+`UnbindKey` action in the user's `bindings.json` file.
+
 # Bindable actions and bindable keys
 
 The list of default keybindings contains most of the possible actions and keys
@@ -196,6 +201,7 @@ HSplit
 PreviousSplit
 ToggleMacro
 PlayMacro
+UnbindKey
 ```
 
 Here is the list of all possible keys you can bind:


### PR DESCRIPTION
* adds new special-case keybinding to remove an existing default key binding.
* hides the show/close help text in the status line when no key is assigned to "ToggleHelp"
* updating documentation to reflect new features


Note: Unbinding can be chained just like other existing commands, but it must come first in the chain.