### PR TITLE
fixing bug in closing tabs and not being able to select tabs

### DIFF
--- a/cmd/micro/tab.go
+++ b/cmd/micro/tab.go
@@ -245,6 +245,8 @@ func DisplayTabs() {
 		// use the constructed buffer as the display buffer to print
 		// onscreen.
 		fileRunes = displayText
+	} else {
+		tabBarOffset = 0
 	}
 
 	// iterate over the width of the terminal display and for each column,


### PR DESCRIPTION
seems that I introduced a bug with my changes to add tab scrolling, where if you opened enough tabs to go off-screen then closed enough to fit back on a single screen you couldn't use the mouse to click on tabs anymore. this change correctly resets the "X" offset of the tabs back to zero in the case that the tabs will all fit on the existing screen-space.