### PR TITLE
Replaced tmp directory with file directory

### DIFF
--- a/runtime/plugins/linter/linter.lua
+++ b/runtime/plugins/linter/linter.lua
@@ -12,15 +12,15 @@ end
 function runLinter()
     local ft = CurView().Buf:FileType()
     local file = CurView().Buf.Path
-    local devnull = "/dev/null"
-    local temp = os.getenv("TMPDIR")
+    local dir = DirectoryName(file)
     if OS == "windows" then
         devnull = "NUL"
-        temp = os.getenv("TEMP")
+    else
+    	devnull = "/dev/null"
     end
     if ft == "go" then
         lint("gobuild", "go", {"build", "-o", devnull}, "%f:%l: %m")
-        lint("golint", "golint", {CurView().Buf.Path}, "%f:%l:%d+: %m")
+        lint("golint", "golint", {file}, "%f:%l:%d+: %m")
     elseif ft == "lua" then
         lint("luacheck", "luacheck", {"--no-color", file}, "%f:%l:%d+: %m")
     elseif ft == "python" then
@@ -38,7 +38,7 @@ function runLinter()
     elseif ft == "d" then
         lint("dmd", "dmd", {"-color=off", "-o-", "-w", "-wi", "-c", file}, "%f%(%l%):.+: %m")
     elseif ft == "java" then
-        lint("javac", "javac", {"-d", temp, file}, "%f:%l: error: %m")
+        lint("javac", "javac", {"-d", dir, file}, "%f:%l: error: %m")
     elseif ft == "javascript" then
         lint("jshint", "jshint", {file}, "%f: line %l,.+, %m")
     elseif ft == "nim" then


### PR DESCRIPTION
This fixes the issue where linting Java files would fail on most Linux systems. This is an update of #541 
I also replaced `CurView().Buf.Path` with the local `file` variable in the Go lint function, for consistency.