### PR TITLE
Added title setting (Requires tcell pull!) and optimized tab display.

### DIFF
--- a/cmd/micro/tab.go
+++ b/cmd/micro/tab.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"sort"
+	"path/filepath"
 
 	"github.com/zyedidia/tcell"
 )
@@ -89,7 +90,9 @@ func TabbarString() (string, map[int]int) {
 		} else {
 			str += " "
 		}
-		str += t.views[t.CurView].Buf.GetName()
+		//To address issue 556.2
+		_, name := filepath.Split(t.views[t.CurView].Buf.GetName())
+		str += name
 		if i == curTab {
 			str += "]"
 		} else {

--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -976,14 +976,14 @@ func (v *View) DisplayCursor(x, y int) {
 
 // Display renders the view, the cursor, and statusline
 func (v *View) Display() {
+	//Set title to the name of the current buffer
+	screen.SetTitle("micro: " + v.Buf.GetName())
 	v.DisplayView()
 	// Don't draw the cursor if it is out of the viewport or if it has a selection
 	if (v.Cursor.Y-v.Topline < 0 || v.Cursor.Y-v.Topline > v.Height-1) || v.Cursor.HasSelection() {
 		screen.HideCursor()
 	}
 	_, screenH := screen.Size()
-	//Set title to the name of the current buffer
-	screen.SetTitle("micro: " + t.views[t.CurView].Buf.GetName())
 	if v.Buf.Settings["statusline"].(bool) {
 		v.sline.Display()
 	} else if (v.y + v.Height) != screenH-1 {

--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -983,7 +983,7 @@ func (v *View) Display() {
 	}
 	_, screenH := screen.Size()
 	//Set title to the name of the current buffer
-	tcell.SetTitle("micro: " + t.views[t.CurView].Buf.GetName())
+	screen.SetTitle("micro: " + t.views[t.CurView].Buf.GetName())
 	if v.Buf.Settings["statusline"].(bool) {
 		v.sline.Display()
 	} else if (v.y + v.Height) != screenH-1 {

--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -982,6 +982,8 @@ func (v *View) Display() {
 		screen.HideCursor()
 	}
 	_, screenH := screen.Size()
+	//Set title to the name of the current buffer
+	tcell.SetTitle("micro: " + t.views[t.CurView].Buf.GetName())
 	if v.Buf.Settings["statusline"].(bool) {
 		v.sline.Display()
 	} else if (v.y + v.Height) != screenH-1 {


### PR DESCRIPTION
Micro should now set the title to the "micro: _name of current buffer_" every time the display is updated and also should make better use of the tab bar as per issue #557 . I didn't address everything I mentioned in that issue for various reasons, but this part seemed to be the best received so I went ahead and tried for an implementation of it. This will require you to pull this request: https://github.com/zyedidia/tcell/pull/6 into tcell to get the title set function.