### PR TITLE
Fix merge conflict / syntax of colors.md

### DIFF
--- a/runtime/help/colors.md
+++ b/runtime/help/colors.md
@@ -5,7 +5,7 @@ This help page aims to cover two aspects of micro's syntax highlighting engine:
 - How to create colorschemes and use them
 - How to create syntax files to add to the list of languages micro can highlight
 
-### Colorschemes
+## Colorschemes
 
 Micro comes with a number of colorschemes by default. Here is the list:
 
@@ -191,13 +191,10 @@ Here's a list of subgroups used in micro's built-in syntax files.
 
 In the future, plugins may also be able to use color groups for styling.
 
-### Syntax files
+## Syntax files
 
-The syntax files specify how to highlight certain languages.
+The syntax files is written in yaml-format and specify how to highlight languages.
 
-<<<<<<< HEAD
-Syntax files are specified in the yaml format.
-=======
 Micro's builtin syntax highlighting tries very hard to be sane, sensible
 and provide ample coverage of the meaningful elements of a language. Micro has
 syntax files built int for over 100 languages now. However, there may be 
@@ -205,11 +202,7 @@ situations where you find Micro's highlighting to be insufficient or not to
 your liking. Good news is you can create syntax files (.micro extension), place them in 
 `~/.config/micro/syntax` and Micro will use those instead.
 
-The first statement in a syntax file will probably the syntax statement. This tells micro
-what language the syntax file is for and how to detect a file in that language.
->>>>>>> master
-
-#### Filetype defintion
+### Filetype defintion
 
 You must start the syntax file by declaring the filetype:
 
@@ -219,7 +212,7 @@ filetype: go
 
 #### Detect definition
 
-Then you can provide information about how to detect the filetype:
+Then you must provide information about how to detect the filetype:
 
 ```
 detect:
@@ -227,7 +220,7 @@ detect:
 ```
 
 Micro will match this regex against a given filename to detect the filetype. You may also
-provide an optional `header` regex that will check the first line of the file. For example for yaml:
+provide an optional `header` regex that will check the first line of the file. For example:
 
 ```
 detect:
@@ -299,7 +292,3 @@ for html:
     rules:
         - include: "css"
 ```
-
-Note: The format of syntax files will be changing with the view refactor.
-If this help file still retains this note but the syntax files are yaml
-please open an issue.


### PR DESCRIPTION
I've changed "can provide" to "must provide" for detection of filetypes (i.e. `detect:`) as micro crashes if omitted.