### PR TITLE
Adding Danger to provide linting for the yaml files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,4 @@
 language: go
+rvm:
+  - 2.2
 script: make ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: go
-script: make test
+script: make ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: go
-rvm:
-  - 2.2
+before_install:
+  - rvm install 2.2
 script: make ci

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+
+rules:
+  line-length: disable
+  document-start: disable

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,3 @@
+
+yaml.lint_yaml_files("runtime/syntax/*")
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem "danger"
+gem "danger-plugin-yaml", :git => "https://github.com/samdmarshall/danger-plugin-yaml"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,60 @@
+GIT
+  remote: https://github.com/samdmarshall/danger-plugin-yaml
+  revision: 4bb1193a1d908c034eca165589c01b61d269363b
+  specs:
+    danger-plugin-yaml (0.1.0)
+      danger
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    claide (1.0.1)
+    claide-plugins (0.9.2)
+      cork
+      nap
+      open4 (~> 1.3)
+    colored (1.2)
+    colored2 (3.1.2)
+    cork (0.2.0)
+      colored (~> 1.2)
+    danger (4.3.2)
+      claide (~> 1.0)
+      claide-plugins (>= 0.9.2)
+      colored2 (~> 3.1)
+      cork (~> 0.1)
+      faraday (~> 0.9)
+      faraday-http-cache (~> 1.0)
+      git (~> 1)
+      kramdown (~> 1.5)
+      octokit (~> 4.2)
+      terminal-table (~> 1)
+    faraday (0.11.0)
+      multipart-post (>= 1.2, < 3)
+    faraday-http-cache (1.3.1)
+      faraday (~> 0.8)
+    git (1.3.0)
+    kramdown (1.13.2)
+    multipart-post (2.0.0)
+    nap (1.1.0)
+    octokit (4.6.2)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    open4 (1.3.4)
+    public_suffix (2.0.5)
+    sawyer (0.8.1)
+      addressable (>= 2.3.5, < 2.6)
+      faraday (~> 0.8, < 1.0)
+    terminal-table (1.7.3)
+      unicode-display_width (~> 1.1.1)
+    unicode-display_width (1.1.3)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  danger
+  danger-plugin-yaml!
+
+BUNDLED WITH
+   1.14.6

--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,8 @@ test:
 
 clean:
 	rm -f micro
+
+ci: test
+	gem install bundler
+	bundle install
+	danger --verbose


### PR DESCRIPTION
Using a tool called [Danger](http://danger.systems) to provide some automatic linting and verification of the new syntax files. For this to run on CI and report back on the PR an access token should be provided to the CI configuration. You can create one to have it post back under your own account or create a new account just for danger to post back with (this is allowed under the GitHub ToS). You can also run danger locally before you submit a PR:

1. Install [bundler](http://bundler.io)
2. Install Danger + yamllint plugin (`bundle install`)
3. Run Danger (`danger local --verbose`)


This resolves #609 