### PR TITLE
Refactor lineCounter to use bufio scanner

### DIFF
--- a/cmd/micro/lineArray.go
+++ b/cmd/micro/lineArray.go
@@ -10,22 +10,12 @@ import (
 )
 
 func lineCounter(r io.Reader) (int, error) {
-	buf := make([]byte, 32*1024)
 	count := 0
-	lineSep := []byte{'\n'}
-
-	for {
-		c, err := r.Read(buf)
-		count += bytes.Count(buf[:c], lineSep)
-
-		switch {
-		case err == io.EOF:
-			return count, nil
-
-		case err != nil:
-			return count, err
-		}
+	s := bufio.NewScanner(r)
+	for s.Scan() {
+		count++
 	}
+	return count, s.Err()
 }
 
 func runeToByteIndex(n int, txt []byte) int {


### PR DESCRIPTION
Using Scanner simpiflies the code because:
    - The default token is a newline
    - Scanner.Err() does not return EOF error

This commit also will double the maxium buffer size.