### PR TITLE
Update micro to be classic confined snap

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -5,12 +5,11 @@ description: |
   Micro is a terminal-based text editor that aims to be easy to use and
   intuitive, while also taking advantage of the full capabilities of modern
   terminals.
-confinement: strict
+confinement: classic
 
 apps:
   micro:
     command: bin/micro
-    plugs: [home]
 
 parts:
   micro:


### PR DESCRIPTION
As a text editor, micro will need to be able to edit files outside the confined world snap gives it. So this PR changes the confinement model of micro from strict to classic, making it way more useful on snap enabled systems.

If accepted and when this lands, I'd recommend re-building the micro snap and pushing a release all the way through to the stable channel.

Note: Classic confined snaps require manual review, so there may be a short delay the first time, after submitting the snap.