### PR TITLE
Add micro snap install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ On Windows, you can install micro through Chocolatey:
 choco install micro
 ```
 
+On Linux, you can install micro through [snap](https://snapcraft.io/docs/core/install)
+
+```
+snap install micro --beta
+```
+
 ### Building from source
 
 If your operating system does not have a binary release, but does run Go, you can build from source.


### PR DESCRIPTION
Adds the simple command line install instructions for snap enabled systems, to complement the Windows and Mac command line instructions. 

Note: Once PR #638 lands and a new classic confined snap is in the stable channel, the "--beta" tag will need replacing with "--classic".