### PR TITLE
Caps lock issue#658

### DIFF
--- a/cmd/micro/messenger.go
+++ b/cmd/micro/messenger.go
@@ -172,6 +172,8 @@ func (m *Messenger) YesNoPrompt(prompt string) (bool, bool) {
 				}
 			case tcell.KeyCtrlC, tcell.KeyCtrlQ, tcell.KeyEscape:
 				m.AddLog("\t--> (cancel)")
+				m.Clear()
+				m.Reset()
 				m.hasPrompt = false
 				return false, true
 			}

--- a/cmd/micro/messenger.go
+++ b/cmd/micro/messenger.go
@@ -161,11 +161,11 @@ func (m *Messenger) YesNoPrompt(prompt string) (bool, bool) {
 		case *tcell.EventKey:
 			switch e.Key() {
 			case tcell.KeyRune:
-				if e.Rune() == 'y' {
+				if e.Rune() == 'y' || e.Rune() == 'Y' {
 					m.AddLog("\t--> y")
 					m.hasPrompt = false
 					return true, false
-				} else if e.Rune() == 'n' {
+				} else if e.Rune() == 'n' || e.Rune() == 'N' {
 					m.AddLog("\t--> n")
 					m.hasPrompt = false
 					return false, false

--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -199,18 +199,19 @@ func (v *View) ScrollDown(n int) {
 // causing them to lose the unsaved changes
 func (v *View) CanClose() bool {
 	if v.Type == vtDefault && v.Buf.IsModified {
-		var char rune
+		var choice bool
 		var canceled bool
 		if v.Buf.Settings["autosave"].(bool) {
-			char = 'y'
+			choice = true
 		} else {
-			char, canceled = messenger.LetterPrompt("Save changes to "+v.Buf.GetName()+" before closing? (y,n,esc) ", 'y', 'n', 'Y', 'N')
+			choice, canceled = messenger.YesNoPrompt("Save changes to " + v.Buf.GetName() + " before closing? (y,n,esc) ")
 		}
 		if !canceled {
-			if char == 'y' || char == 'Y' {
+			//if char == 'y' {
+			if choice {
 				v.Save(true)
 				return true
-			} else if char == 'n' || char == 'N' {
+			} else {
 				return true
 			}
 		}


### PR DESCRIPTION
I have changed the quit message to use the yesnoprompt instead of the letterprompt and changed the caps Y and N in that function so all yesnoprompt questions can be used with caps lock on.

I have looked at your commit for this issue but I think this would be better.
I have tested it and it has the same behavior as before.

If you do not like it then just reject this pull request.

If there is any issue you need help or testing  on linux then let me know and I will try my best to help.
