### PR TITLE
use space for indentchar if empty, fixes #660

### DIFF
--- a/cmd/micro/cellview.go
+++ b/cmd/micro/cellview.go
@@ -67,7 +67,12 @@ type CellView struct {
 func (c *CellView) Draw(buf *Buffer, top, height, left, width int) {
 	tabsize := int(buf.Settings["tabsize"].(float64))
 	softwrap := buf.Settings["softwrap"].(bool)
-	indentchar := []rune(buf.Settings["indentchar"].(string))[0]
+	indentrunes := []rune(buf.Settings["indentchar"].(string))
+	// if empty indentchar settings, use space
+	if indentrunes == nil || len(indentrunes) == 0 {
+		indentrunes = []rune(" ")
+	}
+	indentchar := indentrunes[0]
 
 	start := buf.Cursor.Y
 	if buf.Settings["syntax"].(bool) && buf.syntaxDef != nil {


### PR DESCRIPTION
Setting indentchar to `""` _should_ be a way to disable completely, though.