### PR TITLE
before saving check for view type and if scratch is true then do not save 

### DIFF
--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -757,8 +757,8 @@ func (v *View) Save(usePlugin bool) bool {
 		return false
 	}
 
-	if v.Type == vtHelp {
-		// We can't save the help text
+	if v.Type.scratch == true {
+		// We can't save any view type with scratch set. eg help and log text
 		return false
 	}
 	// If this is an empty buffer, ask for a filename


### PR DESCRIPTION
## Details
Viewtype is not checked when saving. (Veiw.go line 20-23. is the list of view types)
Help and Log view are set to not saving but you can save the log view.
## Changed
Changed the save to check the view type - scratch instead of just vthelp.
## Conclusion
This should be future proof if more viewtypes are added later with not saving option set.