### PR TITLE
Added kotlin highlighting and fixed swift line comment todo not highlighting

### DIFF
--- a/runtime/syntax/kotlin.yaml
+++ b/runtime/syntax/kotlin.yaml
@@ -1,0 +1,66 @@
+filetype: kotlin
+
+detect:
+    filename: "\\.kt$"
+
+rules:
+     
+    # Operators
+    - symbol.operator: ([.:;,+*|=!?\\%]|<|>|/|-|&)
+       
+    # Statements Keywords
+    - statement: \b(as|by|class|constructor|companion|fun|import|in|infix|interface|inline|is|out|operator|package|return|suspend|super|this|when|val|var)\b
+    - statement.properties: \b(get|set)\b
+    - statement.control: \b(break|continue|else|do|if|try|catch|finally|for|while)\b
+    - statement.class: \b(abstract|annotation|data|enum|final|open|sealed)\b
+    - statement.member: \b(override|lateinit|init)\b
+    - statement.access: \b(internal|private|protected|public)\b
+    - statement.parameter: \b(crossinline|noinline|reified|vararg)\b
+    
+    # Expression and types
+    - type: \b(dynamic|object|throw|typealias|typeof)\b 
+
+    # Meta
+    - statement.meta: \@(\bfile|delegate|field|get|property|receiver|set|setparam|param|)\b
+
+    # Constant
+    - constant: \b(true|false|null)
+    - constant.number: ([0-9]+)
+    
+    # Storage Types
+    - type.storage: \b(Byte|Char|Double|Float|Int|Long|Short|Boolean|Unit|Nothing)\b
+    
+    # Collections
+    - type.collections: \b(Array)\b
+
+     # String
+    - constant.string:
+        start: \"
+        end: \"
+        skip: \\.
+        rules:
+            - constant.specialChar: (\\0|\\\\|\\t|\\n|\\r|\\"|\\')
+            - constant.unicode: \\u\{[[:xdigit:]]+}
+
+    # Shebang Line
+    - comment.shebang: ^(#!).*
+    
+    # Line Comment
+    - comment.line: "//.*"
+    
+    # Block Comment
+    - comment.block:
+        start: "/\\*"
+        end: "\\*/"
+        rules:
+            - todo: "(TODO|XXX|FIXME):?"
+      
+    # Doc Block Comment
+    - comment.block:
+        start: "/\\*\\*"
+        end: "\\*/"
+        rules:
+            - todo: "(TODO|XXX|FIXME):?"
+
+    # Todo
+    - todo: "(TODO|XXX|FIXME):?"

--- a/runtime/syntax/swift.yaml
+++ b/runtime/syntax/swift.yaml
@@ -78,9 +78,6 @@ rules:
     # Shebang Line
     - comment.shebang: ^(#!).*
 
-    # Todo
-    - todo: "(TODO|XXX|FIXME):?"
-
     # Doc Comment
     - comment.doc: (///).*
     
@@ -100,3 +97,6 @@ rules:
         end: "\\*/"
         rules:
             - todo: "(TODO|XXX|FIXME):?"
+
+    # Todo
+    - todo: "(TODO|XXX|FIXME):?"


### PR DESCRIPTION
Added kotlin syntax highlighting.

Fixed swift line comment TODO not highlighting, by moving the check to the bottom of the file.