### PR TITLE
fixed a panic when a line is cut out(strg+k) and the next line is empty.

### DIFF
--- a/cmd/micro/cursor.go
+++ b/cmd/micro/cursor.go
@@ -1,6 +1,8 @@
 package main
 
-import "github.com/zyedidia/clipboard"
+import (
+	"github.com/zyedidia/clipboard"
+)
 
 // The Cursor struct stores the location of the cursor in the view
 // The complicated part about the cursor is storing its location.
@@ -340,6 +342,11 @@ func (c *Cursor) GetVisualX() int {
 	if c.X > len(runes) {
 		c.X = len(runes) - 1
 	}
+
+	if c.X < 0 {
+		c.X = 0
+	}
+
 	return StringWidth(string(runes[:c.X]), tabSize)
 }
 


### PR DESCRIPTION
Micro panics with:
```
Micro encountered an error: runtime error: slice bounds out of range
runtime.errorString runtime error: slice bounds out of range
/usr/local/go/src/runtime/panic.go:491 (0x42b8d3)
        gopanic: reflectcall(nil, unsafe.Pointer(d.fn), deferArgs(d), uint32(d.siz), uint32(d.siz))
/usr/local/go/src/runtime/panic.go:35 (0x42a61e)
        panicslice: panic(sliceError)
/home/rkaufmann/go/src/github.com/zyedidia/micro/cmd/micro/cursor.go:353 (0x88b02e)
        (*Cursor).GetVisualX: return StringWidth(string(runes[:c.X]), tabSize)
/home/rkaufmann/go/src/github.com/zyedidia/micro/cmd/micro/eventhandler.go:137 (0x88c020)
        (*EventHandler).Remove: c.LastVisualX = c.GetVisualX()
/home/rkaufmann/go/src/github.com/zyedidia/micro/cmd/micro/cursor.go:78 (0x888b76)
        (*Cursor).DeleteSelection: c.buf.Remove(c.CurSelection[0], c.CurSelection[1])
/home/rkaufmann/go/src/github.com/zyedidia/micro/cmd/micro/actions.go:1068 (0x870b44)
        (*View).CutLine: v.Cursor.DeleteSelection()
/home/rkaufmann/go/src/github.com/zyedidia/micro/cmd/micro/view.go:469 (0x8cbe0b)
        (*View).ExecuteActions: relocate = action(v, true) || relocate
/home/rkaufmann/go/src/github.com/zyedidia/micro/cmd/micro/view.go:511 (0x8cc579)
        (*View).HandleEvent: relocate = v.ExecuteActions(actions) || relocate
/home/rkaufmann/go/src/github.com/zyedidia/micro/cmd/micro/micro.go:487 (0x89786a)
        main: CurView().HandleEvent(event)
/usr/local/go/src/runtime/proc.go:185 (0x42d6dd)
        main: fn()
/usr/local/go/src/runtime/asm_amd64.s:2337 (0x45a811)
        goexit: BYTE    $0x90   // NOP
```
when i cut a line with ctrl+k and the next line is empty.

This small change should fix this.