### PR TITLE
multi-byte characters are overlapped in prompt message

### DIFF
--- a/cmd/micro/messenger.go
+++ b/cmd/micro/messenger.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/zyedidia/clipboard"
 	"github.com/zyedidia/tcell"
+	"github.com/mattn/go-runewidth"
 )
 
 // TermMessage sends a message to the user in the terminal. This usually occurs before
@@ -463,8 +464,10 @@ func (m *Messenger) Display() {
 	if m.hasMessage {
 		if m.hasPrompt || globalSettings["infobar"].(bool) {
 			runes := []rune(m.message + m.response)
+			posx = 0
 			for x := 0; x < len(runes); x++ {
-				screen.SetContent(x, h-1, runes[x], nil, m.style)
+				screen.SetContent(posx, h-1, runes[x], nil, m.style)
+				posx += runewidth.RuneWidth(runes[x])
 			}
 		}
 	}

--- a/cmd/micro/messenger.go
+++ b/cmd/micro/messenger.go
@@ -464,7 +464,7 @@ func (m *Messenger) Display() {
 	if m.hasMessage {
 		if m.hasPrompt || globalSettings["infobar"].(bool) {
 			runes := []rune(m.message + m.response)
-			posx = 0
+			posx := 0
 			for x := 0; x < len(runes); x++ {
 				screen.SetContent(posx, h-1, runes[x], nil, m.style)
 				posx += runewidth.RuneWidth(runes[x])


### PR DESCRIPTION
In Linux, there was a rendering problem with prompt message. Because multi-byte characters are overlapped. So I fixed it.

My environment is
* Ubuntu 17.04
* Golang 1.7
* Terminal: Gnome-Terminal and xterm