### PR TITLE
Display number of lines in the JumpLine prompt

### DIFF
--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -1479,7 +1480,8 @@ func (v *View) JumpLine(usePlugin bool) bool {
 	}
 
 	// Prompt for line number
-	linestring, canceled := messenger.Prompt("Jump to line # ", "", "LineNumber", NoCompletion)
+	message := fmt.Sprintf("Jump to line (1 - %v) # ", v.Buf.NumLines)
+	linestring, canceled := messenger.Prompt(message, "", "LineNumber", NoCompletion)
 	if canceled {
 		return false
 	}


### PR DESCRIPTION
Pull request for issue #731.

Change the JumpLine prompt from `Jump to line # ` to `Jump to line (1 - 1337) # `.

(I do not have experience with Go, do not hesitate to correct me)