### PR TITLE
Move current line down/up: cursor stay with moved line

### DIFF
--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -1165,7 +1165,6 @@ func (v *View) MoveLinesUp(usePlugin bool) bool {
 			v.Cursor.Loc.Y,
 			v.Cursor.Loc.Y+1,
 		)
-		v.Cursor.UpN(1)
 		messenger.Message("Moved up current line")
 	}
 	v.Buf.IsModified = true
@@ -1204,7 +1203,6 @@ func (v *View) MoveLinesDown(usePlugin bool) bool {
 			v.Cursor.Loc.Y,
 			v.Cursor.Loc.Y+1,
 		)
-		v.Cursor.DownN(1)
 		messenger.Message("Moved down current line")
 	}
 	v.Buf.IsModified = true


### PR DESCRIPTION
This (`ALT+(UP/DOWN)`):

![capture-video-2017-08-03-11_58_17](https://user-images.githubusercontent.com/22885898/28916801-ba5d2596-7843-11e7-9c82-58349ae1db90.gif)

Has been corrected:

![capture-video-2017-08-03-11_58_58](https://user-images.githubusercontent.com/22885898/28916802-ba7c4a66-7843-11e7-877d-3139928d436b.gif)

When I did `ALT+UP` or `ALT+DOWN`, the cursor was moved one line up or down. Now, the cursor stay on the good line (the moved line).