### PR TITLE
Fix somes selections issues

### DIFF
--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -370,7 +370,7 @@ func (v *View) SelectRight(usePlugin bool) bool {
 	}
 
 	loc := v.Cursor.Loc
-	count := v.Buf.End().Move(-1, v.Buf)
+	count := v.Buf.End()
 	if loc.GreaterThan(count) {
 		loc = count
 	}

--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -347,7 +347,7 @@ func (v *View) SelectLeft(usePlugin bool) bool {
 	}
 
 	loc := v.Cursor.Loc
-	count := v.Buf.End().Move(-1, v.Buf)
+	count := v.Buf.End()
 	if loc.GreaterThan(count) {
 		loc = count
 	}

--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -249,7 +249,7 @@ func (v *View) CursorRight(usePlugin bool) bool {
 	}
 
 	if v.Cursor.HasSelection() {
-		v.Cursor.Loc = v.Cursor.CurSelection[1].Move(-1, v.Buf)
+		v.Cursor.Loc = v.Cursor.CurSelection[1]
 		v.Cursor.ResetSelection()
 		v.Cursor.StoreVisualX()
 	} else {


### PR DESCRIPTION
SelectLeft (`Shift+Left`) was impossible on the last character (it was ignored):

![capture-video-2017-08-03-20_30_25](https://user-images.githubusercontent.com/22885898/28937698-fa2fee86-788b-11e7-886c-a902e01b21a0.gif)

Now, it's possible:

![capture-video-2017-08-03-20_31_10](https://user-images.githubusercontent.com/22885898/28937699-fa31744a-788b-11e7-8de5-0fbbd38991bc.gif)

---

The commit 85969fe ("CursorRight on selection places the [...]") corrects the placement of the cursor when `Right` is clicked:
![capture-video-2017-08-03-20_52_24](https://user-images.githubusercontent.com/22885898/28938397-3c2609f4-788e-11e7-9789-5c9266ca285a.gif)
Becomes:
![capture-video-2017-08-03-20_53_03](https://user-images.githubusercontent.com/22885898/28938398-3c288a08-788e-11e7-9c39-5dec133402b4.gif)

---

Commit 10fd655: when we do `Shift+Right` after the last character, instead of do nothing, the last character is selected. This commit fix that.

---

Issues are always related with `.Move(-1, v.Buf)`.