### PR TITLE
make syntax_checker work with error messages

### DIFF
--- a/runtime/syntax/syntax_checker.go
+++ b/runtime/syntax/syntax_checker.go
@@ -15,16 +15,24 @@ func main() {
 	for _, f := range files {
 		if strings.HasSuffix(f.Name(), ".yaml") {
 			input, _ := ioutil.ReadFile(f.Name())
-			_, err := highlight.ParseDef(input)
+			//fmt.Println("Checking file -> ", f.Name())
+			file, err := highlight.ParseFile(input)
 			if err != nil {
 				hadErr = true
-				fmt.Printf("%s:\n", f.Name())
+				fmt.Printf("Could not parse file -> %s:\n", f.Name())
 				fmt.Println(err)
+				continue
+			}
+			_, err1 := highlight.ParseDef(file, nil)
+			if err1 != nil {
+				hadErr = true
+				fmt.Printf("Could not parse input file using highlight.ParseDef(%s):\n", f.Name())
+				fmt.Println(err1)
 				continue
 			}
 		}
 	}
 	if !hadErr {
-		fmt.Println("No issues!")
+		fmt.Println("No issues found!")
 	}
 }


### PR DESCRIPTION
syntax checker not working.
Looked at code and the parameters have changed due to 

commit 84e350aa6fe857d7ce934447d340d50f241d18d6
Author: Zachary Yedidia <zyedidia@gmail.com>
Date:   Tue May 2 10:30:27 2017 -0400

    Optimize memory usage for loading syntax files

Tested and fails now on errors in syntax files.