### PR TITLE
missing line number offset to current line highlighting for loop. Fix #795

### DIFF
--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -935,7 +935,7 @@ func (v *View) DisplayView() {
 
 		if v.Buf.Settings["cursorline"].(bool) && tabs[curTab].CurView == v.Num &&
 			!v.Cursor.HasSelection() && v.Cursor.Y == realLineN {
-			for i := lastX; i < xOffset+v.Width; i++ {
+			for i := lastX; i < xOffset+v.Width-v.lineNumOffset; i++ {
 				style := GetColor("cursor-line")
 				fg, _, _ := style.Decompose()
 				style = style.Background(fg)


### PR DESCRIPTION
### Before Fix
The current line highlighting works correctly with ruler off but not with ruler on. (line numbers to side)
### Fix
Should fix the current line highlighting with ruler on. (works correctly with ruler on/off)