### PR TITLE
Ensure snap is built with git version/tag info

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: micro
-version: master
+version: git
 summary: A modern and intuitive terminal-based text editor
 description: |
   Micro is a terminal-based text editor that aims to be easy to use and


### PR DESCRIPTION
Changing from version: master to version: git will prevent the snap being built with the text 'master' as the version, but instead use the latest git tag or version info. This makes it easier to figure out which build is which in the store.