### PR TITLE
Support .es files and fix js parenthesis highlighting

### DIFF
--- a/runtime/syntax/javascript.yaml
+++ b/runtime/syntax/javascript.yaml
@@ -1,13 +1,13 @@
 filetype: javascript
 
 detect:
-    filename: "\\.js$"
+    filename: "(\\.js$|\\.es[5678]?$)"
 
 rules:
     - constant.number: "\\b[-+]?([1-9][0-9]*|0[0-7]*|0x[0-9a-fA-F]+)([uU][lL]?|[lL][uU]?)?\\b"
     - constant.number: "\\b[-+]?([0-9]+\\.[0-9]*|[0-9]*\\.[0-9]+)([EePp][+-]?[0-9]+)?[fFlL]?"
     - constant.number: "\\b[-+]?([0-9]+[EePp][+-]?[0-9]+)[fFlL]?"
-    - identifier: "[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[(]"
+    - identifier: "[A-Za-z_][A-Za-z0-9_]*[[:space:]]*"
     - statement: "\\b(break|case|catch|continue|default|delete|do|else|finally)\\b"
     - statement: "\\b(for|function|class|extends|get|if|in|instanceof|new|return|set|switch)\\b"
     - statement: "\\b(switch|this|throw|try|typeof|var|const|let|void|while|with)\\b"


### PR DESCRIPTION
* This allows `micro` to use javascript syntax highlighting on `.es`, `.es6|7|8` files
* Fix parenthesis highlighting with @is73 regex, see #864