### PR TITLE
Add option value completion on setlocal

### DIFF
--- a/cmd/micro/command.go
+++ b/cmd/micro/command.go
@@ -89,7 +89,7 @@ func MakeCommand(name, function string, completions ...Completion) {
 func DefaultCommands() map[string]StrCommand {
 	return map[string]StrCommand{
 		"set":        {"Set", []Completion{OptionCompletion, OptionValueCompletion}},
-		"setlocal":   {"SetLocal", []Completion{OptionCompletion, NoCompletion}},
+		"setlocal":   {"SetLocal", []Completion{OptionCompletion, OptionValueCompletion}},
 		"show":       {"Show", []Completion{OptionCompletion, NoCompletion}},
 		"bind":       {"Bind", []Completion{NoCompletion}},
 		"run":        {"Run", []Completion{NoCompletion}},


### PR DESCRIPTION
`OptionValueCompletion` has been added on `set` ([#5a7ddb8](https://github.com/yannicka/micro/commit/5a7ddb83302ea9f5323fe5a52574e4978c959af9)) but not on `setlocal`. This commit fix that.