### PR TITLE
Use spaces for nim

### DIFF
--- a/runtime/plugins/ftoptions/ftoptions.lua
+++ b/runtime/plugins/ftoptions/ftoptions.lua
@@ -11,7 +11,7 @@ function onViewOpen(view)
 
     if ft == "makefile" or ft == "go" then
         SetOption("tabstospaces", "off")
-    elseif ft == "python" or ft == "python2" or ft == "python3" or ft == "yaml" then
+    elseif ft == "python" or ft == "python2" or ft == "python3" or ft == "yaml" or ft =="nim" then
         SetOption("tabstospaces", "on")
     end
 end


### PR DESCRIPTION
From manual:
Nim's standard grammar describes an indentation sensitive language. This means that all the control structures are recognized by indentation. Indentation consists only of spaces; tabulators are not allowed.