### PR TITLE
search: Only update lastSearch on ENTER

### DIFF
--- a/cmd/micro/search.go
+++ b/cmd/micro/search.go
@@ -64,7 +64,12 @@ func HandleSearchEvent(event tcell.Event, v *View) {
 			// Exit the search mode
 			ExitSearch(v)
 			return
-		case tcell.KeyCtrlQ, tcell.KeyCtrlC, tcell.KeyEnter:
+		case tcell.KeyEnter:
+			// If the user has pressed Enter, they want this to be the lastSearch
+			lastSearch = messenger.response
+			EndSearch()
+			return
+		case tcell.KeyCtrlQ, tcell.KeyCtrlC:
 			// Done
 			EndSearch()
 			return
@@ -179,9 +184,7 @@ func Search(searchStr string, v *View, down bool) {
 			found = searchUp(r, v, v.Buf.End(), searchStart)
 		}
 	}
-	if found {
-		lastSearch = searchStr
-	} else {
+	if !found {
 		v.Cursor.ResetSelection()
 	}
 }


### PR DESCRIPTION
Hi there,

I updated the built-in search behaviour to match the UX of vim/emacs a bit more closely, by updating `lastSearch` only when the user presses ENTER.

This has a few effects:

- `lastSearch` doesn't get overriden with partial searches
unnecessarily, which matches the behaviour of vim/emacs etc.

- Selecting a word, then pressing C-c C-f ENTER works better as you can
now use C-n and C-p to jump to more occurrences of what you just
searched for. Without this, C-n would jump to what you searched for
*previously*, which is a bit unintuitive.

- `lastSearch` will now be updated even if the search did not match -
again, this matches the behaviour of vim/emacs.
