### PR TITLE
Update Lua syntax

### DIFF
--- a/runtime/syntax/lua.yaml
+++ b/runtime/syntax/lua.yaml
@@ -22,7 +22,7 @@ rules:
     - constant: "\\b(false|nil|true)\\b"
     - statement: "(\\b(dofile|require|include)|%q|%!|%Q|%r|%x)\\b"
     - constant.number: "\\b([0-9]+)\\b"
-    - symbol: "(\\(|\\)|\\[|\\]|\\{|\\}|\\*\\*|\\*|/|%|\\+|-|\\^|>|>=|<|<=|~=|=|\\.\\.)"
+    - symbol: "(\\(|\\)|\\[|\\]|\\{|\\}|\\*\\*|\\*|/|%|\\+|-|\\^|>|>=|<|<=|~=|=|\\.\\.|#)"
 
     - constant.string:
         start: "\""

--- a/runtime/syntax/lua.yaml
+++ b/runtime/syntax/lua.yaml
@@ -46,11 +46,6 @@ rules:
 
     - special: "\\\\[0-7][0-7][0-7]|\\\\x[0-9a-fA-F][0-9a-fA-F]|\\\\[abefnrs]|(\\\\c|\\\\C-|\\\\M-|\\\\M-\\\\C-)."
 
-    - comment:
-        start: "#"
-        end: "$"
-        rules: []
-
     - comment: 
         start: "\\-\\-"
         end: "$"


### PR DESCRIPTION
The Lua syntax .yaml incorrectly treated '#' as the beginning of a comment line.
This PR treats '#' as a symbol instead.