### PR TITLE
savehistory bugfix

### DIFF
--- a/cmd/micro/messenger.go
+++ b/cmd/micro/messenger.go
@@ -501,6 +501,8 @@ func (m *Messenger) LoadHistory() {
 
 		if err != nil {
 			m.Error("Error loading history:", err)
+			SetOption("savehistory", "false")
+			m.history = make(map[string][]string)
 			return
 		}
 

--- a/cmd/micro/settings.go
+++ b/cmd/micro/settings.go
@@ -326,10 +326,12 @@ func SetOption(option, value string) error {
 		}
 	}
 
-	if _, ok := CurView().Buf.Settings[option]; ok {
-		for _, tab := range tabs {
-			for _, view := range tab.views {
-				SetLocalOption(option, value, view)
+	if len(tabs) != 0 {
+		if _, ok := CurView().Buf.Settings[option]; ok {
+			for _, tab := range tabs {
+				for _, view := range tab.views {
+					SetLocalOption(option, value, view)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
If the history file is unreadable or unparseable, Messenger.history remained nil, causing a panic on read.

Now in that case, we temporarily disable saving history and initialize history to empty, instead of nil