### PR TITLE
stop version error when updating #906 and option to disable builtin plugin.

### DIFF
--- a/runtime/plugins/literate/literate.lua
+++ b/runtime/plugins/literate/literate.lua
@@ -1,4 +1,7 @@
-VERSION = "1.0.0"
+-- VERSION = "1.0.0"
+if GetOption("literate") == nil then
+    AddOption("literate", true)
+end
 
 function startswith(str, start)
    return string.sub(str,1,string.len(start))==start
@@ -16,6 +19,7 @@ function split(string, sep)
 end
 
 function onViewOpen(view)
+    if not GetOption("literate") then return end
     if not endswith(view.Buf.Path, ".lit") then
         return
     end


### PR DESCRIPTION
Stops the #906 `plugin update` error, as commenting out the version info stops the compare error.
(Not best solution but works for now.) 

Added option to disable builtin plugin.