### PR TITLE
changed filepath.join to path.join to work on linux and windows. fix #931

### DIFF
--- a/cmd/micro/pluginmanager.go
+++ b/cmd/micro/pluginmanager.go
@@ -429,13 +429,13 @@ func (pv *PluginVersion) DownloadAndInstall() error {
 			parts = parts[1:]
 		}
 
-		targetName := path.Join(targetDir, path.Join(parts...))
+		targetName := filepath.Join(targetDir, filepath.Join(parts...))
 		if f.FileInfo().IsDir() {
 			if err := os.MkdirAll(targetName, dirPerm); err != nil {
 				return err
 			}
 		} else {
-			basepath := path.Dir(targetName)
+			basepath := filepath.Dir(targetName)
 
 			if err := os.MkdirAll(basepath, dirPerm); err != nil {
 				return err

--- a/cmd/micro/pluginmanager.go
+++ b/cmd/micro/pluginmanager.go
@@ -422,14 +422,14 @@ func (pv *PluginVersion) DownloadAndInstall() error {
 			allPrefixed = true
 		}
 	}
-
+	// Install files and directory's
 	for _, f := range z.File {
 		parts := strings.Split(f.Name, "/")
 		if allPrefixed {
 			parts = parts[1:]
 		}
 
-		targetName := filepath.Join(targetDir, filepath.Join(parts...))
+		targetName := path.Join(targetDir, path.Join(parts...))
 		if f.FileInfo().IsDir() {
 			if err := os.MkdirAll(targetName, dirPerm); err != nil {
 				return err


### PR DESCRIPTION
fix #931
In windows the `basepath` does not get parsed correctly.

Changed filepath.join to path.join to work on windows.
Tested on Windows and Linux not tested on Mac.