### PR TITLE
create plugin folders work on windows fix #931

### DIFF
--- a/cmd/micro/pluginmanager.go
+++ b/cmd/micro/pluginmanager.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
-	"path"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -423,6 +422,7 @@ func (pv *PluginVersion) DownloadAndInstall() error {
 		}
 	}
 
+	// Install files and directory's
 	for _, f := range z.File {
 		parts := strings.Split(f.Name, "/")
 		if allPrefixed {
@@ -435,7 +435,7 @@ func (pv *PluginVersion) DownloadAndInstall() error {
 				return err
 			}
 		} else {
-			basepath := path.Dir(targetName)
+			basepath := filepath.Dir(targetName)
 
 			if err := os.MkdirAll(basepath, dirPerm); err != nil {
 				return err


### PR DESCRIPTION
fix #931
In windows the `basepath` does not get parsed correctly.

Changed `path.dir` to `filepath.dir` to work on windows.
(Docs say path.dir should not be used for file paths only url paths)
Tested on Windows and Linux not tested on Mac.