### PR TITLE
Changes to add support for Insert Key Press

### DIFF
--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -1697,6 +1697,22 @@ func (v *View) CommandMode(usePlugin bool) bool {
 	return false
 }
 
+// ToggleOverwriteMode lets the user toggle the text overwrite mode
+func (v *View) ToggleOverwriteMode(usePlugin bool) bool {
+	if v.mainCursor() {
+		if usePlugin && !PreActionCall("ToggleOverwriteMode", v) {
+			return false
+		}
+
+		v.isOverwriteMode = !v.isOverwriteMode
+
+		if usePlugin {
+			return PostActionCall("ToggleOverwriteMode", v)
+		}
+	}
+	return false
+}
+
 // Escape leaves current mode
 func (v *View) Escape(usePlugin bool) bool {
 	if v.mainCursor() {

--- a/cmd/micro/bindings.go
+++ b/cmd/micro/bindings.go
@@ -90,6 +90,7 @@ var bindingActions = map[string]func(*View, bool) bool{
 	"ClearStatus":           (*View).ClearStatus,
 	"ShellMode":             (*View).ShellMode,
 	"CommandMode":           (*View).CommandMode,
+	"ToggleOverwriteMode":   (*View).ToggleOverwriteMode,
 	"Escape":                (*View).Escape,
 	"Quit":                  (*View).Quit,
 	"QuitAll":               (*View).QuitAll,
@@ -563,6 +564,7 @@ func DefaultBindings() map[string]string {
 		"CtrlW":          "NextSplit",
 		"CtrlU":          "ToggleMacro",
 		"CtrlJ":          "PlayMacro",
+		"Insert":         "ToggleOverwriteMode",
 
 		// Emacs-style keybindings
 		"Alt-f": "WordRight",

--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -74,7 +74,7 @@ type View struct {
 	mouseReleased bool
 
 	// We need to keep track of insert key press toggle
-	isInsertMode bool
+	isOverwriteMode bool
 	// This stores when the last click was
 	// This is useful for detecting double and triple clicks
 	lastClickTime time.Time
@@ -247,9 +247,9 @@ func (v *View) OpenBuffer(buf *Buffer) {
 	// Set mouseReleased to true because we assume the mouse is not being pressed when
 	// the editor is opened
 	v.mouseReleased = true
-	// Set isInsertMode to false, because we assume we are in the default mode when editor
+	// Set isOverwriteMode to false, because we assume we are in the default mode when editor
 	// is opened
-	v.isInsertMode = false
+	v.isOverwriteMode = false
 	v.lastClickTime = time.Time{}
 }
 
@@ -569,9 +569,7 @@ func (v *View) HandleEvent(event tcell.Event) {
 				}
 			}
 		}
-		if e.Key() == tcell.KeyInsert {
-			v.isInsertMode = !v.isInsertMode
-		}
+
 		if !isBinding && e.Key() == tcell.KeyRune {
 			// Check viewtype if readonly don't insert a rune (readonly help and log view etc.)
 			if v.Type.Readonly == false {
@@ -584,7 +582,7 @@ func (v *View) HandleEvent(event tcell.Event) {
 						v.Cursor.ResetSelection()
 					}
 
-					if v.isInsertMode {
+					if v.isOverwriteMode {
 						next := v.Cursor.Loc
 						next.X++
 						v.Buf.Replace(v.Cursor.Loc, next, string(e.Rune()))


### PR DESCRIPTION
Adding view flag to support insert mode.
When insert mode is turned on, existing characters will be replaced/overwritten.
Pressing the insert key toggles insert mode.
Issue: #591 