### PR TITLE
Fix git-commit comment syntax

### DIFF
--- a/runtime/syntax/git-commit.yaml
+++ b/runtime/syntax/git-commit.yaml
@@ -8,7 +8,7 @@ rules:
     - ignore: ".*"
     # Comments
     - comment:
-        start: "#"
+        start: "^#"
         end: "$"
         rules: []
     # File changes


### PR DESCRIPTION
A comment in a git-commit must have the hash at the start of the line, instead of just anywhere in the line. So this fixes that.