### PR TITLE
Add some Lua syntax

### DIFF
--- a/runtime/syntax/lua.yaml
+++ b/runtime/syntax/lua.yaml
@@ -19,11 +19,11 @@ rules:
     - identifier: "debug\\.\\b(debug|getfenv|gethook|getinfo|getlocal|getmetatable|getregistry|getupvalue|getuservalue|setfenv|sethook|setlocal|setmetatable|setupvalue|setuservalue|traceback|upvalueid|upvaluejoin)\\b"
     - identifier: "bit32\\.\\b(arshift|band|bnot|bor|btest|bxor|extract|replace|lrotate|lshift|rrotate|rshift)\\b"
     - identifier: "\\:\\b(close|flush|lines|read|seek|setvbuf|write|byte|char|dump|find|format|gmatch|gsub|len|lower|match|pack|packsize|rep|reverse|sub|unpack|upper)\\b"
-    - identifier: "\\b(self)\\b"
+    - identifier: "\\b(self|arg)\\b"
     - constant: "\\b(false|nil|true)\\b"
     - statement: "(\\b(dofile|require|include)|%q|%!|%Q|%r|%x)\\b"
     - constant.number: "\\b([0-9]+)\\b"
-    - symbol: "(\\(|\\)|\\[|\\]|\\{|\\}|\\*\\*|\\*|/|%|\\+|-|\\^|>|>=|<|<=|~=|=|\\.\\.|#)"
+    - symbol: "(\\(|\\)|\\[|\\]|\\{|\\}|\\*\\*|\\*|/|%|\\+|-|\\^|>|>=|<|<=|~=|=|[\\.]{2,3}|#)"
 
     - constant.string:
         start: "\""

--- a/runtime/syntax/lua.yaml
+++ b/runtime/syntax/lua.yaml
@@ -18,7 +18,7 @@ rules:
     - identifier: "coroutine\\.\\b(create|isyieldable|resume|running|status|wrap|yield)\\b"
     - identifier: "debug\\.\\b(debug|getfenv|gethook|getinfo|getlocal|getmetatable|getregistry|getupvalue|getuservalue|setfenv|sethook|setlocal|setmetatable|setupvalue|setuservalue|traceback|upvalueid|upvaluejoin)\\b"
     - identifier: "bit32\\.\\b(arshift|band|bnot|bor|btest|bxor|extract|replace|lrotate|lshift|rrotate|rshift)\\b"
-    - identifier: "\\:\\b(close|flush|lines|read|seek|setvbuf|write)\\b"
+    - identifier: "\\:\\b(close|flush|lines|read|seek|setvbuf|write|byte|char|dump|find|format|gmatch|gsub|len|lower|match|pack|packsize|rep|reverse|sub|unpack|upper)\\b"
     - constant: "\\b(false|nil|true)\\b"
     - statement: "(\\b(dofile|require|include)|%q|%!|%Q|%r|%x)\\b"
     - constant.number: "\\b([0-9]+)\\b"

--- a/runtime/syntax/lua.yaml
+++ b/runtime/syntax/lua.yaml
@@ -19,6 +19,7 @@ rules:
     - identifier: "debug\\.\\b(debug|getfenv|gethook|getinfo|getlocal|getmetatable|getregistry|getupvalue|getuservalue|setfenv|sethook|setlocal|setmetatable|setupvalue|setuservalue|traceback|upvalueid|upvaluejoin)\\b"
     - identifier: "bit32\\.\\b(arshift|band|bnot|bor|btest|bxor|extract|replace|lrotate|lshift|rrotate|rshift)\\b"
     - identifier: "\\:\\b(close|flush|lines|read|seek|setvbuf|write|byte|char|dump|find|format|gmatch|gsub|len|lower|match|pack|packsize|rep|reverse|sub|unpack|upper)\\b"
+    - identifier: "\\b(self)\\b"
     - constant: "\\b(false|nil|true)\\b"
     - statement: "(\\b(dofile|require|include)|%q|%!|%Q|%r|%x)\\b"
     - constant.number: "\\b([0-9]+)\\b"
@@ -50,11 +51,12 @@ rules:
         start: "\\-\\-\\[(\\=*|\\#*)\\["
         end: "\\-\\-\\](\\=*|\\#*)\\]"
         rules:
-            - todo: "(TODO|XXX|FIXME):?"
+            - todo: "(TODO|NOTE|FIXME):?"
 
 # this has to go after block comment or block comment does not work
 
     - comment: 
         start: "\\-\\-"
         end: "$"
-        rules: []
+        rules:
+          - todo: "(TODO|NOTE|FIXME):?"


### PR DESCRIPTION
All Lua strings have the string functions inside of them.

'...you can use the string functions in object-oriented style'
See '6.4 – String Manipulation' in https://www.lua.org/manual/5.3/manual.html

Also added `TODO`, `NOTE`, and `FIXME` highlighting into single-line comments, and a `self` highlighter.