### PR TITLE
Fix micro (color) file syntax

### DIFF
--- a/runtime/syntax/micro.yaml
+++ b/runtime/syntax/micro.yaml
@@ -6,13 +6,25 @@ detect:
 rules:
     - statement: "\\b(syntax|color(-link)?)\\b"
     - statement: "\\b(start=|end=)\\b"
-    - identifier: "\\b(default|comment|symbol|identifier|constant(.string(.char)?|.number)?|statement|preproc|type|special|underlined|error|todo|statusline|indent-char|(current-)?line-number|gutter-error|gutter-warning|cursor-line|color-column)\\b"
+    # Simple one-liners
+    - identifier: "\\b(default|number|statement|underlined|error|todo|statusline|indent-char|cursor\\-line|color\\-column|ignore|divider|tabbar)\\b"
+    # Separate identifiers to keep "complex" regex clean
+    - identifier: "\\b(special(Char)?)\\b"
+    - identifier: "\\b((current\\-)?line\\-number)\\b"
+    - identifier: "\\b(gutter\\-(info|error|warning){1})\\b"
+    - identifier: "\\b(comment(\\.bright)?)\\b"
+    - identifier: "\\b(symbol(\\.(brackets|operator|tag))?)\\b"
+    - identifier: "\\b(identifier(\\.(class|macro|var))?)\\b"
+    - identifier: "\\b(constant(\\.(bool(\\.(true|false){1})?|number|specialChar|string(\\.url)?){1})?)\\b"
+    - identifier: "\\b(preproc(\\.shebang)?)\\b"
+    - identifier: "\\b(type(\\.keyword)?)\\b"
     - constant.number: "\\b(|h|A|0x)+[0-9]+(|h|A)+\\b"
     - constant.number: "\\b0x[0-9 a-f A-F]+\\b"
     - comment:
         start: "#"
         end: "$"
-        rules: []
+        rules:
+          - todo: "(FIXME|TODO|NOTE):?"
     - constant.string:
         start: "\""
         end: "\""
@@ -20,4 +32,3 @@ rules:
         rules:
             - constant.specialChar: "\\\\."
     - constant.number: "#[0-9 A-F a-f]+"
-    


### PR DESCRIPTION
Some of the words were missing, so this adds those.

I added everything that was in the doc, but I have the feeling I might be missing something. For example, what's `start=` and `end=` do?