### PR TITLE
make keybinings.md more explicit

### DIFF
--- a/runtime/help/keybindings.md
+++ b/runtime/help/keybindings.md
@@ -31,7 +31,7 @@ following in the `bindings.json` file.
 ```json
 {
 	"CtrlY": "Undo",
-	"CtrlZ": "Redo"
+	"CtrlZ": "Redo",
 }
 ```
 
@@ -43,7 +43,15 @@ save and quit you can bind it like so:
 
 ```json
 {
-    "Alt-s": "Save,Quit"
+	"Alt-s": "Save,Quit",
+}
+```
+
+This is the same as:
+
+```json
+{
+	"Alts": "Save,Quit",
 }
 ```
 
@@ -54,7 +62,7 @@ You can also bind a key to execute a command in command mode (see
 
 ```json
 {
-    "Alt-p": "command:pwd"
+	"Alt-p": "command:pwd",
 }
 ```
 
@@ -68,7 +76,7 @@ you could rebind `CtrlG` to `> help`:
 
 ```json
 {
-    "CtrlG": "command-edit:help "
+    "CtrlG": "command-edit:help",
 }
 ```
 
@@ -100,7 +108,7 @@ terminal to send `\x1bctrlback` and then bind it in `bindings.json`:
 
 ```json
 {
-    "\u001bctrlback": "DeleteWordLeft"
+    "\u001bctrlback": "DeleteWordLeft",
 }
 ```
 
@@ -368,7 +376,7 @@ MouseWheelLeft
 MouseWheelRight
 ```
 
-# Default keybinding configuration.
+# Default keybinding configuration
 
 ```json
 {
@@ -473,8 +481,9 @@ MouseWheelRight
 Note: On some old terminal emulators and on Windows machines, `CtrlH` should be
 used for backspace.
 
-Additionally, alt keys can be bound by using `Alt-key`. For example `Alt-a` or
+Alt keys can be bound by using `Alt-key`. For example `Alt-a` or
 `Alt-Up`. Micro supports an optional `-` between modifiers like `Alt` and 
-`Ctrl` so `Alt-a` could be rewritten as `Alta` (case matters for alt bindings).
-This is why in the default keybindings you can see `AltShiftLeft` instead of
-`Alt-ShiftLeft` (they are equivalent).
+`Ctrl` so `Alt-a` could be rewritten as `Alta`.
+
+Case matters for alt bindings only.
+This is why in the default keybindings you can see `AltShiftLeft`. `AltShiftLeft` and `Alt-ShiftLeft` are equivalent.


### PR DESCRIPTION
This is my first PR and result of a [couple of questions I had](https://github.com/zyedidia/micro/issues/974) and suspect others might as well have.

1. enhances the understanding of `KeyKey2` == `Key-Key2`
2. enhances the understanding of `Alt` + `Shift` vs. others + `Shift`
3. Makes bindings.json easier to extend by always having `,` at EOL, this was already the case for the `Default keybinding configuration`. This eliminates a possible error for beginners


[furthermore it would help if bindings.json was created by default](https://github.com/zyedidia/micro/issues/969#issuecomment-354967453)