### PR TITLE
Remove weird ignore on git-commit

### DIFF
--- a/runtime/syntax/git-commit.yaml
+++ b/runtime/syntax/git-commit.yaml
@@ -1,29 +1,25 @@
 filetype: git-commit
 
 detect:
-    filename: "COMMIT_EDITMSG|TAG_EDITMSG"
+    filename: "^(.*[\\/])?(COMMIT_EDITMSG|TAG_EDITMSG)$"
 
 rules:
-    # Commit message
-    - ignore: ".*"
-    # Comments
-    - comment:
-        start: "^#"
-        end: "$"
-        rules: []
     # File changes
     - type.keyword: "#[[:space:]](deleted|modified|new file|renamed):[[:space:]].*"
     - type.keyword: "#[[:space:]]deleted:"
     - type.keyword: "#[[:space:]]modified:"
     - type.keyword: "#[[:space:]]new file:"
     - type.keyword: "#[[:space:]]renamed:"
-    # Untracked filenames
-    - error: "^#	[^/?*:;{}\\\\]+\\.[^/?*:;{}\\\\]+$"
     - type.keyword: "^#[[:space:]]Changes.*[:]"
     - type.keyword: "^#[[:space:]]Your branch and '[^']+"
     - type.keyword: "^#[[:space:]]Your branch and '"
     - type.keyword: "^#[[:space:]]On branch [^ ]+"
     - type.keyword: "^#[[:space:]]On branch"
-    # Recolor hash symbols
-    - special: "#"
+    # Color keywords for closing issues (such as on Github)
+    - type.keyword: "\\b(?i)((fix(es|ed)?|close(s|d)?) #[0-9]+)\\b"
 
+    # Comments
+    - comment.line:
+        start: "^#"
+        end: "$"
+        rules: []

--- a/runtime/syntax/git-rebase-todo.yaml
+++ b/runtime/syntax/git-rebase-todo.yaml
@@ -1,28 +1,19 @@
 filetype: git-rebase-todo
 
 detect:
-    filename: "git-rebase-todo"
+    filename: "^(.*[\\/])?git\\-rebase\\-todo$"
 
 rules:
+    # Rebase commands
+    - statement: "^(p(ick)?|r(eword)?|e(dit)?|s(quash)?|f(ixup)?|x|exec|d(rop)?)\\b"
+    # Commit IDs
+    - identifier: "\\b([0-9a-f]{7,40})\\b"
+
+    # Color keywords for Github (and others)
+    - type.keyword: "\\b(?i)((fix(es|ed)?|close(s|d)?) #[0-9]+)\\b"
+
     # Comments
-    - comment:
-        start: "#"
+    - comment.line:
+        start: "^#"
         end: "$"
         rules: []
-    # Rebase commands
-    - statement: "^(e|edit) [0-9a-f]{7,40}"
-    - statement: "^#  (e, edit)"
-    - statement: "^(f|fixup) [0-9a-f]{7,40}"
-    - statement: "^#  (f, fixup)"
-    - statement: "^(p|pick) [0-9a-f]{7,40}"
-    - statement: "^#  (p, pick)"
-    - statement: "^(r|reword) [0-9a-f]{7,40}"
-    - statement: "^#  (r, reword)"
-    - statement: "^(s|squash) [0-9a-f]{7,40}"
-    - statement: "^#  (s, squash)"
-    - statement: "^(x|exec) [^ ]+ [0-9a-f]{7,40}"
-    - statement: "^#  (x, exec)"
-    # Recolor hash symbols
-    - special: "#"
-    # Commit IDs
-    - identifier: "[0-9a-f]{7,40}"


### PR DESCRIPTION
It was needlessly highlighting everything that wasn't a comment.

Adds keyword detection for Github-esque issue-closing syntax.
Adds missing 'd' and 'drop' highlighting in git-rebase-todo

---

I addded more verbose filename detection because I noticed that it tried to highlight `git-rebase-todo.yaml` as a `git-rebase-todo` file, instead of a `yaml` file. 

Might be wise to consider doing something like I did for most/all syntax files, or otherwise changing how the detect filename works so it only works off of a basename.