### PR TITLE
Fix Makefile equals highlighting

### DIFF
--- a/runtime/syntax/makefile.yaml
+++ b/runtime/syntax/makefile.yaml
@@ -7,8 +7,8 @@ detect:
 rules:
     - preproc: "\\<(ifeq|ifdef|ifneq|ifndef|else|endif)\\>"
     - statement: "^(export|include|override)\\>"
-    - operator: "^[^:=	]+:"
-    - operator: "([=,%]|\\+=|\\?=|:=|&&|\\|\\|)"
+    - symbol.operator: "^[^:=	]+:"
+    - symbol.operator: "([=,%]|\\+=|\\?=|:=|&&|\\|\\|)"
     - statement: "\\$\\((abspath|addprefix|addsuffix|and|basename|call|dir)[[:space:]]"
     - statement: "\\$\\((error|eval|filter|filter-out|findstring|firstword)[[:space:]]"
     - statement: "\\$\\((flavor|foreach|if|info|join|lastword|notdir|or)[[:space:]]"


### PR DESCRIPTION
I think they weren't being highlighted at all, leading to a weird looking default white box around them.