### PR TITLE
Allow Micro to Open Directories

### DIFF
--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -107,9 +107,10 @@ func LoadInput() []*Buffer {
 			}
 
 			buf, err := NewBufferFromFile(args[i])
+			// If we have an error, display the error and open an empty buffer anyways
 			if err != nil {
-				TermMessage(err)
-				continue
+				messenger.Error(err)
+				buf = NewBufferFromString("", args[i])
 			}
 			// If the file didn't exist, input will be empty, and we'll open an empty buffer
 			buffers = append(buffers, buf)


### PR DESCRIPTION
There is a request (#1023) to have Micro change its working directory when a folder is given as the first argument. The idea would be, since the filemanager plugin works off the current directory, this would allow someone using the plugin to immediately run `tree` and have the filebrowser view where they want it. While I do like the filemanager plugin, I do see this kind of change as being focused towards a specific plugin, and while the easy route out would be to have micro do os.Chdir in the presence of a single folder, this doesn't give us any behavior for multiple folders, and I think an approach that handles multiple folders would be more plugin-agnostic.

For some background, some editors like Sublime Text allow a user to pass multiple directories to it: `sublime /path/a ./path/b`. This would open up both directories in Sublime's file manager. To allow something similar, I propose allowing micro to open a directory as an empty buffer. Following the example for sublime, the command `micro /path/a ./path/b` would open two tabs: an empty buffer with /path/a, and an empty buffer with ./path/b. I'm assuming, at this point, that plugins like filemanager can be reworked so `tree` would use the current view's filename as the path to spawn the view from.

For some of this to work I had to make some modifies to how saveToFile works; part of the work that went into it duplicates some code from SaveAs, and I'm pretty certain this approach can be refactored quite a bit. I wouldn't necessarily say that this pull request is _ready_ to be merged because of that, but I wanted to put this out to see if this kind of behavior is desired; at a very minimum, micro.go should be modified to check to see if the argument passed is a directory (when NewBufferFromFile errors out).

As part of this, I did notice a behavior: micro never prompts a user to overwrite a file if they start with an empty buffer and save it over an existing file. This adds a check for that.