### PR TITLE
Add support for ~username syntax (fix #1033)

### DIFF
--- a/cmd/micro/util.go
+++ b/cmd/micro/util.go
@@ -330,27 +330,27 @@ func ReplaceHome(path string) string {
 		return path
 	}
 
-	var foo *user.User
+	var userData *user.User
 
 	homeString := strings.Split(path, "/")[0]
 	if homeString == "~" {
 		var err error
-		foo, err = user.Current()
+		userData, err = user.Current()
 		if err != nil {
 			messenger.Error("Could not find user: ", err)
 		}
 	} else {
 		userString := homeString[1:]
 		var err error
-		foo, err = user.Lookup(userString)
+		userData, err = user.Lookup(userString)
 		if err != nil {
 			messenger.Error("Could not find user: ", err)
 		}
 	}
 
-	home := foo.HomeDir
+	home := userData.HomeDir
 
-	return strings.Replace(path, "~", home, 1)
+	return strings.Replace(path, homeString, home, 1)
 }
 
 // GetPath returns a filename without everything following a `:`

--- a/cmd/micro/util.go
+++ b/cmd/micro/util.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"os/user"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -9,9 +10,8 @@ import (
 	"strings"
 	"time"
 	"unicode/utf8"
-
+	
 	"github.com/mattn/go-runewidth"
-	homedir "github.com/mitchellh/go-homedir"
 )
 
 // Util.go is a collection of utility functions that are used throughout
@@ -330,11 +330,26 @@ func ReplaceHome(path string) string {
 		return path
 	}
 
-	home, err := homedir.Dir()
-	if err != nil {
-		messenger.Error("Could not find home directory: ", err)
-		return path
+	var foo *user.User
+
+	homeString := strings.Split(path, "/")[0]
+	if homeString == "~" {
+		var err error
+		foo, err = user.Current()
+		if err != nil {
+			messenger.Error("Could not find user: ", err)
+		}
+	} else {
+		userString := homeString[1:]
+		var err error
+		foo, err = user.Lookup(userString)
+		if err != nil {
+			messenger.Error("Could not find user: ", err)
+		}
 	}
+
+	home := foo.HomeDir
+
 	return strings.Replace(path, "~", home, 1)
 }
 

--- a/cmd/micro/util.go
+++ b/cmd/micro/util.go
@@ -331,18 +331,16 @@ func ReplaceHome(path string) string {
 	}
 
 	var userData *user.User
+	var err error
 
 	homeString := strings.Split(path, "/")[0]
 	if homeString == "~" {
-		var err error
 		userData, err = user.Current()
 		if err != nil {
 			messenger.Error("Could not find user: ", err)
 		}
 	} else {
-		userString := homeString[1:]
-		var err error
-		userData, err = user.Lookup(userString)
+		userData, err = user.Lookup(homeString[1:])
 		if err != nil {
 			messenger.Error("Could not find user: ", err)
 		}


### PR DESCRIPTION
This is my first time writing Go, so please critique the style and implementation. But as far as my testing goes, this should solve #1033.

I've only tested this on Linux, but I see no reason why it wouldn't also work with other systems, as long as os/user handles it properly.