### PR TITLE
Implement SpawnMultiCursorSelect

### DIFF
--- a/cmd/micro/bindings.go
+++ b/cmd/micro/bindings.go
@@ -109,6 +109,7 @@ var bindingActions = map[string]func(*View, bool) bool{
 	"ScrollUp":              (*View).ScrollUpAction,
 	"ScrollDown":            (*View).ScrollDownAction,
 	"SpawnMultiCursor":      (*View).SpawnMultiCursor,
+	"SpawnMultiCursorSelect":(*View).SpawnMultiCursorSelect,
 	"RemoveMultiCursor":     (*View).RemoveMultiCursor,
 	"RemoveAllMultiCursors": (*View).RemoveAllMultiCursors,
 	"SkipMultiCursor":       (*View).SkipMultiCursor,
@@ -600,6 +601,7 @@ func DefaultBindings() map[string]string {
 		"Ctrl-MouseLeft": "MouseMultiCursor",
 
 		"Alt-n": "SpawnMultiCursor",
+		"CtrlM": "SpawnMultiCursorSelect",
 		"Alt-p": "RemoveMultiCursor",
 		"Alt-c": "RemoveAllMultiCursors",
 		"Alt-x": "SkipMultiCursor",

--- a/runtime/help/keybindings.md
+++ b/runtime/help/keybindings.md
@@ -464,6 +464,7 @@ MouseWheelRight
 
     // Multiple cursors bindings
     "Alt-n": "SpawnMultiCursor",
+    "CtrlM": "SpawnMultiCursorSelect",
     "Alt-p": "RemoveMultiCursor",
     "Alt-c": "RemoveAllMultiCursors",
     "Alt-x": "SkipMultiCursor",


### PR DESCRIPTION
Implement a feature similar to 'visual block' in Vim by creating a function which adds a multicursor at the beginning of each line in a selection. This makes it easier to insert arbitrary numbers of cursors.

(As a side note, I am very new to micro and Go in general, I won't be offended at all if this is rejected for reasons of code quality...)