### PR TITLE
home toggles between start of line and start of text

### DIFF
--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -435,7 +435,11 @@ func (v *View) StartOfLine(usePlugin bool) bool {
 
 	v.deselect(0)
 
-	v.Cursor.Start()
+	if v.Cursor.X != 0 {
+		v.Cursor.Start()
+	} else {
+		v.Cursor.StartOfText()
+	}
 
 	if usePlugin {
 		return PostActionCall("StartOfLine", v)

--- a/cmd/micro/cursor.go
+++ b/cmd/micro/cursor.go
@@ -333,6 +333,18 @@ func (c *Cursor) Start() {
 	c.LastVisualX = c.GetVisualX()
 }
 
+// StartOfText moves the cursor to the first non-whitespace rune of 
+// the line it is on
+func (c *Cursor) StartOfText() {
+	c.Start()
+	for IsWhitespace(c.RuneUnder(c.X)) {
+		if c.X == Count(c.buf.Line(c.Y)) {
+			break
+		}
+		c.Right()
+	}
+}
+
 // GetCharPosInLine gets the char position of a visual x y
 // coordinate (this is necessary because tabs are 1 char but
 // 4 visual spaces)


### PR DESCRIPTION
by default home sends the cursor to the beginning of the line. if the cursor is at the beginning of the line already though, home will send the cursor to the first non-whitespace rune. tapping home will toggle between these two line starts.