### PR TITLE
Make ^X act like ^K when nothing is selected

### DIFF
--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -1220,7 +1220,7 @@ func (v *View) Cut(usePlugin bool) bool {
 		}
 		return true
 	} else {
-		return CutLine(usePlugin)
+		return v.CutLine(usePlugin)
 	}
 }
 

--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -1219,6 +1219,8 @@ func (v *View) Cut(usePlugin bool) bool {
 			return PostActionCall("Cut", v)
 		}
 		return true
+	} else {
+		return CutLine(usePlugin)
 	}
 
 	return false

--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -1222,8 +1222,6 @@ func (v *View) Cut(usePlugin bool) bool {
 	} else {
 		return CutLine(usePlugin)
 	}
-
-	return false
 }
 
 // DuplicateLine duplicates the current line or selection


### PR DESCRIPTION
^K is hard to reach with your left hand or requires to use both hands
Also with this you could remove ^K whatsoever and make room for a different command
This is how I configured nano by the way
Line duplication also becomes nearly instantaneous with a flash-quick ^X+^V+^V combo (nano doesn't have a dedicated shortcut)
Small block (5-10 lines) cuts/copies/duplicates can also be made this way

Also, I haven't written a single line of Go so this might not even compile, but you get the idea