### PR TITLE
Allow upper-case letters in Replace() prompt

### DIFF
--- a/cmd/micro/command.go
+++ b/cmd/micro/command.go
@@ -614,7 +614,7 @@ func Replace(args []string) {
 			}
 			view.Relocate()
 			RedrawAll()
-			choice, canceled := messenger.LetterPrompt("Perform replacement? (y,n,a)", 'y', 'n', 'a')
+			choice, canceled := messenger.LetterPrompt("Perform replacement? (y,n,a)", 'y', 'n', 'a', 'Y', 'N', 'A')
 			if canceled {
 				if view.Cursor.HasSelection() {
 					view.Cursor.Loc = view.Cursor.CurSelection[0]


### PR DESCRIPTION
For people like me who use caps-lock to type in caps
Sometimes I need to press caps-lock for Replace(), then press it again to resume typing caps