### PR TITLE
Code optimisation

### DIFF
--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -20,6 +20,8 @@ import (
 	"github.com/zyedidia/micro/cmd/micro/highlight"
 )
 
+const LargeFileThreshold = 50000
+
 var (
 	// 0 - no line type detected
 	// 1 - lf detected
@@ -246,7 +248,7 @@ func NewBuffer(reader io.Reader, size int64, path string) *Buffer {
 	}
 
 	if !b.Settings["fastdirty"].(bool) {
-		if size > 50000 {
+		if size > LargeFileThreshold {
 			// If the file is larger than a megabyte fastdirty needs to be on
 			b.Settings["fastdirty"] = true
 		} else {
@@ -475,6 +477,7 @@ func (b *Buffer) SaveAs(filename string) error {
 		}
 		b.Cursor.Relocate()
 	}
+
 	if b.Settings["eofnewline"].(bool) {
 		end := b.End()
 		if b.RuneAt(Loc{end.X - 1, end.Y}) != '\n' {
@@ -548,7 +551,7 @@ func (b *Buffer) SaveAs(filename string) error {
 	}
 
 	if !b.Settings["fastdirty"].(bool) {
-		if fileSize > 50000 {
+		if fileSize > LargeFileThreshold {
 			// For large files 'fastdirty' needs to be on
 			b.Settings["fastdirty"] = true
 		} else {
@@ -683,7 +686,7 @@ func (b *Buffer) RuneAt(loc Loc) rune {
 	return '\n'
 }
 
-// Line returns a single line as an array of runes
+// LineBytes returns a single line as an array of runes
 func (b *Buffer) LineBytes(n int) []byte {
 	if n >= len(b.lines) {
 		return []byte{}
@@ -691,7 +694,7 @@ func (b *Buffer) LineBytes(n int) []byte {
 	return b.lines[n].data
 }
 
-// Line returns a single line as an array of runes
+// LineRunes returns a single line as an array of runes
 func (b *Buffer) LineRunes(n int) []rune {
 	if n >= len(b.lines) {
 		return []rune{}

--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -723,8 +723,16 @@ func (b *Buffer) Lines(start, end int) []string {
 }
 
 // Len gives the length of the buffer
-func (b *Buffer) Len() int {
-	return Count(b.String())
+func (b *Buffer) Len() (n int) {
+	for _, l := range b.lines {
+		n += utf8.RuneCount(l.data)
+	}
+
+	if len(b.lines) > 1 {
+		n += len(b.lines) - 1 // account for newlines
+	}
+
+	return
 }
 
 // MoveLinesUp moves the range of lines up one row

--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"crypto/md5"
 	"encoding/gob"
@@ -448,7 +449,7 @@ func (b *Buffer) Serialize() error {
 
 	name := configDir + "/buffers/" + EscapePath(b.AbsPath)
 
-	return overwriteFile(name, func(file *os.File) error {
+	return overwriteFile(name, func(file io.Writer) error {
 		return gob.NewEncoder(file).Encode(SerializedBuffer{
 			b.EventHandler,
 			b.Cursor,
@@ -511,7 +512,7 @@ func (b *Buffer) SaveAs(filename string) error {
 
 	var fileSize int
 
-	err := overwriteFile(absFilename, func(file *os.File) (e error) {
+	err := overwriteFile(absFilename, func(file io.Writer) (e error) {
 		if len(b.lines) == 0 {
 			return
 		}
@@ -564,8 +565,9 @@ func (b *Buffer) SaveAs(filename string) error {
 }
 
 // overwriteFile opens the given file for writing, truncating if one exists, and then calls
-// the supplied function with the file object, also making sure the file is closed afterwards.
-func overwriteFile(name string, fn func(*os.File) error) (err error) {
+// the supplied function with the file as io.Writer object, also making sure the file is
+// closed afterwards.
+func overwriteFile(name string, fn func(io.Writer) error) (err error) {
 	var file *os.File
 
 	if file, err = os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644); err != nil {
@@ -578,7 +580,13 @@ func overwriteFile(name string, fn func(*os.File) error) (err error) {
 		}
 	}()
 
-	err = fn(file)
+	w := bufio.NewWriter(file)
+
+	if err = fn(w); err != nil {
+		return
+	}
+
+	err = w.Flush()
 	return
 }
 

--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -11,10 +11,10 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/zyedidia/micro/cmd/micro/highlight"
@@ -466,15 +466,14 @@ func init() {
 func (b *Buffer) SaveAs(filename string) error {
 	b.UpdateRules()
 	if b.Settings["rmtrailingws"].(bool) {
-		r := regexp.MustCompile(`[ \t]+$`)
-		for lineNum, line := range b.Lines(0, b.NumLines) {
-			indices := r.FindStringIndex(line)
-			if indices == nil {
-				continue
+		for i, l := range b.lines {
+			pos := len(bytes.TrimRightFunc(l.data, unicode.IsSpace))
+
+			if pos < len(l.data) {
+				b.deleteToEnd(Loc{pos, i})
 			}
-			startLoc := Loc{indices[0], lineNum}
-			b.deleteToEnd(startLoc)
 		}
+
 		b.Cursor.Relocate()
 	}
 


### PR DESCRIPTION
Thanks guys for developing the good editor. I have been using it for a while, and I found that it tends to become a bit sluggish when editing large files. This PR adds some optimisations (but no new functionality) to speed things up and to reduce memory allocations, in particular:
- Buffered output makes saving large files significantly faster;
- md5 hash calculations no longer stringify the whole buffer or file;
- Trimming trailing whitespace operation optimised to remove unnecessary allocations;
- Added parallel hash recalculation when turning off `fastdirty` setting;
- Other small stylistic changes.

Hope this code is useful.