### PR TITLE
Allows opening files using full path on Windows

### DIFF
--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -77,9 +77,9 @@ type SerializedBuffer struct {
 	ModTime      time.Time
 }
 
-// NewBufferFromFile opens a new buffer using the given filepath
+// NewBufferFromFile opens a new buffer using the given path
 // It will also automatically handle `~`, and line/column with filename:l:c
-// It will return an empty buffer if the filepath does not exist
+// It will return an empty buffer if the path does not exist
 // and an error if the file is a directory
 func NewBufferFromFile(path string) (*Buffer, error) {
 	filename, cursorPosition := GetPathAndCursorPosition(path)
@@ -96,16 +96,15 @@ func NewBufferFromFile(path string) (*Buffer, error) {
 	var buf *Buffer
 	if err != nil {
 		// File does not exist -- create an empty buffer with that name
-		buf = NewBufferFromString("", path)
+		buf = NewBufferFromString("", filename)
 	} else {
-		buf = NewBuffer(file, FSize(file), path, cursorPosition)
+		buf = NewBuffer(file, FSize(file), filename, cursorPosition)
 	}
 
 	return buf, nil
 }
 
-// NewBufferFromString creates a new buffer containing the given
-// string
+// NewBufferFromString creates a new buffer containing the given string
 func NewBufferFromString(text, path string) *Buffer {
 	return NewBuffer(strings.NewReader(text), int64(len(text)), path, []string{"0", "0"})
 }

--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -19,6 +19,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/zyedidia/micro/cmd/micro/highlight"
+	"runtime"
 )
 
 const LargeFileThreshold = 50000
@@ -114,7 +115,7 @@ func NewBufferFromString(text, path string) *Buffer {
 func NewBuffer(reader io.Reader, size int64, path string) *Buffer {
 	startpos := Loc{0, 0}
 	startposErr := true
-	if strings.Contains(path, ":") {
+	if runtime.GOOS != "windows" && strings.Contains(path, ":") {
 		var err error
 		split := strings.Split(path, ":")
 		path = split[0]

--- a/cmd/micro/util.go
+++ b/cmd/micro/util.go
@@ -360,8 +360,38 @@ func ReplaceHome(path string) string {
 // This is used for opening files like util.go:10:5 to specify a line and column
 func GetPath(path string) string {
 	// FIXME -> this breaks the line/column functionality on windows
-	if runtime.GOOS != "windows" && strings.Contains(path, ":") {
-		path = strings.Split(path, ":")[0]
+	// so what's possible
+	// -> Relative file no dot (any OS): myfile:10:5
+	// -> Relative file (any OS): ./myfile:10:5
+	// -> Absolute file (Windows): W:/myfile:10:5
+	// -> Absolute file (Unix): /home/dtasev/myfile:10:5
+	// naive => string[1] == :
+	//		- fails when filename is length of 1 -> file "f" => f:5
+
+	// if current OS is Windows and the absolute path is provided this will be a string of the type C:\dir\files...
+	// if the user has passed a line/column then the last index of the colon will NOT be at position ^ after the drive
+	// letter, but somewhere else. The exception is a single letter file
+	if runtime.GOOS == "windows" {
+		// TODO handle single letter file later
+		lastColonIndex := strings.LastIndex(path, ":")
+
+		// if the colon index is after the position of the drive letter,
+		// that it is possible that there is more than one colon
+		if lastColonIndex > 1 {
+			// if the drive letter colon is present correctly cuts the filename out
+			if path[1] == ':' {
+				// capture the drive letter with the [:2]. We cannot use the lastColonIndex variable
+				// as the syntax supports two colons at the end - for line and column (:10:5)
+				path = path[:2] + strings.Split(path[2:], ":")[0]
+			} else {
+				// the drive letter is not present, just retrieve the filename
+				path = strings.Split(path, ":")[0]
+			}
+		}
+	} else {
+		if strings.Contains(path, ":") {
+			path = strings.Split(path, ":")[0]
+		}
 	}
 	return path
 }

--- a/cmd/micro/util.go
+++ b/cmd/micro/util.go
@@ -359,7 +359,8 @@ func ReplaceHome(path string) string {
 // GetPath returns a filename without everything following a `:`
 // This is used for opening files like util.go:10:5 to specify a line and column
 func GetPath(path string) string {
-	if strings.Contains(path, ":") {
+	// FIXME -> this breaks the line/column functionality on windows
+	if runtime.GOOS != "windows" && strings.Contains(path, ":") {
 		path = strings.Split(path, ":")[0]
 	}
 	return path

--- a/cmd/micro/util.go
+++ b/cmd/micro/util.go
@@ -12,6 +12,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/mattn/go-runewidth"
+	"regexp"
 )
 
 // Util.go is a collection of utility functions that are used throughout
@@ -356,50 +357,43 @@ func ReplaceHome(path string) string {
 	return strings.Replace(path, homeString, home, 1)
 }
 
-// GetPath returns a filename without everything following a `:`
+// GetPathAndCursorPosition returns a filename without everything following a `:`
 // This is used for opening files like util.go:10:5 to specify a line and column
-func GetPath(path string) (string, []string) {
-	// so what's possible
-	// -> Relative file no dot (any OS): myfile:10:5
-	// -> Relative file (any OS): ./myfile:10:5
-	// -> Absolute file (Windows): W:/myfile:10:5
-	// -> Absolute file (Unix): /home/dtasev/myfile:10:5
-	// naive => string[1] == :
-	//		- fails when filename is length of 1 -> file "f" => f:5
+// Special cases like Windows Absolute path (C:\myfile.txt:10:5) are handled correctly.
+func GetPathAndCursorPosition(path string) (string, []string) {
+	re := regexp.MustCompile(`([\s\S]+?)(?::(\d+))(?::(\d+))?`)
+	match := re.FindStringSubmatch(path)
+	// no lines/columns were specified in the path, return just the path with cursor at 0, 0
+	if len(match) == 0 {
+		return path, []string{"0", "0"}
+	} else if match[len(match)-1] != "" {
+		// if the last capture group match isn't empty then both line and column were provided
+		return match[1], match[2:]
+	}
+	// if it was empty, then only a line was provided, so default to column 0
+	return match[1], []string{match[2], "0"}
+}
 
-	var cursorPosition []string
-	// TODO maybe make easier with strings.Count(path, ":") or maybe not
-	if strings.Contains(path, ":") {
-		// if current OS is Windows and the absolute path is provided this will be a string of the type C:\dir\files...
-		// if the user has passed a line/column then the last index of the colon will NOT be at position ^ after the drive
-		var driveLetter = ""
-		var pathSplit []string
-		if runtime.GOOS == "windows" {
-			// TODO handle single letter file later
-			lastColonIndex := strings.LastIndex(path, ":")
+func ParseCursorLocation(cursorPositions []string) (Loc, error) {
+	startpos := Loc{0, 0}
+	var err error
 
-			// if the colon index is after the position of the drive letter,
-			// that it is possible that there is more than one colon
-			if lastColonIndex > 1 {
-				// if the drive letter colon is present correctly cuts the filename out
-				if path[1] == ':' {
-					// capture the drive letter with the [:2]. We cannot use the lastColonIndex variable
-					// as the syntax supports two colons at the end - for line and column (:10:5)
-					driveLetter = path[:2]
-					pathSplit = strings.Split(path[2:], ":")
-				} else {
-					// the drive letter is not present, just retrieve the filename
-					pathSplit = strings.Split(path, ":")
-				}
-			}
-		} else {
-			pathSplit = strings.Split(path, ":")
-		}
-		path = driveLetter + pathSplit[0]
-		cursorPosition = pathSplit[1:]
-	} else {
-		cursorPosition = []string{"0", "0"}
+	// if no positions are available exit early
+	if len(cursorPositions) == 0 {
+		return startpos, err
 	}
 
-	return path, cursorPosition
+	startpos.Y, err = strconv.Atoi(cursorPositions[0])
+	if err != nil {
+		messenger.Error("Error parsing cursor position: ", err)
+	} else {
+		if len(cursorPositions) > 1 {
+			startpos.X, err = strconv.Atoi(cursorPositions[1])
+			if err != nil {
+				messenger.Error("Error parsing cursor position: ", err)
+			}
+		}
+	}
+
+	return startpos, err
 }

--- a/cmd/micro/util.go
+++ b/cmd/micro/util.go
@@ -358,8 +358,7 @@ func ReplaceHome(path string) string {
 
 // GetPath returns a filename without everything following a `:`
 // This is used for opening files like util.go:10:5 to specify a line and column
-func GetPath(path string) string {
-	// FIXME -> this breaks the line/column functionality on windows
+func GetPath(path string) (string, []string) {
 	// so what's possible
 	// -> Relative file no dot (any OS): myfile:10:5
 	// -> Relative file (any OS): ./myfile:10:5
@@ -368,30 +367,39 @@ func GetPath(path string) string {
 	// naive => string[1] == :
 	//		- fails when filename is length of 1 -> file "f" => f:5
 
-	// if current OS is Windows and the absolute path is provided this will be a string of the type C:\dir\files...
-	// if the user has passed a line/column then the last index of the colon will NOT be at position ^ after the drive
-	// letter, but somewhere else. The exception is a single letter file
-	if runtime.GOOS == "windows" {
-		// TODO handle single letter file later
-		lastColonIndex := strings.LastIndex(path, ":")
+	var cursorPosition []string
+	// TODO maybe make easier with strings.Count(path, ":") or maybe not
+	if strings.Contains(path, ":") {
+		// if current OS is Windows and the absolute path is provided this will be a string of the type C:\dir\files...
+		// if the user has passed a line/column then the last index of the colon will NOT be at position ^ after the drive
+		var driveLetter = ""
+		var pathSplit []string
+		if runtime.GOOS == "windows" {
+			// TODO handle single letter file later
+			lastColonIndex := strings.LastIndex(path, ":")
 
-		// if the colon index is after the position of the drive letter,
-		// that it is possible that there is more than one colon
-		if lastColonIndex > 1 {
-			// if the drive letter colon is present correctly cuts the filename out
-			if path[1] == ':' {
-				// capture the drive letter with the [:2]. We cannot use the lastColonIndex variable
-				// as the syntax supports two colons at the end - for line and column (:10:5)
-				path = path[:2] + strings.Split(path[2:], ":")[0]
-			} else {
-				// the drive letter is not present, just retrieve the filename
-				path = strings.Split(path, ":")[0]
+			// if the colon index is after the position of the drive letter,
+			// that it is possible that there is more than one colon
+			if lastColonIndex > 1 {
+				// if the drive letter colon is present correctly cuts the filename out
+				if path[1] == ':' {
+					// capture the drive letter with the [:2]. We cannot use the lastColonIndex variable
+					// as the syntax supports two colons at the end - for line and column (:10:5)
+					driveLetter = path[:2]
+					pathSplit = strings.Split(path[2:], ":")
+				} else {
+					// the drive letter is not present, just retrieve the filename
+					pathSplit = strings.Split(path, ":")
+				}
 			}
+		} else {
+			pathSplit = strings.Split(path, ":")
 		}
+		path = driveLetter + pathSplit[0]
+		cursorPosition = pathSplit[1:]
 	} else {
-		if strings.Contains(path, ":") {
-			path = strings.Split(path, ":")[0]
-		}
+		cursorPosition = []string{"0", "0"}
 	}
-	return path
+
+	return path, cursorPosition
 }

--- a/cmd/micro/util_test.go
+++ b/cmd/micro/util_test.go
@@ -106,7 +106,13 @@ func TestWidthOfLargeRunes(t *testing.T) {
 
 func assertEqual(t *testing.T, expected interface{}, result interface{}) {
 	if expected != result {
-		t.Fatalf("Expected: %s != Got: %s", expected, result)
+		t.Fatalf("Expected: %d != Got: %d", expected, result)
+	}
+}
+
+func assertTrue(t *testing.T, condition bool) {
+	if !condition {
+		t.Fatalf("Condition was not true. Got false")
 	}
 }
 
@@ -293,4 +299,43 @@ func TestGetPathAbsoluteUnixOnlyLine(t *testing.T) {
 	assertEqual(t, path, "/home/user/myfile")
 	assertEqual(t, "10", cursorPosition[0])
 	assertEqual(t, "0", cursorPosition[1])
+}
+func TestParseCursorLocationOneArg(t *testing.T) {
+	location, err := ParseCursorLocation([]string{"3"})
+
+	assertEqual(t, 3, location.Y)
+	assertEqual(t, 0, location.X)
+	assertEqual(t, nil, err)
+}
+func TestParseCursorLocationTwoArgs(t *testing.T) {
+	location, err := ParseCursorLocation([]string{"3", "15"})
+
+	assertEqual(t, 3, location.Y)
+	assertEqual(t, 15, location.X)
+	assertEqual(t, nil, err)
+}
+func TestParseCursorLocationNoArgs(t *testing.T) {
+	location, err := ParseCursorLocation([]string{})
+	// the expected result is the start position - 0, 0
+	assertEqual(t, 0, location.Y)
+	assertEqual(t, 0, location.X)
+	assertEqual(t, nil, err)
+}
+func TestParseCursorLocationFirstArgNotValidNumber(t *testing.T) {
+	// the messenger is necessary as ParseCursorLocation
+	// puts a message in it on error
+	messenger = new(Messenger)
+	_, err := ParseCursorLocation([]string{"apples", "1"})
+	// the expected result is the start position - 0, 0
+	assertTrue(t, messenger.hasMessage)
+	assertTrue(t, err != nil)
+}
+func TestParseCursorLocationSecondArgNotValidNumber(t *testing.T) {
+	// the messenger is necessary as ParseCursorLocation
+	// puts a message in it on error
+	messenger = new(Messenger)
+	_, err := ParseCursorLocation([]string{"1", "apples"})
+	// the expected result is the start position - 0, 0
+	assertTrue(t, messenger.hasMessage)
+	assertTrue(t, err != nil)
 }

--- a/cmd/micro/util_test.go
+++ b/cmd/micro/util_test.go
@@ -103,3 +103,194 @@ func TestWidthOfLargeRunes(t *testing.T) {
 		t.Error("WidthOfLargeRunes 5 Failed. Got", w)
 	}
 }
+
+func assertEqual(t *testing.T, expected interface{}, result interface{}) {
+	if expected != result {
+		t.Fatalf("Expected: %s != Got: %s", expected, result)
+	}
+}
+
+func TestGetPathRelativeWithDot(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition("./myfile:10:5")
+
+	assertEqual(t, path, "./myfile")
+	assertEqual(t, "10", cursorPosition[0])
+	assertEqual(t, "5", cursorPosition[1])
+}
+func TestGetPathRelativeWithDotWindows(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition(".\\myfile:10:5")
+
+	assertEqual(t, path, ".\\myfile")
+	assertEqual(t, "10", cursorPosition[0])
+	assertEqual(t, cursorPosition[1], "5")
+}
+func TestGetPathRelativeNoDot(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition("myfile:10:5")
+
+	assertEqual(t, path, "myfile")
+	assertEqual(t, "10", cursorPosition[0])
+
+	assertEqual(t, cursorPosition[1], "5")
+}
+func TestGetPathAbsoluteWindows(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition("C:\\myfile:10:5")
+
+	assertEqual(t, path, "C:\\myfile")
+	assertEqual(t, "10", cursorPosition[0])
+
+	assertEqual(t, cursorPosition[1], "5")
+
+	path, cursorPosition = GetPathAndCursorPosition("C:/myfile:10:5")
+
+	assertEqual(t, path, "C:/myfile")
+	assertEqual(t, "10", cursorPosition[0])
+
+	assertEqual(t, cursorPosition[1], "5")
+}
+func TestGetPathAbsoluteUnix(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition("/home/user/myfile:10:5")
+
+	assertEqual(t, path, "/home/user/myfile")
+	assertEqual(t, "10", cursorPosition[0])
+
+	assertEqual(t, cursorPosition[1], "5")
+}
+
+func TestGetPathRelativeWithDotWithoutLineAndColumn(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition("./myfile")
+
+	assertEqual(t, path, "./myfile")
+	assertEqual(t, "0", cursorPosition[0])
+
+	assertEqual(t, "0", cursorPosition[1])
+}
+func TestGetPathRelativeWithDotWindowsWithoutLineAndColumn(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition(".\\myfile")
+
+	assertEqual(t, path, ".\\myfile")
+	assertEqual(t, "0", cursorPosition[0])
+
+	assertEqual(t, "0", cursorPosition[1])
+}
+func TestGetPathRelativeNoDotWithoutLineAndColumn(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition("myfile")
+
+	assertEqual(t, path, "myfile")
+	assertEqual(t, "0", cursorPosition[0])
+
+	assertEqual(t, "0", cursorPosition[1])
+}
+func TestGetPathAbsoluteWindowsWithoutLineAndColumn(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition("C:\\myfile")
+
+	assertEqual(t, path, "C:\\myfile")
+	assertEqual(t, "0", cursorPosition[0])
+
+	assertEqual(t, "0", cursorPosition[1])
+
+	path, cursorPosition = GetPathAndCursorPosition("C:/myfile")
+
+	assertEqual(t, path, "C:/myfile")
+	assertEqual(t, "0", cursorPosition[0])
+
+	assertEqual(t, "0", cursorPosition[1])
+}
+func TestGetPathAbsoluteUnixWithoutLineAndColumn(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition("/home/user/myfile")
+
+	assertEqual(t, path, "/home/user/myfile")
+	assertEqual(t, "0", cursorPosition[0])
+
+	assertEqual(t, "0", cursorPosition[1])
+}
+func TestGetPathSingleLetterFileRelativePath(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition("a:5:6")
+
+	assertEqual(t, path, "a")
+	assertEqual(t, "5", cursorPosition[0])
+	assertEqual(t, "6", cursorPosition[1])
+}
+func TestGetPathSingleLetterFileAbsolutePathWindows(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition("C:\\a:5:6")
+
+	assertEqual(t, path, "C:\\a")
+	assertEqual(t, "5", cursorPosition[0])
+	assertEqual(t, "6", cursorPosition[1])
+
+	path, cursorPosition = GetPathAndCursorPosition("C:/a:5:6")
+
+	assertEqual(t, path, "C:/a")
+	assertEqual(t, "5", cursorPosition[0])
+	assertEqual(t, "6", cursorPosition[1])
+}
+func TestGetPathSingleLetterFileAbsolutePathUnix(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition("/home/user/a:5:6")
+
+	assertEqual(t, path, "/home/user/a")
+	assertEqual(t, "5", cursorPosition[0])
+	assertEqual(t, "6", cursorPosition[1])
+}
+func TestGetPathSingleLetterFileAbsolutePathWindowsWithoutLineAndColumn(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition("C:\\a")
+
+	assertEqual(t, path, "C:\\a")
+	assertEqual(t, "0", cursorPosition[0])
+
+	assertEqual(t, "0", cursorPosition[1])
+
+	path, cursorPosition = GetPathAndCursorPosition("C:/a")
+
+	assertEqual(t, path, "C:/a")
+	assertEqual(t, "0", cursorPosition[0])
+	assertEqual(t, "0", cursorPosition[1])
+}
+func TestGetPathSingleLetterFileAbsolutePathUnixWithoutLineAndColumn(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition("/home/user/a")
+
+	assertEqual(t, path, "/home/user/a")
+	assertEqual(t, "0", cursorPosition[0])
+	assertEqual(t, "0", cursorPosition[1])
+}
+
+// TODO test for only line without a column
+func TestGetPathRelativeWithDotOnlyLine(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition("./myfile:10")
+
+	assertEqual(t, path, "./myfile")
+	assertEqual(t, "10", cursorPosition[0])
+	assertEqual(t, "0", cursorPosition[1])
+}
+func TestGetPathRelativeWithDotWindowsOnlyLine(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition(".\\myfile:10")
+
+	assertEqual(t, path, ".\\myfile")
+	assertEqual(t, "10", cursorPosition[0])
+	assertEqual(t, "0", cursorPosition[1])
+}
+func TestGetPathRelativeNoDotOnlyLine(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition("myfile:10")
+
+	assertEqual(t, path, "myfile")
+	assertEqual(t, "10", cursorPosition[0])
+	assertEqual(t, "0", cursorPosition[1])
+}
+func TestGetPathAbsoluteWindowsOnlyLine(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition("C:\\myfile:10")
+
+	assertEqual(t, path, "C:\\myfile")
+	assertEqual(t, "10", cursorPosition[0])
+	assertEqual(t, "0", cursorPosition[1])
+
+	path, cursorPosition = GetPathAndCursorPosition("C:/myfile:10")
+
+	assertEqual(t, path, "C:/myfile")
+	assertEqual(t, "10", cursorPosition[0])
+	assertEqual(t, "0", cursorPosition[1])
+}
+func TestGetPathAbsoluteUnixOnlyLine(t *testing.T) {
+	path, cursorPosition := GetPathAndCursorPosition("/home/user/myfile:10")
+
+	assertEqual(t, path, "/home/user/myfile")
+	assertEqual(t, "10", cursorPosition[0])
+	assertEqual(t, "0", cursorPosition[1])
+}


### PR DESCRIPTION
Work that has been done:
- Fixes https://github.com/zyedidia/micro/issues/1122
- Old line/column functionality kept and working with full paths and relative paths
- Tests added for the changed functions