### PR TITLE
Fix -startpos flag being ignored

### DIFF
--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -234,8 +234,8 @@ func GetBufferCursorLocation(cursorPosition []string, b *Buffer) (Loc, error) {
 		}
 
 		// if some arguments were found make sure they don't go outside the file and cause overflows
+		cursorLocation.Y = lineNum
 		cursorLocation.X = colNum
-		cursorLocation.Y = lineNum - 1
 		// Check to avoid line overflow
 		if cursorLocation.Y > b.NumLines-1 {
 			cursorLocation.Y = b.NumLines - 1

--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -227,7 +227,7 @@ func GetBufferCursorLocation(cursorPosition []string, b *Buffer) (Loc, error) {
 		}
 		// if -startpos has invalid arguments, use the arguments from filename.
 		// This will have a default value (0, 0) even when the filename arguments are invalid
-		if errPos1 != nil || errPos2 != nil {
+		if errPos1 != nil || errPos2 != nil || len(*flagStartPos) == 0 {
 			// otherwise check if there are any arguments after the filename and use them
 			lineNum = cursorLocation.Y
 			colNum = cursorLocation.X

--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -224,28 +224,29 @@ func GetBufferCursorLocation(cursorPosition []string, b *Buffer) (Loc, error) {
 		if len(positions) == 2 {
 			lineNum, errPos1 = strconv.Atoi(positions[0])
 			colNum, errPos2 = strconv.Atoi(positions[1])
-		} else if cursorLocationError == nil {
+		}
+		// if -startpos has invalid arguments, use the arguments from filename.
+		// This will have a default value (0, 0) even when the filename arguments are invalid
+		if errPos1 != nil || errPos2 != nil {
 			// otherwise check if there are any arguments after the filename and use them
 			lineNum = cursorLocation.Y
 			colNum = cursorLocation.X
 		}
 
 		// if some arguments were found make sure they don't go outside the file and cause overflows
-		if errPos1 == nil && errPos2 == nil {
-			cursorLocation.X = colNum
-			cursorLocation.Y = lineNum - 1
-			// Check to avoid line overflow
-			if cursorLocation.Y > b.NumLines - 1 {
-				cursorLocation.Y = b.NumLines - 1
-			} else if cursorLocation.Y < 0 {
-				cursorLocation.Y = 0
-			}
-			// Check to avoid column overflow
-			if cursorLocation.X > len(b.Line(cursorLocation.Y)) {
-				cursorLocation.X = len(b.Line(cursorLocation.Y))
-			} else if cursorLocation.X < 0 {
-				cursorLocation.X = 0
-			}
+		cursorLocation.X = colNum
+		cursorLocation.Y = lineNum - 1
+		// Check to avoid line overflow
+		if cursorLocation.Y > b.NumLines-1 {
+			cursorLocation.Y = b.NumLines - 1
+		} else if cursorLocation.Y < 0 {
+			cursorLocation.Y = 0
+		}
+		// Check to avoid column overflow
+		if cursorLocation.X > len(b.Line(cursorLocation.Y)) {
+			cursorLocation.X = len(b.Line(cursorLocation.Y))
+		} else if cursorLocation.X < 0 {
+			cursorLocation.X = 0
 		}
 	}
 	return cursorLocation, cursorLocationError

--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -234,7 +234,7 @@ func GetBufferCursorLocation(cursorPosition []string, b *Buffer) (Loc, error) {
 		}
 
 		// if some arguments were found make sure they don't go outside the file and cause overflows
-		cursorLocation.Y = lineNum
+		cursorLocation.Y = lineNum - 1
 		cursorLocation.X = colNum
 		// Check to avoid line overflow
 		if cursorLocation.Y > b.NumLines-1 {

--- a/cmd/micro/buffer_test.go
+++ b/cmd/micro/buffer_test.go
@@ -1,0 +1,1 @@
+package main

--- a/cmd/micro/buffer_test.go
+++ b/cmd/micro/buffer_test.go
@@ -1,1 +1,114 @@
 package main
+
+import (
+	"testing"
+)
+
+func TestGetBufferCursorLocationEmptyArgs(t *testing.T) {
+	buf := NewBufferFromString("this is my\nbuffer\nfile\nhello", "")
+
+	location, err := GetBufferCursorLocation(nil, buf)
+
+	assertEqual(t, 0, location.Y)
+	assertEqual(t, 0, location.X)
+
+	// an error is present due to the cursorLocation being nil
+	assertTrue(t, err != nil)
+
+}
+
+func TestGetBufferCursorLocationStartposFlag(t *testing.T) {
+	buf := NewBufferFromString("this is my\nbuffer\nfile\nhello", "")
+
+	*flagStartPos = "1,2"
+
+	location, err := GetBufferCursorLocation(nil, buf)
+
+	assertTrue(t, 1 == location.Y)
+	assertTrue(t, 2 == location.X)
+
+	// an error is present due to the cursorLocation being nil
+	assertTrue(t, err != nil)
+}
+
+func TestGetBufferCursorLocationInvalidStartposFlag(t *testing.T) {
+	buf := NewBufferFromString("this is my\nbuffer\nfile\nhello", "")
+
+	*flagStartPos = "apples,2"
+
+	location, err := GetBufferCursorLocation(nil, buf)
+	// expect to default to the start of the file, which is 0,0
+	assertEqual(t, 0, location.Y)
+	assertEqual(t, 0, location.X)
+
+	// an error is present due to the cursorLocation being nil
+	assertTrue(t, err != nil)
+}
+func TestGetBufferCursorLocationStartposFlagAndCursorPosition(t *testing.T) {
+	text := "this is my\nbuffer\nfile\nhello"
+	cursorPosition := []string{"3", "1"}
+
+	buf := NewBufferFromString(text, "")
+
+	*flagStartPos = "1,2"
+
+	location, err := GetBufferCursorLocation(cursorPosition, buf)
+	// expect to have the flag positions, not the cursor position
+	assertEqual(t, 1, location.Y)
+	assertEqual(t, 2, location.X)
+
+	assertTrue(t, err == nil)
+}
+func TestGetBufferCursorLocationCursorPositionAndInvalidStartposFlag(t *testing.T) {
+	text := "this is my\nbuffer\nfile\nhello"
+	cursorPosition := []string{"3", "1"}
+
+	buf := NewBufferFromString(text, "")
+
+	*flagStartPos = "apples,2"
+
+	location, err := GetBufferCursorLocation(cursorPosition, buf)
+	// expect to have the flag positions, not the cursor position
+	assertEqual(t, 3, location.Y)
+	assertEqual(t, 1, location.X)
+
+	// no errors this time as cursorPosition is not nil
+	assertTrue(t, err == nil)
+}
+
+func TestGetBufferCursorLocationNoErrorWhenOverflowWithStartpos(t *testing.T) {
+	text := "this is my\nbuffer\nfile\nhello"
+
+	buf := NewBufferFromString(text, "")
+
+	*flagStartPos = "50,50"
+
+	location, err := GetBufferCursorLocation(nil, buf)
+	// expect to have the flag positions, not the cursor position
+	assertEqual(t, buf.NumLines-1, location.Y)
+	assertEqual(t, 5, location.X)
+
+	// error is expected as cursorPosition is nil
+	assertTrue(t, err != nil)
+}
+func TestGetBufferCursorLocationNoErrorWhenOverflowWithCursorPosition(t *testing.T) {
+	text := "this is my\nbuffer\nfile\nhello"
+	cursorPosition := []string{"50", "2"}
+
+	*flagStartPos = ""
+
+	buf := NewBufferFromString(text, "")
+
+	location, err := GetBufferCursorLocation(cursorPosition, buf)
+	// expect to have the flag positions, not the cursor position
+	assertEqual(t, buf.NumLines-1, location.Y)
+	assertEqual(t, 2, location.X)
+
+	// error is expected as cursorPosition is nil
+	assertTrue(t, err == nil)
+}
+
+//func TestGetBufferCursorLocationColonArgs(t *testing.T) {
+//	buf := new(Buffer)
+
+//}

--- a/cmd/micro/buffer_test.go
+++ b/cmd/micro/buffer_test.go
@@ -24,7 +24,8 @@ func TestGetBufferCursorLocationStartposFlag(t *testing.T) {
 
 	location, err := GetBufferCursorLocation(nil, buf)
 
-	assertTrue(t, 1 == location.Y)
+	// note: 1 is subtracted from the line to get the correct index in the buffer
+	assertTrue(t, 0 == location.Y)
 	assertTrue(t, 2 == location.X)
 
 	// an error is present due to the cursorLocation being nil
@@ -54,7 +55,8 @@ func TestGetBufferCursorLocationStartposFlagAndCursorPosition(t *testing.T) {
 
 	location, err := GetBufferCursorLocation(cursorPosition, buf)
 	// expect to have the flag positions, not the cursor position
-	assertEqual(t, 1, location.Y)
+	// note: 1 is subtracted from the line to get the correct index in the buffer
+	assertEqual(t, 0, location.Y)
 	assertEqual(t, 2, location.X)
 
 	assertTrue(t, err == nil)
@@ -69,7 +71,8 @@ func TestGetBufferCursorLocationCursorPositionAndInvalidStartposFlag(t *testing.
 
 	location, err := GetBufferCursorLocation(cursorPosition, buf)
 	// expect to have the flag positions, not the cursor position
-	assertEqual(t, 3, location.Y)
+	// note: 1 is subtracted from the line to get the correct index in the buffer
+	assertEqual(t, 2, location.Y)
 	assertEqual(t, 1, location.X)
 
 	// no errors this time as cursorPosition is not nil

--- a/cmd/micro/util.go
+++ b/cmd/micro/util.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mattn/go-runewidth"
 	"regexp"
+	"github.com/go-errors/errors"
 )
 
 // Util.go is a collection of utility functions that are used throughout
@@ -363,9 +364,9 @@ func ReplaceHome(path string) string {
 func GetPathAndCursorPosition(path string) (string, []string) {
 	re := regexp.MustCompile(`([\s\S]+?)(?::(\d+))(?::(\d+))?`)
 	match := re.FindStringSubmatch(path)
-	// no lines/columns were specified in the path, return just the path with cursor at 0, 0
+	// no lines/columns were specified in the path, return just the path with no cursor location
 	if len(match) == 0 {
-		return path, []string{"0", "0"}
+		return path, nil
 	} else if match[len(match)-1] != "" {
 		// if the last capture group match isn't empty then both line and column were provided
 		return match[1], match[2:]
@@ -379,8 +380,8 @@ func ParseCursorLocation(cursorPositions []string) (Loc, error) {
 	var err error
 
 	// if no positions are available exit early
-	if len(cursorPositions) == 0 {
-		return startpos, err
+	if cursorPositions == nil {
+		return startpos, errors.New("No cursor positions were provided.")
 	}
 
 	startpos.Y, err = strconv.Atoi(cursorPositions[0])

--- a/cmd/micro/util_test.go
+++ b/cmd/micro/util_test.go
@@ -106,7 +106,7 @@ func TestWidthOfLargeRunes(t *testing.T) {
 
 func assertEqual(t *testing.T, expected interface{}, result interface{}) {
 	if expected != result {
-		t.Fatalf("Expected: %s != Got: %s", expected, result)
+		t.Fatalf("Expected: %d != Got: %d", expected, result)
 	}
 }
 

--- a/cmd/micro/util_test.go
+++ b/cmd/micro/util_test.go
@@ -106,7 +106,7 @@ func TestWidthOfLargeRunes(t *testing.T) {
 
 func assertEqual(t *testing.T, expected interface{}, result interface{}) {
 	if expected != result {
-		t.Fatalf("Expected: %d != Got: %d", expected, result)
+		t.Fatalf("Expected: %s != Got: %s", expected, result)
 	}
 }
 
@@ -150,64 +150,56 @@ func TestGetPathAbsoluteWindows(t *testing.T) {
 
 	assertEqual(t, path, "C:/myfile")
 	assertEqual(t, "10", cursorPosition[0])
-
-	assertEqual(t, cursorPosition[1], "5")
+	assertEqual(t, "5", cursorPosition[1])
 }
+
 func TestGetPathAbsoluteUnix(t *testing.T) {
 	path, cursorPosition := GetPathAndCursorPosition("/home/user/myfile:10:5")
 
 	assertEqual(t, path, "/home/user/myfile")
 	assertEqual(t, "10", cursorPosition[0])
-
-	assertEqual(t, cursorPosition[1], "5")
+	assertEqual(t, "5", cursorPosition[1])
 }
 
 func TestGetPathRelativeWithDotWithoutLineAndColumn(t *testing.T) {
 	path, cursorPosition := GetPathAndCursorPosition("./myfile")
 
 	assertEqual(t, path, "./myfile")
-	assertEqual(t, "0", cursorPosition[0])
-
-	assertEqual(t, "0", cursorPosition[1])
+	// no cursor position in filename, nil should be returned
+	assertTrue(t, cursorPosition == nil)
 }
 func TestGetPathRelativeWithDotWindowsWithoutLineAndColumn(t *testing.T) {
 	path, cursorPosition := GetPathAndCursorPosition(".\\myfile")
 
 	assertEqual(t, path, ".\\myfile")
-	assertEqual(t, "0", cursorPosition[0])
+	assertTrue(t, cursorPosition == nil)
 
-	assertEqual(t, "0", cursorPosition[1])
 }
 func TestGetPathRelativeNoDotWithoutLineAndColumn(t *testing.T) {
 	path, cursorPosition := GetPathAndCursorPosition("myfile")
 
 	assertEqual(t, path, "myfile")
-	assertEqual(t, "0", cursorPosition[0])
+	assertTrue(t, cursorPosition == nil)
 
-	assertEqual(t, "0", cursorPosition[1])
 }
 func TestGetPathAbsoluteWindowsWithoutLineAndColumn(t *testing.T) {
 	path, cursorPosition := GetPathAndCursorPosition("C:\\myfile")
 
 	assertEqual(t, path, "C:\\myfile")
-	assertEqual(t, "0", cursorPosition[0])
-
-	assertEqual(t, "0", cursorPosition[1])
+	assertTrue(t, cursorPosition == nil)
 
 	path, cursorPosition = GetPathAndCursorPosition("C:/myfile")
 
 	assertEqual(t, path, "C:/myfile")
-	assertEqual(t, "0", cursorPosition[0])
+	assertTrue(t, cursorPosition == nil)
 
-	assertEqual(t, "0", cursorPosition[1])
 }
 func TestGetPathAbsoluteUnixWithoutLineAndColumn(t *testing.T) {
 	path, cursorPosition := GetPathAndCursorPosition("/home/user/myfile")
 
 	assertEqual(t, path, "/home/user/myfile")
-	assertEqual(t, "0", cursorPosition[0])
+	assertTrue(t, cursorPosition == nil)
 
-	assertEqual(t, "0", cursorPosition[1])
 }
 func TestGetPathSingleLetterFileRelativePath(t *testing.T) {
 	path, cursorPosition := GetPathAndCursorPosition("a:5:6")
@@ -240,25 +232,22 @@ func TestGetPathSingleLetterFileAbsolutePathWindowsWithoutLineAndColumn(t *testi
 	path, cursorPosition := GetPathAndCursorPosition("C:\\a")
 
 	assertEqual(t, path, "C:\\a")
-	assertEqual(t, "0", cursorPosition[0])
-
-	assertEqual(t, "0", cursorPosition[1])
+	assertTrue(t, cursorPosition == nil)
 
 	path, cursorPosition = GetPathAndCursorPosition("C:/a")
 
 	assertEqual(t, path, "C:/a")
-	assertEqual(t, "0", cursorPosition[0])
-	assertEqual(t, "0", cursorPosition[1])
+	assertTrue(t, cursorPosition == nil)
+
 }
 func TestGetPathSingleLetterFileAbsolutePathUnixWithoutLineAndColumn(t *testing.T) {
 	path, cursorPosition := GetPathAndCursorPosition("/home/user/a")
 
 	assertEqual(t, path, "/home/user/a")
-	assertEqual(t, "0", cursorPosition[0])
-	assertEqual(t, "0", cursorPosition[1])
+	assertTrue(t, cursorPosition == nil)
+
 }
 
-// TODO test for only line without a column
 func TestGetPathRelativeWithDotOnlyLine(t *testing.T) {
 	path, cursorPosition := GetPathAndCursorPosition("./myfile:10")
 
@@ -315,11 +304,12 @@ func TestParseCursorLocationTwoArgs(t *testing.T) {
 	assertEqual(t, nil, err)
 }
 func TestParseCursorLocationNoArgs(t *testing.T) {
-	location, err := ParseCursorLocation([]string{})
+	location, err := ParseCursorLocation(nil)
 	// the expected result is the start position - 0, 0
 	assertEqual(t, 0, location.Y)
 	assertEqual(t, 0, location.X)
-	assertEqual(t, nil, err)
+	// an error will be present here as the positions we're parsing are a nil
+	assertTrue(t, err != nil)
 }
 func TestParseCursorLocationFirstArgNotValidNumber(t *testing.T) {
 	// the messenger is necessary as ParseCursorLocation


### PR DESCRIPTION
Fixes #1128, `-startpos` functionality now works again with the previous changes.

Refactored cursor position logic into a function in `buffer.go`.
Added tests for the cursor position logic in `buffer_test.go`.

The `-startpos` flag is considered first, and if any arguments are present, any arguments passed in with the colons after the filename will be ignored.

Passing invalid argument to `-startpos` will cause micro to ignore the flag. It will then try to read colon line/col arguments. If they are not present, it will default to location `0,0`

Example:
`micro -startpos 30:40 myfile:13:20`
- `13:20` is ignored, cursor will be on line 30, column 40

`micro -startpos apples:40 myfile:13:20`
- `apples:40` is ignored, cursor will be on line 13, column 20

Other fixes:
- Fixed crash when the line number passed equals the number of lines. This would cause the buffer to overflow [here](https://github.com/zyedidia/micro/pull/1129/commits/c36bc19dcebf05ba25bb86bbc2081697a917f2fe#diff-b8b391849d86928ed02420e69283f150L179). Fixed by [checking against lines - 1](https://github.com/zyedidia/micro/pull/1129/commits/c36bc19dcebf05ba25bb86bbc2081697a917f2fe#diff-b8b391849d86928ed02420e69283f150R238). To replicate bug load a file and pass cursor argument so that the cursor is on the last line. E.g. `micro LICENSE:24` (using LICENSE file from download). Or `micro -startpos 24,1 LICENSE`