### PR TITLE
Added syntax highlighting for ATS

### DIFF
--- a/runtime/syntax/ats.yaml
+++ b/runtime/syntax/ats.yaml
@@ -1,0 +1,109 @@
+filetype: ATS
+
+detect:
+    filename: "\\.(d|h|s)ats$"
+
+rules:
+    - default: \b[[:alnum:]]+[^0-9A-Za-z]
+
+    # Some C macros and other ATS macros
+    - preproc: ^[[:space:]]*#[[:space:]]*(define|pragma|include|(un|ifn?)def|endif|el(if|se)|if|warning|error|assert)\b
+    - preproc: ^[[:space:]]*#[[:space:]]*(codegen2|codegen3|elifdef|elifndef|prerr|print|require|then|staload|dynload)\b
+
+    # Operators
+    - symbol.operator: "[.:;+`|~<>?='\\&]|/|%|-|,|!|\\*"
+    - symbol.operator: \^
+
+    # Types, abstract types and some predefined sorts
+    - type: \b(addr|age?z|bool|char|cls|schar|uchar|double|eff|exn|float|int(ptr)?|lincloptr|uint)\b
+    - type: \b(lint|ulint|llint|ullint|nat|prop|ptr|prf|real|ref|size_t|ssize_t|sint|usint|string|tkind|viewt|view|v?t0p|vt|void)\b
+    - type: \b(fun[01]|cloptr(0|1)?|cloref(0|1)?|clo(0|1)?)\b
+    - type: \b(prop[+-]|t[@0]ype[+-]?|type[+-]?|viewt[@0]ype[+-]?|viewtype[+-]?|vt[@0]ype[+-]?|vtype[+-]?|view[+-]w)
+
+    # Statements
+    - statement: \b(abstype|abst|absprop|absviewt|absvt(ype)?|absview|and|andalso|as|(re)?assume|begin|(pr)?csase|s?case)\b
+    - statement: \b(classdec|dataprop|data(v|view)?type|dataview|datasort|else|end|exception|extype|extvar|s?if)\b
+    - statement: \b(ifcase|for|in|infix(l|r)?|let|local|macrodef|macdef|not|of|op|or|orelse|overload|(pre|post|non)fix)\b
+    - statement: \b(propdef|rec|sortdef|stacst|stadef|stavar|sta|symelim|symintr|tkindef|then|try|viewdef|v?typedef)\b
+    - statement: \b(viewtypedef|(pr)?va(l|r)|when|where|while|with|withtype|withprop|withv(iew)?type|withview)\b
+    - statement: \b(abst[@0]ype|absviewt[@0]ype|absviewtype|absvt[@0]ype)\b
+    - statement: \b(import|staload|dynload)\b
+    - statement: \b(case[+-]|(pr)?va(l|r)[+-]|for\*|while\*)
+    # Added in ATS2 0.3.11
+    - statement: \b(abstbox|abstflat|absvtbox|absvtflat)\b
+    - statement: \b(absimpl|absreimpl)\b
+
+    # Numbers
+    - constant.number: (\b[0-9]+\b|\b0(x|b)[0-9A-Fa-f]+\b)
+    - constant.number: \b[0-9]+(u|U|l|L|ul|UL|f|F|b|B)?\b
+
+    # Function-related keywords, special functions and namespaces. Not really identifiers
+    - identifier: \b(fix|(pr)?fu?n|fnx|castfn|praxi|extern|lam|llam|(pr)?implement|(pr)?implmnt)\b
+    - identifier: \b(fix@|fold@|free@|lam@|llam@|addr@|view@|ref@)
+    - identifier: \b(fn\*)
+    - identifier: \$\w*\b
+
+    # Other keywords, function effects...
+    - special: (\$(arrpsz|arrptrsize|break|continue|d2ctype|delay|effmask_(ntm|exn|ref|wrt|all)))\b
+    - special: (\$(effmask|extern|extype_struct|extype|extkind|extval|extfcall|extmcall|ldelay|literal))\b
+    - special: (\$(li?st_vt|li?st_t|li?st|myfilename|myfunction|mylocation|raise|rec(ord)?_vt))\b
+    - special: (\$(rec(ord)?_t|rec(ord)?|(r|l)par|sep|showtype|solver_assert|solver_verify|tempenver))\b
+    - special: (\$(tup(le)?_vt|tup(le)?_t|tup(le)?|tyrep|vararg|vcopyenv_vt|vcopyenv_v))\b
+    - special: \!(wrt|exnref|exnwrt|exn|refwrt|ref|all|ntm|laz)\b
+    - special: \b(f?print(ln)?!|prerrln!)
+
+    # Boolean values
+    - constant.bool: \b(true|false|null)\b
+
+
+    # The "%{ ... %}" block inserts foreign code into ATS at compile-time
+    # Code inside it is generally C or JavaScript
+    - default:
+        start: "%{[#^$]?"
+        end: "%}"
+        skip: "\\."
+        limit-group: symbol.operator
+        rules:
+            - include: "c"
+            - include: "javascript"
+
+
+    # Strings and chars
+    - constant.string:
+        start: \"
+        end: \"
+        skip: \\.
+        rules:
+            - constant.specialChar: \\.
+
+    - constant.char: ('\\?.')
+
+
+    # Comments
+
+    # "////" comments everything until EOF
+    - comment.block:
+        start: ////
+        end: (m)$
+        rules:
+            - todo: (TODO|XXX|FIXME)
+
+    - comment.line:
+        start: //
+        end: $
+        rules:
+            - todo: (TODO|XXX|FIXME)
+
+    # ML-like block comment
+    - comment.block:
+        start: \(\*
+        end: \*\)
+        rules:
+            - todo: (TODO|XXX|FIXME)
+
+    # C-like block comment
+    - comment.block:
+        start: /\*
+        end: \*\/
+        rules:
+            - todo: (TODO|XXX|FIXME)

--- a/runtime/syntax/ats.yaml
+++ b/runtime/syntax/ats.yaml
@@ -11,14 +11,14 @@ rules:
     - preproc: ^[[:space:]]*#[[:space:]]*(codegen2|codegen3|elifdef|elifndef|prerr|print|require|then|staload|dynload)\b
 
     # Operators
-    - symbol.operator: "[.:;+`|~<>?='\\&]|/|%|-|,|!|\\*"
+    - symbol.operator: "[.:;+`|~<>?='\\&]|/|%|-|,|!|\\*|@|\\#"
     - symbol.operator: \^
 
     # Types, abstract types and some predefined sorts
     - type: \b(addr|age?z|bool|char|cls|schar|uchar|double|eff|exn|float|int(ptr)?|lincloptr|uint)\b
     - type: \b(lint|ulint|llint|ullint|nat|prop|ptr|prf|real|ref|size_t|ssize_t|sint|usint|string|tkind|viewt|view|v?t0p|vt|void)\b
     - type: \b(fun[01]|cloptr(0|1)?|cloref(0|1)?|clo(0|1)?)\b
-    - type: \b(prop[+-]|t[@0]ype[+-]?|type[+-]?|viewt[@0]ype[+-]?|viewtype[+-]?|vt[@0]ype[+-]?|vtype[+-]?|view[+-]w)
+    - type: \b(prop[+-]|t[@0]ype[+-]?|type[+-]?|viewt[@0]ype[+-]?|viewtype[+-]?|vt[@0]ype[+-]?|vtype[+-]?|view[+-]?)
 
     # Statements
     - statement: \b(abstype|abst|absprop|absviewt|absvt(ype)?|absview|and|andalso|as|(re)?assume|begin|(pr)?csase|s?case)\b

--- a/runtime/syntax/ats.yaml
+++ b/runtime/syntax/ats.yaml
@@ -84,7 +84,7 @@ rules:
     # "////" comments everything until EOF
     - comment.block:
         start: ////
-        end: (m)$
+        end: $a
         rules:
             - todo: (TODO|XXX|FIXME)
 


### PR DESCRIPTION
Adds support for the ATS programming language (http://www.ats-lang.org).
Note that this syntax is focused on ATS2 (Postiats), but the syntax of the previous versions are somewhat similar.