### PR TITLE
Fix UpN to handle going from long line to short line

### DIFF
--- a/cmd/micro/cursor.go
+++ b/cmd/micro/cursor.go
@@ -255,7 +255,6 @@ func (c *Cursor) RuneUnder(x int) rune {
 	}
 	return line[x]
 }
-
 // UpN moves the cursor up N lines (if possible)
 func (c *Cursor) UpN(amount int) {
 	proposedY := c.Y - amount
@@ -266,9 +265,8 @@ func (c *Cursor) UpN(amount int) {
 		proposedY = c.buf.NumLines - 1
 	}
 
-	runes := []rune(c.buf.Line(c.Y))
+	runes := []rune(c.buf.Line(proposedY))
 	c.X = c.GetCharPosInLine(proposedY, c.LastVisualX)
-
 	if c.X > len(runes) || (amount < 0 && proposedY == c.Y) {
 		c.X = len(runes)
 	}


### PR DESCRIPTION
This makes the cursor position check the target line's length instead of the source line's position which seems like it was the intended functionality.