### PR TITLE
Update sh.yaml to support Ash scripts

### DIFF
--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -1,8 +1,8 @@
 filetype: shell
 
 detect:
-    filename: "(\\.sh$|\\.bash|\\.bashrc|bashrc|\\.bash_aliases|bash_aliases|\\.bash_functions|bash_functions|\\.bash_profile|bash_profile|Pkgfile|pkgmk.conf|profile|rc.conf|PKGBUILD|.ebuild\\$|APKBUILD)"
-    header: "^#!.*/(env +)?(ba)?sh( |$)"
+    filename: "(\\.sh$|\\.bash|\\.ash|\\.bashrc|bashrc|\\.bash_aliases|bash_aliases|\\.bash_functions|bash_functions|\\.bash_profile|bash_profile|\\.profile|profile|Pkgfile|pkgmk.conf|profile|rc.conf|PKGBUILD|.ebuild\\$|APKBUILD)"
+    header: "^#!.*/(env +)?(ba)?(a)?sh( |$)"
 
 rules:
     # Numbers


### PR DESCRIPTION
Enables automatic highlighting of Ash scripts as well as Bash, Sh and Dash scripts.

Updates `runtime/syntax/sh.yaml`:
    * modifies the hashbang detection to also detect `#!/bin/ash`
    * adds `.ash` and  `.profile` extensions

(I've no idea if other changes are required, not tested locally but Travis tests passed)