### PR TITLE
Highlight .tscn, .tres and project.godot files using INI syntax

### DIFF
--- a/runtime/syntax/ini.yaml
+++ b/runtime/syntax/ini.yaml
@@ -1,8 +1,7 @@
 filetype: ini
 
-detect: 
-    filename: "\\.(ini|desktop|lfl|override)$|(mimeapps\\.list|pinforc|setup\\.cfg)$|weechat/.+\\.conf$"
-    header: "^\\[[A-Za-z]+\\]$"
+detect:
+    filename: "\\.(ini|desktop|lfl|override|tscn|tres)$|(mimeapps\\.list|pinforc|setup\\.cfg|project\\.godot)$|weechat/.+\\.conf$"
 
 rules:
     - constant.bool.true: "\\btrue\\b"


### PR DESCRIPTION
This also removes header detection for INI syntax, which could occasionally cause other file types (such as systemd service files) to be detected as INI.