### PR TITLE
Use symbol.operator and symbol.brackets scopes correctly in Python syntax file

### DIFF
--- a/runtime/syntax/python2.yaml
+++ b/runtime/syntax/python2.yaml
@@ -23,9 +23,9 @@ rules:
       # decorators
     - brightgreen: "@.*[(]"
       # operators
-    - statement: "([.:;,+*|=!\\%@]|<|>|/|-|&)"
+    - symbol.operator: "([.:;,+*|=!\\%@]|<|>|/|-|&)"
       # parentheses
-    - statement: "([(){}]|\\[|\\])"
+    - symbol.brackets: "([(){}]|\\[|\\])"
       # numbers
     - constant.number: "\\b[0-9]+\\b"
 

--- a/runtime/syntax/python3.yaml
+++ b/runtime/syntax/python3.yaml
@@ -16,15 +16,15 @@ rules:
       # types
     - type: "\\b(bool|bytearray|bytes|classmethod|complex|dict|enumerate|filter|float|frozenset|int|list|map|memoryview|object|property|range|reversed|set|slice|staticmethod|str|super|tuple|type|zip)\\b"
       # definitions
-    - identifier: "def [a-zA-Z_0-9]+" 
+    - identifier: "def [a-zA-Z_0-9]+"
       # keywords
-    - statement: "\\b(and|as|assert|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|nonlocal|not|or|pass|raise|return|try|while|with|yield)\\b" 
+    - statement: "\\b(and|as|assert|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|nonlocal|not|or|pass|raise|return|try|while|with|yield)\\b"
       # decorators
     - brightgreen: "@.*[(]"
       # operators
-    - statement: "([.:;,+*|=!\\%@]|<|>|/|-|&)"
+    - symbol.operator: "([.:;,+*|=!\\%@]|<|>|/|-|&)"
       # parentheses
-    - statement: "([(){}]|\\[|\\])"
+    - symbol.brackets: "([(){}]|\\[|\\])"
       # numbers
     - constant.number: "\\b[0-9]+\\b"
 


### PR DESCRIPTION
Currently operators and brackets are tagged with `statement`, whereas [other syntax files](https://github.com/zyedidia/micro/blob/de35d00ba7880540074b6ce500bbd1b82e986f61/runtime/syntax/c%2B%2B.yaml#L17-L18) as well as the [documentation](https://github.com/zyedidia/micro/blob/d953339a565abc11a19863cac4b4610fca56bcc7/runtime/help/colors.md#creating-a-colorscheme) say they should be tagged with `symbol.operator` and `symbol.brackets`, respectively.