### PR TITLE
match .edn files

### DIFF
--- a/runtime/syntax/clojure.yaml
+++ b/runtime/syntax/clojure.yaml
@@ -1,7 +1,7 @@
 filetype: clojure
 
 detect:
-    filename: "\\.(clj[sc]?)$"
+    filename: "\\.(clj[sc]?|edn)$"
 
 rules:
 


### PR DESCRIPTION
there was no file/match for edn (Clojure's json) files, so that would solve it.
edn files just use Clojure's literals, so there would be no need for a whole another config file or rules, it just follows the same ones