### PR TITLE
Changed regex for Gentoo etc-portage to include detection of folders

### DIFF
--- a/runtime/syntax/gentoo-etc-portage.yaml
+++ b/runtime/syntax/gentoo-etc-portage.yaml
@@ -1,7 +1,7 @@
 filetype: etc-portage
 
 detect:
-    filename: "\\.(keywords|mask|unmask|use)$"
+    filename: "\\.(keywords|mask|unmask|use)(/.+)?$"
 
 rules:
     # Use flags:


### PR DESCRIPTION
This is the default regex for nano on Gentoo. This allows syntax highlighting of files in etc-portage folders, since the keywords | mask | unmask | use files can also be directories.