### PR TITLE
Python syntax: docstring should be string, not comment

### DIFF
--- a/runtime/syntax/python2.yaml
+++ b/runtime/syntax/python2.yaml
@@ -29,7 +29,7 @@ rules:
       # numbers
     - constant.number: "\\b[0-9]+\\b"
 
-    - comment:
+    - constant.string:
         start: "\"\"\""
         end: "\"\"\""
         rules: []

--- a/runtime/syntax/python3.yaml
+++ b/runtime/syntax/python3.yaml
@@ -28,7 +28,7 @@ rules:
       # numbers
     - constant.number: "\\b[0-9]+\\b"
 
-    - comment:
+    - constant.string:
         start: "\"\"\""
         end: "\"\"\""
         rules: []


### PR DESCRIPTION
In Python, `"""` delimits multiline strings, not comments.