### PR TITLE
Fix for the empty replace issue

### DIFF
--- a/cmd/micro/shellwords/shellwords.go
+++ b/cmd/micro/shellwords/shellwords.go
@@ -65,6 +65,9 @@ loop:
 			if singleQuoted || doubleQuoted || backQuote || dollarQuote {
 				buf += string(r)
 				backtick += string(r)
+			} else if buf == "\"\"" {
+				args = append(args, buf)
+				buf = ""
 			} else if got {
 				buf = replaceEnv(buf)
 				args = append(args, buf)
@@ -117,6 +120,9 @@ loop:
 			}
 		case '"':
 			if !singleQuoted && !dollarQuote {
+				if doubleQuoted && buf == "" {
+					args = append(args, buf)
+				}
 				doubleQuoted = !doubleQuoted
 				continue
 			}


### PR DESCRIPTION
The issue is due to the the way shellword process the input. It was
written to ignore empty quotes.The changes replaces "" with empty string and \"\" with double
quotes ("").

Fixes Issue #1246