### PR TITLE
Update zsh.yaml

### DIFF
--- a/runtime/syntax/zsh.yaml
+++ b/runtime/syntax/zsh.yaml
@@ -46,7 +46,7 @@ rules:
         rules: []
 
     - comment:
-        start: "#"
+        start: "(^|\\s)#"
         end: "$"
         rules: []
 


### PR DESCRIPTION
Copied comment start from sh.yaml so that stuff like `$#` doesn't count as comments