### PR TITLE
Update sh.yaml

### DIFF
--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -20,8 +20,8 @@ rules:
     - statement: "--[a-z-]+"
     - statement: "\\ -[a-z]+"
 
-    - identifier: "\\$\\{?[0-9A-Z_!@#$*?-]+\\}?"
-    - identifier: "\\$\\{?[0-9A-Z_!@#$*?-]+\\}?"
+    - identifier: "\\$\\{?[0-9A-Za-z_!@#$*?-]+\\}?"
+    - identifier: "\\$\\{?[0-9A-Za-z_!@#$*?-]+\\}?"
 
     - constant.string:
         start: "\""


### PR DESCRIPTION
This should fix #1237 by adding back the lowercase characters to the identifier name. I am not sure why it got remove in 54bb99d7580cc1bc76507ce64ff78ef2038c8066. Hopefully, it is not related to any glitch.