### PR TITLE
Update documentation to include Material colorscheme

### DIFF
--- a/runtime/help/colors.md
+++ b/runtime/help/colors.md
@@ -55,6 +55,7 @@ These require terminals that support true color and require `MICRO_TRUECOLOR=1` 
   look its best. Use cmc-16 if your terminal doesn't support true color.
 * `gruvbox-tc`: The true color version of the gruvbox colorscheme
 * `github-tc`: The true color version of the Github colorscheme
+* `material-tc`: Colorscheme based off of Google's Material Design palette
 
 ### Monochrome
 


### PR DESCRIPTION
In merged PR https://github.com/zyedidia/micro/pull/1206, I added a Material colorscheme, but forgot to add it to the documentation. This adds a line to `colors.md` listing the availability of `material-tc`.