### PR TITLE
Update Julia keywords for verions 1.x and remove unrelated words

### DIFF
--- a/runtime/syntax/julia.yaml
+++ b/runtime/syntax/julia.yaml
@@ -18,7 +18,7 @@ rules:
       # decorators
     - identifier.macro: "@[A-Za-z0-9_]+"
       # operators
-    - symbol.operator: "[-+*/|=%<>&~^]|\\b(and|not|or|is|in)\\b"
+    - symbol.operator: "[-+*/|=%<>&~^]|\\b(in|isa|where)\\b"
       # parentheses
     - symbol.brackets: "([(){}]|\\[|\\])"
       # numbers

--- a/runtime/syntax/julia.yaml
+++ b/runtime/syntax/julia.yaml
@@ -13,7 +13,8 @@ rules:
       # definitions
     - identifier: "[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[(]"
       # keywords
-    - statement: "\\b(begin|break|catch|continue|function|elseif|struct|else|end|finally|for|global|local|const|if|include|import|using|require|macro|println|return|try|type|while|module)\\b"
+    - statement: "\\b(baremodule|begin|break|catch|const|continue|do|else|elseif|end|export|finally|for|function|global|if|import|let|local|macro|module|quote|return|struct|try|using|while)\\b"
+    - statement: "\\b(abstract type|primitive type|mutable struct\\b)"
       # decorators
     - identifier.macro: "@[A-Za-z0-9_]+"
       # operators


### PR DESCRIPTION
Reserved keywords for version 1.x are listed at https://docs.julialang.org/en/v1/base/base/#Keywords-1, and there are also reserved two-word sequence.

This PR
- update reserved keywords
- add reserved two-word sequence
- update string infix operators