### PR TITLE
Update julia.yaml

### DIFF
--- a/runtime/syntax/julia.yaml
+++ b/runtime/syntax/julia.yaml
@@ -13,11 +13,11 @@ rules:
       # definitions
     - identifier: "[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[(]"
       # keywords
-    - statement: "\\b(begin|break|catch|continue|function|elseif|struct|else|end|finally|for|global|local|const|if|include|import|using|require|macro|println|return|try|type|while|module)\\b"
+    - statement: "\\b(begin|break|catch|continue|function|elseif|struct|else|end|finally|for|global|local|let|const|if|import|using|macro|println|return|try|while|module)\\b"
       # decorators
     - identifier.macro: "@[A-Za-z0-9_]+"
       # operators
-    - symbol.operator: "[-+*/|=%<>&~^]|\\b(and|not|or|is|in)\\b"
+    - symbol.operator: "[-+*/|=%<>&~^]|\\b(isa|in)\\b"
       # parentheses
     - symbol.brackets: "([(){}]|\\[|\\])"
       # numbers


### PR DESCRIPTION
Some keywords are not in Julia and were removed. `include` is a standard function with no special property (no syntax-level highlight required)