### PR TITLE
add support for input and scalar defintiions (for graphql-tools schema)

### DIFF
--- a/runtime/syntax/graphql.yaml
+++ b/runtime/syntax/graphql.yaml
@@ -4,7 +4,7 @@ detect:
     filename: "\\.(gql|graphql)$"
 
 rules:
-    - type: "\\b(?:(query|mutation|subscription|type|fragment|schema|union|on|extends?))\\b"
+    - type: "\\b(?:(query|mutation|subscription|type|input|scalar|fragment|schema|union|on|extends?))\\b"
 
     # scalar types
     - statement: "\\b(ID|Int|Float|Boolean|String|Datetime|Null)\\b"


### PR DESCRIPTION
Super-minor addition to highlight `input` and `scalar` keywords in graphql syntax.

I use these to define graphql-services with [graphql-tools](https://github.com/apollographql/graphql-tools)

This allows something like this:

```graphql
type Query {
  # get a single user
  user(id: ID!): User

  # get all users, optionally filterd by `where`
  users(where: WhereUser): [User]!
}

type Mutation {
  # Add a new user
  userAdd(input: InputUserAdd!): User!

  # Edit an existing user  
  userEdit(input: InputUserEdit!): User!

  # Delete an existing user
  userDelete(id: ID!): Boolean!
}

type User {
  id: ID!
  email: Email!
  name: String!
  createAt: Datetime
  updatedAt: Datetime
}

scalar Email

input WhereUser {
  email: WhereString
  name: WhereString
  createdAt: WhereDatetime
}

input WhereDatetime {
  EQ: Datetime
  BEFORE: Datetime
  AFTER: Datetime
  AND: [WhereDatetime]
  OR: [WhereDatetime]
}

input WhereString {
  EQ: String
  GT: String
  LT: String
  AND: [WhereString]
  OR: [WhereString]
}

input InputUserAdd {
  email: String!
  name: String!
}

input InputUserEdit {
  id: ID!
  email: Email
  name: String
}
```