### PR TITLE
Add dynamic scaling to scrollmargin in settings

### DIFF
--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -136,7 +136,7 @@ func (v *View) ScrollUpAction(usePlugin bool) bool {
 			return false
 		}
 
-		scrollspeed := int(v.Buf.Settings["scrollspeed"].(float64))
+		scrollspeed := v.Buf.Settings["scrollspeed"].(int)
 		v.ScrollUp(scrollspeed)
 
 		if usePlugin {
@@ -153,7 +153,7 @@ func (v *View) ScrollDownAction(usePlugin bool) bool {
 			return false
 		}
 
-		scrollspeed := int(v.Buf.Settings["scrollspeed"].(float64))
+		scrollspeed := v.Buf.Settings["scrollspeed"].(int)
 		v.ScrollDown(scrollspeed)
 
 		if usePlugin {
@@ -227,7 +227,7 @@ func (v *View) CursorLeft(usePlugin bool) bool {
 		tabstospaces := v.Buf.Settings["tabstospaces"].(bool)
 		tabmovement := v.Buf.Settings["tabmovement"].(bool)
 		if tabstospaces && tabmovement {
-			tabsize := int(v.Buf.Settings["tabsize"].(float64))
+			tabsize := v.Buf.Settings["tabsize"].(int)
 			line := v.Buf.Line(v.Cursor.Y)
 			if v.Cursor.X-tabsize >= 0 && line[v.Cursor.X-tabsize:v.Cursor.X] == Spaces(tabsize) && IsStrWhitespace(line[0:v.Cursor.X-tabsize]) {
 				for i := 0; i < tabsize; i++ {
@@ -261,7 +261,7 @@ func (v *View) CursorRight(usePlugin bool) bool {
 		tabstospaces := v.Buf.Settings["tabstospaces"].(bool)
 		tabmovement := v.Buf.Settings["tabmovement"].(bool)
 		if tabstospaces && tabmovement {
-			tabsize := int(v.Buf.Settings["tabsize"].(float64))
+			tabsize := v.Buf.Settings["tabsize"].(int)
 			line := v.Buf.Line(v.Cursor.Y)
 			if v.Cursor.X+tabsize < Count(line) && line[v.Cursor.X:v.Cursor.X+tabsize] == Spaces(tabsize) && IsStrWhitespace(line[0:v.Cursor.X]) {
 				for i := 0; i < tabsize; i++ {
@@ -570,7 +570,7 @@ func (v *View) Retab(usePlugin bool) bool {
 	}
 
 	toSpaces := v.Buf.Settings["tabstospaces"].(bool)
-	tabsize := int(v.Buf.Settings["tabsize"].(float64))
+	tabsize := v.Buf.Settings["tabsize"].(int)
 	dirty := false
 
 	for i := 0; i < v.Buf.NumLines; i++ {
@@ -748,7 +748,7 @@ func (v *View) Backspace(usePlugin bool) bool {
 		// whitespace at the start of the line, we should delete as if it's a
 		// tab (tabSize number of spaces)
 		lineStart := sliceEnd(v.Buf.LineBytes(v.Cursor.Y), v.Cursor.X)
-		tabSize := int(v.Buf.Settings["tabsize"].(float64))
+		tabSize := v.Buf.Settings["tabsize"].(int)
 		if v.Buf.Settings["tabstospaces"].(bool) && IsSpaces(lineStart) && utf8.RuneCount(lineStart) != 0 && utf8.RuneCount(lineStart)%tabSize == 0 {
 			loc := v.Cursor.Loc
 			v.Buf.Remove(loc.Move(-tabSize, v.Buf), loc)

--- a/cmd/micro/buffer.go
+++ b/cmd/micro/buffer.go
@@ -338,7 +338,7 @@ func (b *Buffer) FileType() string {
 // IndentString returns a string representing one level of indentation
 func (b *Buffer) IndentString() string {
 	if b.Settings["tabstospaces"].(bool) {
-		return Spaces(int(b.Settings["tabsize"].(float64)))
+		return Spaces(b.Settings["tabsize"].(int))
 	}
 	return "\t"
 }

--- a/cmd/micro/cellview.go
+++ b/cmd/micro/cellview.go
@@ -89,7 +89,7 @@ func (c *CellView) Draw(buf *Buffer, top, height, left, width int) {
 		}
 	}
 
-	tabsize := int(buf.Settings["tabsize"].(float64))
+	tabsize := buf.Settings["tabsize"].(int)
 	softwrap := buf.Settings["softwrap"].(bool)
 	indentrunes := []rune(buf.Settings["indentchar"].(string))
 	// if empty indentchar settings, use space

--- a/cmd/micro/cursor.go
+++ b/cmd/micro/cursor.go
@@ -348,7 +348,7 @@ func (c *Cursor) StartOfText() {
 // 4 visual spaces)
 func (c *Cursor) GetCharPosInLine(lineNum, visualPos int) int {
 	// Get the tab size
-	tabSize := int(c.buf.Settings["tabsize"].(float64))
+	tabSize := c.buf.Settings["tabsize"].(int)
 	visualLineLen := StringWidth(c.buf.Line(lineNum), tabSize)
 	if visualPos > visualLineLen {
 		visualPos = visualLineLen
@@ -363,7 +363,7 @@ func (c *Cursor) GetCharPosInLine(lineNum, visualPos int) int {
 // GetVisualX returns the x value of the cursor in visual spaces
 func (c *Cursor) GetVisualX() int {
 	runes := []rune(c.buf.Line(c.Y))
-	tabSize := int(c.buf.Settings["tabsize"].(float64))
+	tabSize := c.buf.Settings["tabsize"].(int)
 	if c.X > len(runes) {
 		c.X = len(runes) - 1
 	}

--- a/cmd/micro/view.go
+++ b/cmd/micro/view.go
@@ -369,7 +369,7 @@ func (v *View) GetSoftWrapLocation(vx, vy int) (int, int) {
 			}
 
 			if ch == '\t' {
-				screenX += int(v.Buf.Settings["tabsize"].(float64)) - 1
+				screenX += v.Buf.Settings["tabsize"].(int) - 1
 			}
 
 			screenX++
@@ -407,7 +407,7 @@ func (v *View) Bottomline() int {
 			}
 
 			if ch == '\t' {
-				screenX += int(v.Buf.Settings["tabsize"].(float64)) - 1
+				screenX += v.Buf.Settings["tabsize"].(int) - 1
 			}
 
 			screenX++
@@ -424,13 +424,23 @@ func (v *View) Bottomline() int {
 	return numLines + v.Topline
 }
 
+func (v *View) ScrollMarginLines() int {
+	setting := v.Buf.Settings["scrollmargin"].(float64)
+	if setting < 1 {
+		height := v.Bottomline() - v.Topline
+		return int(float64(height) * setting)
+	}
+	return int(setting)
+}
+
+
 // Relocate moves the view window so that the cursor is in view
 // This is useful if the user has scrolled far away, and then starts typing
 func (v *View) Relocate() bool {
 	height := v.Bottomline() - v.Topline
 	ret := false
 	cy := v.Cursor.Y
-	scrollmargin := int(v.Buf.Settings["scrollmargin"].(float64))
+	scrollmargin := v.ScrollMarginLines()
 	if cy < v.Topline+scrollmargin && cy > scrollmargin-1 {
 		v.Topline = cy - scrollmargin
 		ret = true
@@ -864,7 +874,7 @@ func (v *View) DisplayView() {
 			realLineN++
 		}
 
-		colorcolumn := int(v.Buf.Settings["colorcolumn"].(float64))
+		colorcolumn := v.Buf.Settings["colorcolumn"].(int)
 		if colorcolumn != 0 && xOffset+colorcolumn-v.leftCol < v.Width {
 			style := GetColor("color-column")
 			fg, _, _ := style.Decompose()
@@ -965,7 +975,7 @@ func (v *View) DisplayView() {
 			if char != nil {
 				lineStyle := char.style
 
-				colorcolumn := int(v.Buf.Settings["colorcolumn"].(float64))
+				colorcolumn := v.Buf.Settings["colorcolumn"].(int)
 				if colorcolumn != 0 && char.visualLoc.X == colorcolumn {
 					style := GetColor("color-column")
 					fg, _, _ := style.Decompose()


### PR DESCRIPTION
To activate, set scrollmargin to something less than 1.

When scrollmargin is set to such a number, say 0.1. And say the height of a buffer's view is 50 lines. Number of lines used for scroll margin would become height * scrollmargin, i.e. 5 lines. As a bonus, it re-scales dynamically when terminal is resized.

I wanted this feature, so I could use the same config file on all my devices running micro, e.g. laptops, desktops and android phones.

Never coded in Go before this, so please do review with caution. And let me know if I missed anything, hopefully not too much.