### PR TITLE
Fix #1314: Add support for diffs from `git commit --verbose`.

### DIFF
--- a/runtime/syntax/git-commit.yaml
+++ b/runtime/syntax/git-commit.yaml
@@ -23,3 +23,14 @@ rules:
         start: "^#"
         end: "$"
         rules: []
+
+    # Diffs (i.e. git commit --verbose)
+    - default:
+        start: "^diff"
+        # Diff output puts a space before file contents on each line so this
+        # should never match valid diff output and extend highlighting to the
+        # end of the file
+        end: "^ENDOFFILE"
+        limit-group: "magenta"
+        rules:
+            - include: "patch"


### PR DESCRIPTION
I spent a _while_ trying to figure out how to make an end regex for a region that matched the end of the file so that I could avoid diff-highlighting in the commit message area, and finally found out that a regex that never matches does the trick. Not the cleanest thing to do but seems good enough.