### PR TITLE
Updated Julia number and string syntax highlighting

### DIFF
--- a/runtime/syntax/julia.yaml
+++ b/runtime/syntax/julia.yaml
@@ -21,9 +21,9 @@ rules:
       # parentheses
     - symbol.brackets: "([(){}]|\\[|\\])"
       # numbers
-    - constant.number: "\\b[0-9]+\\b"
+    - constant.number: "\\b([0-9]+(_[0-9]+)*|0x[0-9a-fA-F]+(_[0-9a-fA-F]+)*|0b[01]+(_[01]+)*|0o[0-7]+(_[0-7]+)*)\\b"
 
-    - constant.string: "\"(\\\\.|[^\"])*\"|'(\\\\.|[^'])*'"
+    - constant.string: "\"(\\\\.|[^\"])*\"|'(\\\\.|[^']){1}'"
 
     - constant.string:
         start: "\"\"\""


### PR DESCRIPTION
This update enhanced Julia syntax highlighting by:
1) Allowing binary, octal and hexadecimal number literals
2) Allowing underscores in number literals
3) Not allowing multiple-character or zero-character character literals.