### PR TITLE
( #1358 ) add vue single-file component syntax highlighting 

### DIFF
--- a/runtime/syntax/vue.yaml
+++ b/runtime/syntax/vue.yaml
@@ -1,0 +1,25 @@
+filetype: vue
+
+detect:
+    filename: "\\.vue$"
+
+rules:
+    - default:
+        start: "<template.*?>"
+        end: "</template.*?>"
+        rules: 
+            - include: "html5"
+        
+    
+    - default: 
+        start: "<script.*?>"
+        end: "</script.*?>"
+        rules:
+            - include: "javascript"
+    
+    - default:
+        start: "<style.*?>"
+        end: "</style.*?>"
+        rules:
+            - include: "css"
+    

--- a/runtime/syntax/vue.yaml
+++ b/runtime/syntax/vue.yaml
@@ -9,8 +9,7 @@ rules:
         end: "</template.*?>"
         rules: 
             - include: "html5"
-        
-    
+            
     - default: 
         start: "<script.*?>"
         end: "</script.*?>"


### PR DESCRIPTION
Pull request for feature request #1358 .
It's pretty basic at the moment and can be improved but that mostly relies on the html5, javascript and css syntax highlighting since these are included for the vue highlighting. 