### PR TITLE
fix #1318. fix html comments and make them work multiline

### DIFF
--- a/runtime/syntax/html.yaml
+++ b/runtime/syntax/html.yaml
@@ -18,8 +18,12 @@ rules:
 
     - symbol.tag: "<|>"
     - constant.string.url: "(ftp(s)?|http(s)?|git|chrome)://[^ 	]+"
-    - comment: "<!--.+?-->"
     - preproc: "<!DOCTYPE.+?>"
+
+    - comment:
+        start: "<!--"
+        end: "-->"
+        rules: []
 
     - constant.string:
         start: "\""


### PR DESCRIPTION
fixes the bug #1318 and additionally allow to the comment to go over multiple lines. 