### PR TITLE
Add textfilter command

### DIFF
--- a/cmd/micro/command.go
+++ b/cmd/micro/command.go
@@ -58,6 +58,7 @@ func init() {
 		"MemUsage":   MemUsage,
 		"Retab":      Retab,
 		"Raw":        Raw,
+		"TextFilter": TextFilter,
 	}
 }
 
@@ -117,6 +118,7 @@ func DefaultCommands() map[string]StrCommand {
 		"memusage":   {"MemUsage", []Completion{NoCompletion}},
 		"retab":      {"Retab", []Completion{NoCompletion}},
 		"raw":        {"Raw", []Completion{NoCompletion}},
+		"textfilter": {"TextFilter", []Completion{NoCompletion}},
 	}
 }
 

--- a/cmd/micro/textfilter.go
+++ b/cmd/micro/textfilter.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+)
+
+// TextFilter command filters the selection through the command.
+// Selection goes to the command input.
+// On successfull run command output replaces the current selection.
+func TextFilter(args []string) {
+	if len(args) == 0 {
+		messenger.Error("usage: textfilter arguments")
+		return
+	}
+	v := CurView()
+	sel := v.Cursor.GetSelection()
+	if sel == "" {
+		v.Cursor.SelectWord()
+		sel = v.Cursor.GetSelection()
+	}
+	var bout, berr bytes.Buffer
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdin = strings.NewReader(sel)
+	cmd.Stderr = &berr
+	cmd.Stdout = &bout
+	err := cmd.Run()
+	if err != nil {
+		messenger.Error(err.Error() + " " + berr.String())
+		return
+	}
+	v.Cursor.DeleteSelection()
+	v.Buf.Insert(v.Cursor.Loc, bout.String())
+}


### PR DESCRIPTION
Please consider merging textfilter command.
It is similar to vim filter command: http://vimdoc.sourceforge.net/htmldoc/change.html#filter.
Example usage:
In micro make a selection, press Ctrl+E, type `textfilter sort`.
Selection will be sorted.
