### PR TITLE
SpawnMultiCursorDown / SpawnMultiCursorUp

### DIFF
--- a/cmd/micro/actions.go
+++ b/cmd/micro/actions.go
@@ -2184,6 +2184,70 @@ func (v *View) SpawnMultiCursor(usePlugin bool) bool {
 	return false
 }
 
+// SpawnMultiCursorUp creates additional cursor, at the same X (if possible), one Y less.
+func (v *View) SpawnMultiCursorUp(usePlugin bool) bool {
+
+	if usePlugin && !PreActionCall("SpawnMultiCursorUp", v) {
+		return false
+	}
+
+	if v.Cursor.Y == 0 {
+   		return false
+	} else {
+		v.Cursor.GotoLoc(Loc{v.Cursor.X, v.Cursor.Y - 1})
+		v.Cursor.Relocate()
+	}
+
+	if v.mainCursor() {
+		c := &Cursor{
+			buf: v.Buf,
+		}
+		c.GotoLoc(Loc{v.Cursor.X, v.Cursor.Y + 1})
+		v.Buf.cursors = append(v.Buf.cursors, c)
+	}
+
+	v.Buf.MergeCursors()
+	v.Buf.UpdateCursors()
+
+	if usePlugin {
+		PostActionCall("SpawnMultiCursorUp", v)
+	}
+
+	return false
+}
+
+// SpawnMultiCursorUp creates additional cursor, at the same X (if possible), one Y more.
+func (v *View) SpawnMultiCursorDown(usePlugin bool) bool {
+
+	if usePlugin && !PreActionCall("SpawnMultiCursorDown", v) {
+		return false
+	}
+
+	if v.Cursor.Y + 1 == v.Buf.LinesNum() {
+		return false
+	} else {
+		v.Cursor.GotoLoc(Loc{v.Cursor.X, v.Cursor.Y + 1})
+		v.Cursor.Relocate()
+	}
+
+	if v.mainCursor() {
+		c := &Cursor{
+			buf: v.Buf,
+		}
+		c.GotoLoc(Loc{v.Cursor.X, v.Cursor.Y - 1})
+		v.Buf.cursors = append(v.Buf.cursors, c)
+	}
+
+	v.Buf.MergeCursors()
+	v.Buf.UpdateCursors()
+
+	if usePlugin {
+		PostActionCall("SpawnMultiCursorDown", v)
+	}
+
+	return false
+}
+
 // SpawnMultiCursorSelect adds a cursor at the beginning of each line of a selection
 func (v *View) SpawnMultiCursorSelect(usePlugin bool) bool {
 	if v.Cursor == &v.Buf.Cursor {

--- a/cmd/micro/bindings.go
+++ b/cmd/micro/bindings.go
@@ -112,6 +112,8 @@ var bindingActions = map[string]func(*View, bool) bool{
 	"ScrollDown":             (*View).ScrollDownAction,
 	"SpawnMultiCursor":       (*View).SpawnMultiCursor,
 	"SpawnMultiCursorSelect": (*View).SpawnMultiCursorSelect,
+	"SpawnMultiCursorUp": (*View).SpawnMultiCursorUp,
+	"SpawnMultiCursorDown": (*View).SpawnMultiCursorDown,
 	"RemoveMultiCursor":      (*View).RemoveMultiCursor,
 	"RemoveAllMultiCursors":  (*View).RemoveAllMultiCursors,
 	"SkipMultiCursor":        (*View).SkipMultiCursor,
@@ -606,6 +608,9 @@ func DefaultBindings() map[string]string {
 		"MouseLeft":      "MousePress",
 		"MouseMiddle":    "PastePrimary",
 		"Ctrl-MouseLeft": "MouseMultiCursor",
+
+		"AltShiftUp": "SpawnMultiCursorUp",
+		"AltShiftDown": "SpawnMultiCursorDown",
 
 		"Alt-n": "SpawnMultiCursor",
 		"Alt-m": "SpawnMultiCursorSelect",


### PR DESCRIPTION
As a person who used to do small file edits in nano, when opening full IDE would be an overkill,  I really liked your editor, since it gives best of two worlds - instant feedback and a lot of text-editor functionalities, that have *normal, human-like, standarized* keybindings out of the box.

One thing that I feel is missing though, is adding multiple cursors with up-down keys: 

![out](https://user-images.githubusercontent.com/13459304/69006214-3c1d8500-092c-11ea-9ebf-fc0f229e6373.gif)

I am aware this functionality may be redundant, having 2 existing multicursor related functions, but wanted to at least start a discussion.