### PR TITLE
Corrected tex comment start separator

### DIFF
--- a/runtime/syntax/tex.yaml
+++ b/runtime/syntax/tex.yaml
@@ -20,9 +20,10 @@ rules:
     - special: "[&\\\\]"
     # macros
     - statement: "\\\\@?[a-zA-Z_]+"
+    - statement: "\\\\%"
     # comments
     - comment:
-        start: "%"
+        start: "[^\\\\]%"
         end: "$"
         rules: []
     - comment:


### PR DESCRIPTION
Hi,

When editing a TeX file, the `%` character is seen as a comment start separator.
But when writing a sentence like this
```tex
The result obtained is 10\% higher than expected. 
```
the end of the sentence is colored as if it was a comment, even though the `%` character is escaped.

This pull request corrects this to only consider as a comment start separator non-escaped `%` characters.
