### PR TITLE
Support csharp-script syntax.

### DIFF
--- a/runtime/syntax/csx.yaml
+++ b/runtime/syntax/csx.yaml
@@ -1,0 +1,8 @@
+filetype: csharp-script
+detect:
+    filename: "\\.csx$"
+    header: "^#!.*/(env +)?dotnet-script( |$)"
+    
+rules:
+    - include: "csharp"
+    - preproc: "\\B(\\#!|\\#[r|load|]+\\b)"


### PR DESCRIPTION
```
#!/usr/bin/env dotnet-script
// Set Runtime
#! "netcoreapp3.0"
// Imports
#load "myAssembly.dll"
#r "nuget:CliWrap,2.5.0"
```
This syntax file basically imports the `csharp` rules and adds it's custom pre-processors. I've been manually adding that file to every single host I've installed micro on - and now I'm tired of that.