### PR TITLE
Syntax highlighting with tree-sitter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/mattn/go-runewidth v0.0.7
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/sergi/go-diff v1.1.0
+	github.com/smacker/go-tree-sitter v0.0.0-20191230102415-949ed041aea3
 	github.com/stretchr/testify v1.4.0
 	github.com/yuin/gopher-lua v0.0.0-20191220021717-ab39c6098bdb
 	github.com/zyedidia/clipboard v0.0.0-20190823154308-241f98e9b197
@@ -22,5 +23,7 @@ require (
 	gopkg.in/yaml.v2 v2.2.7
 	layeh.com/gopher-luar v1.0.7
 )
+
+replace github.com/smacker/go-tree-sitter => github.com/p-e-w/go-tree-sitter v0.0.0-20200125032645-7b3cf93b37eb
 
 go 1.11

--- a/go.sum
+++ b/go.sum
@@ -27,10 +27,14 @@ github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+tw
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/p-e-w/go-tree-sitter v0.0.0-20200125032645-7b3cf93b37eb h1:1SMI3eSMnPqk/NoH4N423P/k8hVz8B8Czhpyu+7lMFA=
+github.com/p-e-w/go-tree-sitter v0.0.0-20200125032645-7b3cf93b37eb/go.mod h1:EiUuVMUfLQj8Sul+S8aKWJwQy7FRYnJCO2EWzf8F5hk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
+github.com/smacker/go-tree-sitter v0.0.0-20191230102415-949ed041aea3 h1:A7DsT+HLXC5VLINUNRwOJsd04aTlmo8nH9SQoWlrVk4=
+github.com/smacker/go-tree-sitter v0.0.0-20191230102415-949ed041aea3/go.mod h1:EiUuVMUfLQj8Sul+S8aKWJwQy7FRYnJCO2EWzf8F5hk=
 github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -114,7 +114,7 @@ type Buffer struct {
 	// This stores the highlighting rules and filetype detection info
 	SyntaxDef *highlight.Def
 	// The Highlighter struct actually performs the highlighting
-	Highlighter *highlight.Highlighter
+	Highlighter highlight.Highlighter
 	// Modifications is the list of modified regions for syntax highlighting
 	Modifications []Loc
 

--- a/pkg/highlight/treesitter.go
+++ b/pkg/highlight/treesitter.go
@@ -1,0 +1,285 @@
+package highlight
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/golang"
+	"github.com/smacker/go-tree-sitter/rust"
+)
+
+var captureNameToScopeName = map[string]string{
+	"attribute": "special",
+	//"charset": "",
+	"comment":          "comment",
+	"constant":         "constant",
+	"constant.builtin": "constant",
+	"constructor":      "type",
+	//"delimiter": "",
+	//"embedded": "",
+	"escape":                  "constant.specialChar",
+	"function":                "identifier",
+	"function.builtin":        "identifier",
+	"function.macro":          "identifier",
+	"function.method":         "identifier",
+	"function.method.builtin": "identifier",
+	"function.special":        "identifier",
+	//"import": "",
+	//"keyframes": "",
+	"keyword": "statement",
+	//"label": "",
+	//"media": "",
+	//"namespace": "",
+	"number":   "constant.number",
+	"operator": "symbol.operator",
+	//"property": "",
+	"punctuation.bracket": "symbol.brackets",
+	//"punctuation.delimiter": "",
+	//"punctuation.special": "",
+	"string":                "constant.string",
+	"string.special":        "constant.string",
+	"string.special.regex":  "constant.string",
+	"string.special.symbol": "constant.string",
+	//"supports": "",
+	"tag":          "symbol.tag",
+	"tag.error":    "error",
+	"type":         "type",
+	"type.builtin": "type",
+	//"variable": "",
+	"variable.builtin": "type",
+	//"variable.parameter": "",
+}
+
+type queryPredicate func([]sitter.QueryCapture, []byte) bool
+
+type treeSitterHighlighter struct {
+	parser       *sitter.Parser
+	query        *sitter.Query
+	captureNames []string
+	predicates   [][]queryPredicate
+}
+
+func NewTreeSitterHighlighter(name string) Highlighter {
+	var language *sitter.Language
+	var queryString string
+
+	switch name {
+	case "go":
+		language = golang.GetLanguage()
+		queryString = goQuery
+	case "rust":
+		language = rust.GetLanguage()
+		queryString = rustQuery
+	default:
+		return nil
+	}
+
+	// Make sure all required scope names are registered
+	for _, scopeName := range captureNameToScopeName {
+		if _, ok := Groups[scopeName]; !ok {
+			numGroups++
+			Groups[scopeName] = numGroups
+		}
+	}
+
+	highlighter := new(treeSitterHighlighter)
+
+	highlighter.parser = sitter.NewParser()
+	highlighter.parser.SetLanguage(language)
+
+	query, err := sitter.NewQuery([]byte(queryString), language)
+	if err != nil {
+		panic(err)
+	}
+	highlighter.query = query
+
+	captureCount := query.CaptureCount()
+	for i := uint32(0); i < captureCount; i++ {
+		captureName := query.CaptureNameForId(i)
+		highlighter.captureNames = append(highlighter.captureNames, captureName)
+	}
+
+	var stringValues []string
+	stringCount := query.StringCount()
+	for i := uint32(0); i < stringCount; i++ {
+		stringValue := query.StringValueForId(i)
+		stringValues = append(stringValues, stringValue)
+	}
+
+	patternCount := query.PatternCount()
+	for i := uint32(0); i < patternCount; i++ {
+		highlighter.predicates = append(highlighter.predicates, []queryPredicate{})
+
+		var predicateSteps []sitter.QueryPredicateStep
+		for _, predicateStep := range query.PredicatesForPattern(i) {
+			if predicateStep.Type == sitter.QueryPredicateStepTypeDone {
+				predicate, err := makePredicate(predicateSteps, stringValues)
+				if err != nil {
+					panic(err)
+				}
+				highlighter.predicates[i] = append(highlighter.predicates[i], predicate)
+				predicateSteps = nil
+			} else {
+				predicateSteps = append(predicateSteps, predicateStep)
+			}
+		}
+	}
+
+	return highlighter
+}
+
+func makePredicate(steps []sitter.QueryPredicateStep, stringValues []string) (queryPredicate, error) {
+	if len(steps) != 3 {
+		return nil, fmt.Errorf("invalid number of predicate steps")
+	}
+
+	if steps[0].Type != sitter.QueryPredicateStepTypeString {
+		return nil, fmt.Errorf("first predicate step must be a string")
+	}
+
+	if steps[1].Type != sitter.QueryPredicateStepTypeCapture {
+		return nil, fmt.Errorf("second predicate step must be a capture")
+	}
+
+	operator := stringValues[steps[0].ValueId]
+
+	// TODO: Implement "eq?", "is-not?" (used by some highlighting queries)
+	switch operator {
+	case "match?":
+		if steps[2].Type != sitter.QueryPredicateStepTypeString {
+			return nil, fmt.Errorf("third predicate step must be a string if the operator is 'match?'")
+		}
+		pattern, err := regexp.Compile(stringValues[steps[2].ValueId])
+		if err != nil {
+			return nil, err
+		}
+		predicate := func(captures []sitter.QueryCapture, source []byte) bool {
+			for _, capture := range captures {
+				if capture.Index == steps[1].ValueId {
+					return pattern.MatchString(capture.Node.Content(source))
+				}
+			}
+			return false
+		}
+		return predicate, nil
+	default:
+		return nil, fmt.Errorf("unsupported predicate operator: %v", operator)
+	}
+}
+
+func (h *treeSitterHighlighter) HighlightString(input string) []LineMatch {
+	var lineMatches []LineMatch
+	return lineMatches
+}
+
+func (h *treeSitterHighlighter) HighlightStates(input LineStates) {
+}
+
+func (h *treeSitterHighlighter) HighlightMatches(input LineStates, startline, endline int) {
+	if startline >= endline {
+		return
+	}
+
+	// TODO: Use tree-sitter interface for reading buffer
+	var buffer bytes.Buffer
+	for i := 0; i < input.LinesNum(); i++ {
+		buffer.Write(input.LineBytes(i))
+		buffer.WriteString("\n")
+	}
+
+	source := buffer.Bytes()
+	tree := h.parser.Parse(source)
+
+	cursor := sitter.NewQueryCursor()
+	cursor.SetPointRange(sitter.Point{uint32(startline), 0}, sitter.Point{uint32(endline), 0})
+	cursor.Exec(h.query, tree.RootNode())
+
+	defaultGroup := Groups["default"]
+
+	var lineMatches []LineMatch
+	for i := startline; i < endline; i++ {
+		lineMatches = append(lineMatches, LineMatch{
+			0: defaultGroup,
+		})
+	}
+
+	var lastNode *sitter.Node
+	var furthestScopeGroup Group
+	var furthestScopeEnd uint32
+	for {
+		match, captureIndex, ok := cursor.NextCapture()
+		if !ok {
+			break
+		}
+
+		satisfiesPredicates := true
+		for _, predicate := range h.predicates[match.PatternIndex] {
+			satisfiesPredicates = satisfiesPredicates && predicate(match.Captures, source)
+		}
+
+		capture := match.Captures[captureIndex]
+
+		// Only the first capture that matches a given node is considered
+		// (this matches the behavior of the tree-sitter playground)
+		if satisfiesPredicates && (lastNode == nil || !capture.Node.Equal(lastNode)) {
+			lastNode = capture.Node
+
+			captureName := h.captureNames[capture.Index]
+
+			if scopeName, ok := captureNameToScopeName[captureName]; ok {
+				scopeGroup := Groups[scopeName]
+
+				start := capture.Node.StartPoint()
+				end := capture.Node.EndPoint()
+
+				startRow := int(start.Row)
+				startColumn := int(start.Column)
+				if startRow < startline {
+					startRow = startline
+					startColumn = 0
+				}
+
+				endRow := int(end.Row)
+				endColumn := int(end.Column)
+				if endRow >= endline {
+					endRow = endline - 1
+					endColumn = len(input.LineBytes(endRow))
+				}
+
+				lineMatches[startRow-startline][startColumn] = scopeGroup
+				for i := startRow + 1; i <= endRow; i++ {
+					lineMatches[i-startline][0] = scopeGroup
+				}
+
+				// The following is a simple and fast solution to the problem
+				// of nested scopes, although it works only for one level of nesting
+				endByte := capture.Node.EndByte()
+				resetGroup := defaultGroup
+
+				if endByte < furthestScopeEnd {
+					resetGroup = furthestScopeGroup
+				} else if endByte > furthestScopeEnd {
+					furthestScopeGroup = scopeGroup
+					furthestScopeEnd = endByte
+				}
+
+				lineMatches[endRow-startline][endColumn] = resetGroup
+			}
+		}
+	}
+
+	for i := startline; i < endline; i++ {
+		if i >= input.LinesNum() {
+			break
+		}
+		input.SetMatch(i, lineMatches[i-startline])
+	}
+}
+
+func (h *treeSitterHighlighter) ReHighlightStates(input LineStates, startline int) {
+}
+
+func (h *treeSitterHighlighter) ReHighlightLine(input LineStates, lineN int) {
+}

--- a/pkg/highlight/treesitter_queries.go
+++ b/pkg/highlight/treesitter_queries.go
@@ -1,0 +1,250 @@
+package highlight
+
+// https://github.com/tree-sitter/tree-sitter-go/blob/1de485aa40e3923afaa2b87acbd53c7c5f49aa7f/queries/highlights.scm
+const goQuery = `
+; Function calls
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (selector_expression
+    field: (field_identifier) @function.method))
+
+; Function definitions
+
+(function_declaration
+  name: (identifier) @function)
+
+(method_declaration
+  name: (field_identifier) @function.method)
+
+; Identifiers
+
+(type_identifier) @type
+(field_identifier) @property
+(identifier) @variable
+
+; Operators
+
+"--" @operator
+"-" @operator
+"-=" @operator
+":=" @operator
+"!" @operator
+"!=" @operator
+"..." @operator
+"*" @operator
+"*" @operator
+"*=" @operator
+"/" @operator
+"/=" @operator
+"&" @operator
+"&&" @operator
+"&=" @operator
+"%" @operator
+"%=" @operator
+"^" @operator
+"^=" @operator
+"+" @operator
+"++" @operator
+"+=" @operator
+"<-" @operator
+"<" @operator
+"<<" @operator
+"<<=" @operator
+"<=" @operator
+"=" @operator
+"==" @operator
+">" @operator
+">=" @operator
+">>" @operator
+">>=" @operator
+"|" @operator
+"|=" @operator
+"||" @operator
+
+; Keywords
+
+"break" @keyword
+"case" @keyword
+"chan" @keyword
+"const" @keyword
+"continue" @keyword
+"default" @keyword
+"defer" @keyword
+"else" @keyword
+"fallthrough" @keyword
+"for" @keyword
+"func" @keyword
+"go" @keyword
+"goto" @keyword
+"if" @keyword
+"import" @keyword
+"interface" @keyword
+"map" @keyword
+"package" @keyword
+"range" @keyword
+"return" @keyword
+"select" @keyword
+"struct" @keyword
+"switch" @keyword
+"type" @keyword
+"var" @keyword
+
+; Literals
+
+(interpreted_string_literal) @string
+(raw_string_literal) @string
+(rune_literal) @string
+(escape_sequence) @escape
+
+(int_literal) @number
+(float_literal) @number
+(imaginary_literal) @number
+
+(true) @constant.builtin
+(false) @constant.builtin
+(nil) @constant.builtin
+
+(comment) @comment
+`
+
+// https://github.com/tree-sitter/tree-sitter-rust/blob/1c37782a5528979a22991f8ed50dd3d3e423ac92/queries/highlights.scm
+const rustQuery = `
+; Identifier conventions
+
+; Assume all-caps names are constants
+((identifier) @constant
+ (match? @constant "^[A-Z][A-Z\\d_]+$'"))
+
+; Assume that uppercase names in paths are types
+((scoped_identifier
+  path: (identifier) @type)
+ (match? @type "^[A-Z]"))
+((scoped_identifier
+  path: (scoped_identifier
+    name: (identifier) @type))
+ (match? @type "^[A-Z]"))
+
+; Assume other uppercase names are enum constructors
+((identifier) @constructor
+ (match? @constructor "^[A-Z]"))
+
+; Function calls
+
+(call_expression
+  function: (identifier) @function)
+(call_expression
+  function: (field_expression
+    field: (field_identifier) @function.method))
+(call_expression
+  function: (scoped_identifier
+    "::"
+    name: (identifier) @function))
+
+(generic_function
+  function: (identifier) @function)
+(generic_function
+  function: (scoped_identifier
+    name: (identifier) @function))
+(generic_function
+  function: (field_expression
+    field: (field_identifier) @function.method))
+
+(macro_invocation
+  macro: (identifier) @function.macro
+  "!" @function.macro)
+
+; Function definitions
+
+(function_item (identifier) @function)
+(function_signature_item (identifier) @function)
+
+; Other identifiers
+
+(type_identifier) @type
+(primitive_type) @type.builtin
+(field_identifier) @property
+
+(line_comment) @comment
+(block_comment) @comment
+
+"(" @punctuation.bracket
+")" @punctuation.bracket
+"[" @punctuation.bracket
+"]" @punctuation.bracket
+
+(type_arguments
+  "<" @punctuation.bracket
+  ">" @punctuation.bracket)
+(type_parameters
+  "<" @punctuation.bracket
+  ">" @punctuation.bracket)
+
+"::" @punctuation.delimiter
+"." @punctuation.delimiter
+";" @punctuation.delimiter
+
+(parameter (identifier) @variable.parameter)
+
+(lifetime (identifier) @label)
+
+"break" @keyword
+"const" @keyword
+"continue" @keyword
+"default" @keyword
+"dyn" @keyword
+"else" @keyword
+"enum" @keyword
+"extern" @keyword
+"fn" @keyword
+"for" @keyword
+"if" @keyword
+"impl" @keyword
+"in" @keyword
+"let" @keyword
+"let" @keyword
+"loop" @keyword
+"macro_rules!" @keyword
+"match" @keyword
+"mod" @keyword
+"move" @keyword
+"pub" @keyword
+"ref" @keyword
+"return" @keyword
+"static" @keyword
+"struct" @keyword
+"trait" @keyword
+"type" @keyword
+"union" @keyword
+"unsafe" @keyword
+"use" @keyword
+"where" @keyword
+"while" @keyword
+(mutable_specifier) @keyword
+(use_list (self) @keyword)
+(scoped_use_list (self) @keyword)
+(scoped_identifier (self) @keyword)
+(super) @keyword
+
+(self) @variable.builtin
+
+(char_literal) @string
+(string_literal) @string
+(raw_string_literal) @string
+
+(boolean_literal) @constant.builtin
+(integer_literal) @constant.builtin
+(float_literal) @constant.builtin
+
+(escape_sequence) @escape
+
+(attribute_item) @attribute
+(inner_attribute_item) @attribute
+
+"as" @operator
+"*" @operator
+"&" @operator
+"'" @operator
+`


### PR DESCRIPTION
This PR adds [tree-sitter](https://github.com/tree-sitter/tree-sitter) as an alternative syntax highlighting engine via the [go-tree-sitter](https://github.com/smacker/go-tree-sitter) bindings (currently only for Go and Rust code, but it is trivial to add more languages). All of tree-sitter's functionality is provided by go-tree-sitter; Micro remains standalone with no dependencies.

Using tree-sitter dramatically improves syntax highlighting quality over Micro's YAML-based highlighting, as demonstrated in this comparison:

![treesitter](https://user-images.githubusercontent.com/2702526/73116597-f0f0a580-3f5e-11ea-8028-009dc9f9cfd0.gif)

Note how tree-sitter correctly highlights *all* type identifiers in yellow, not just those for built-in types. This is possible because tree-sitter's highlighting performs pattern matching on a syntax tree that contains rich information about the structure of code. Similarly, all function declarations and invocations are highlighted in blue. Tree-sitter gets many corner cases right that are difficult or impossible to implement using regular expression patterns, such as raw strings of arbitrary depth in Rust. Keywords are highlighted as keywords only in places where they actually represent language primitives (some languages allow use of keywords as variable names). The list of benefits goes on and on. The above screenshot shows only a glimpse of what is possible with tree-sitter; many more specific syntax captures are available and could be used to provide even richer highlighting if themes were to add support. Not to mention that tree-sitter is also an excellent foundation for building other features like code folding and symbol-based navigation.

And all of this is maintained upstream for you, driven forward by larger projects such as Atom and Neovim that already use tree-sitter.


### Performance

Speed is already perfectly usable for everyday coding, but not yet as fast as Micro's existing highlighting system. The reason is that two important optimizations are still missing:

* Currently, this code creates a copy of the entire buffer for tree-sitter to parse. Tree-sitter is capable of receiving a function pointer instead which would enable tree-sitter to access Micro's line array directly. To get this to work, I will need to figure out how to pass a Go lambda across the Cgo boundary.

* Currently, the entire buffer is parsed on each highlighting operation. Tree-sitter can do *much* better than that, and in fact incremental parsing is one of its main features. Matching Micro's modifications to tree-sitter's tree edits is the missing piece to make this happen.

I intend to address both of these issues soon, at which point I expect the performance of tree-sitter highlighting to match or exceed that of Micro's existing highlighters.


### Executable size

This change adds 1.1 MB (10%) to the size of the compiled Linux executable. Personally, I cannot imagine any situation where I would say "I need those 1.1 MB; give me poor highlighting instead!" But of course, there may be other schools of thought. The tree-sitter integration is quite orthogonal to the rest of Micro's codebase and could easily be turned into a feature that can be disabled with a compile-time flag should this be desired.

Adding more tree-sitter parsers will further increase the executable size. It probably makes sense to limit tree-sitter highlighting to popular languages with complex syntax, like Go, Rust, C, C++, Python and JavaScript.


### Note

This currently uses my fork of go-tree-sitter because I had to add several new bindings to implement this feature. I intend to upstream those additions shortly.

