### PR TITLE
Hide ISSUE_TEMPLATE version help into a comment

### DIFF
--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -2,7 +2,7 @@
 
 ## Specifications
 
-You can use `micro -version` to get the commit hash.
+<!-- You can use `micro -version` to get the commit hash. -->
 
 Commit hash:
 OS:


### PR DESCRIPTION
Because some people don't remove it.
Now it's only visible in Write tab.