### PR TITLE
Increase the default scroll sensitivity to 3

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -207,7 +207,7 @@ var defaultCommonSettings = map[string]interface{}{
 	"saveundo":       false,
 	"scrollbar":      false,
 	"scrollmargin":   float64(3),
-	"scrollspeed":    float64(2),
+	"scrollspeed":    float64(3),
 	"smartpaste":     true,
 	"softwrap":       false,
 	"splitbottom":    true,


### PR DESCRIPTION
This is more in line with most programs out there. For instance, scrolling by 3 lines is the default in most Windows programs.

Moreover, it typically results in less physical strain over time as you don't need to use the mouse wheel as much to navigate.