### PR TITLE
fix: eofnewline not running on files with 1 rune

### DIFF
--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -111,7 +111,7 @@ func (b *Buffer) saveToFile(filename string, withSudo bool) error {
 
 	if b.Settings["eofnewline"].(bool) {
 		end := b.End()
-		if b.RuneAt(Loc{end.X - 1, end.Y}) != '\n' {
+		if b.RuneAt(Loc{end.X, end.Y}) != '\n' {
 			b.Insert(end, "\n")
 		}
 	}


### PR DESCRIPTION
This fixes an off-by-one error where `eofnewline` won't add a new line if you save a file that has only 1 rune.
