### PR TITLE
Add syntax coloration in markdown fenced code

### DIFF
--- a/runtime/syntax/markdown.yaml
+++ b/runtime/syntax/markdown.yaml
@@ -47,3 +47,9 @@ rules:
         start: "`"
         end: "`"
         rules: []
+    
+    - default:
+        start: "^\\s*```shell"
+        end: "^\\s*```"
+        rules:
+          - include: "sh"


### PR DESCRIPTION
Hi, 

Thanks for developing micro. It's good to finally have a usable text editor in the terminal. 

I think the syntax coloration of markdown can be enhanced by applying coloration in fenced code elements according to the specified language. 

Ex: 

```js
console.log('Kikoo'); // <= this should be JS syntax-colored in the raw markdown.
```

I am not sure how to do this exactly so I have copied things from [the HTML syntax coloration file](https://github.com/zyedidia/micro/blob/master/runtime/syntax/html.yaml#L47) as I saw the JS in `script` tags is correctly colored in html files.

Needless to say, there's a truck-load of languages to add in this file but I wanted to get started by having a review on the process before starting to copy-paste (heavily :laughing: ). 

What do you think? 