### PR TITLE
Clarify the Find operation being regex-enabled

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -774,7 +774,7 @@ func (h *BufPane) saveBufToFile(filename string, action string, callback func())
 // Find opens a prompt and searches forward for the input
 func (h *BufPane) Find() bool {
 	h.searchOrig = h.Cursor.Loc
-	InfoBar.Prompt("Find: ", "", "Find", func(resp string) {
+	InfoBar.Prompt("Find (regex): ", "", "Find", func(resp string) {
 		// Event callback
 		match, found, _ := h.Buf.FindNext(resp, h.Buf.Start(), h.Buf.End(), h.searchOrig, true, true)
 		if found {


### PR DESCRIPTION
This makes it more obvious that the Find option accepts regular expressions as input.

See discussion in #1560.