### PR TITLE
Give access to os.UserConfigDir() and os.UserHomeDir() in plugins.

### DIFF
--- a/internal/lua/lua.go
+++ b/internal/lua/lua.go
@@ -378,6 +378,8 @@ func importOs() *lua.LTable {
 	L.SetField(pkg, "Symlink", luar.New(L, os.Symlink))
 	L.SetField(pkg, "TempDir", luar.New(L, os.TempDir))
 	L.SetField(pkg, "Truncate", luar.New(L, os.Truncate))
+	L.SetField(pkg, "UserConfigDir", luar.New(L, os.UserConfigDir))
+	L.SetField(pkg, "UserHomeDir", luar.New(L, os.UserHomeDir))
 
 	return pkg
 }


### PR DESCRIPTION
My plugin provides persistent configuration between usage of micro (keep a list of what should be visible in the navbar). The best place to store this information depends on the operating system. Since go provides an easy way to retrieve the information, we should use it.