### PR TITLE
Clarify regex for `git commit --verbose`

### DIFF
--- a/runtime/syntax/git-commit.yaml
+++ b/runtime/syntax/git-commit.yaml
@@ -26,7 +26,7 @@ rules:
 
     # Diffs (i.e. git commit --verbose)
     - default:
-        start: "^diff"
+        start: "^diff --git"
         # Diff output puts a space before file contents on each line so this
         # should never match valid diff output and extend highlighting to the
         # end of the file


### PR DESCRIPTION
Just minor improvement in order to escape such cases:
![image](https://user-images.githubusercontent.com/20517828/78462656-bd5b9580-76dc-11ea-9253-3d4ef7edd2f4.png)
