### PR TITLE
Fix docs regarding "Home" key and "StartOfText" and "StartOfLine".

### DIFF
--- a/runtime/help/defaultkeys.md
+++ b/runtime/help/defaultkeys.md
@@ -23,7 +23,7 @@ can change it!
 | Shift+arrows                | Move and select text                                                                      |
 | Alt(Ctrl on Mac)+LeftArrow  | Move to the beginning of the current line                                                 |
 | Alt(Ctrl on Mac)+RightArrow | Move to the end of the current line                                                       |
-| Home                        | Move to the beginning of the current line                                                 |
+| Home                        | Move to the beginning of text on the current line                                                 |
 | End                         | Move to the end of the current line                                                       |
 | Ctrl(Alt on Mac)+LeftArrow  | Move cursor one word left                                                                 |
 | Ctrl(Alt on Mac)+RightArrow | Move cursor one word right                                                                |

--- a/runtime/help/keybindings.md
+++ b/runtime/help/keybindings.md
@@ -457,7 +457,7 @@ conventions for text editing defaults.
     "CtrlT":          "AddTab",
     "Alt,":           "PreviousTab",
     "Alt.":           "NextTab",
-    "Home":           "StartOfLine",
+    "Home":           "StartOfText",
     "End":            "EndOfLine",
     "CtrlHome":       "CursorStart",
     "CtrlEnd":        "CursorEnd",


### PR DESCRIPTION
Commit cf41a587a334daeac6e67790953c29bcf5964560 changed the default keybindings but did not change the docs to reflect that. This fixes the issue.