### PR TITLE
Support for piped commands in Shell mode

### DIFF
--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"os/signal"
 	"strings"
-	"log"
 
 	shellquote "github.com/kballard/go-shellquote"
 	"github.com/zyedidia/micro/internal/screen"
@@ -79,98 +79,97 @@ func RunBackgroundShell(input string) (func() string, error) {
 //
 // TODO
 // Implement other type of command support?
-// egs. 
-//	If first ok: cmd1 && cmd2 
+// egs.
+//	If first ok: cmd1 && cmd2
 //  Sequential:  cmd1  & cmd2
 //  Concurrent:  cmd1  ; cmd2
-func executeCmdPipe(outputBuffer *bytes.Buffer, getOutput bool, stack ...*exec.Cmd) (err error) {
+func executeCmdPipe(outputBuffer *bytes.Buffer, getOutput bool, stack ...*exec.Cmd) (err error) {
 	if len(stack) == 0 {
 		return fmt.Errorf("length of the cmd stack is zero (0)")
-	} 
+	}
 
-    var errorBuffer bytes.Buffer
-    var pipeLen int
+	var errorBuffer bytes.Buffer
+	var pipeLen int
 	var pipes []*io.PipeWriter
 
 	// Handle the simple case, i.e. no pipes
 	if len(stack) == 1 {
 		pipeLen = 1
-		stack[0].Stdin = os.Stdin
-		
-		if getOutput {
-			stack[0].Stdout = io.MultiWriter(os.Stdout, outputBuffer)
-		} else {
-			stack[0].Stdout = os.Stdout
-		}
-		
+		stack[0].Stdin = os.Stdin
+
+		if getOutput {
+			stack[0].Stdout = io.MultiWriter(os.Stdout, outputBuffer)
+		} else {
+			stack[0].Stdout = os.Stdout
+		}
+
 		stack[0].Stderr = os.Stderr
 		stack[0].Start()
 
-	    log.Println("ExecuteCmdPipe: stack ->", stack)
-       	log.Println("ExecuteCmdPipe: pipes ->", pipes)
-       	log.Println("ExecuteCmdPipe: pipeLen     ->", pipeLen)
-       	log.Println("ExecuteCmdPipe: want output ->", getOutput)
+		log.Println("ExecuteCmdPipe: stack ->", stack)
+		log.Println("ExecuteCmdPipe: pipes ->", pipes)
+		log.Println("ExecuteCmdPipe: pipeLen     ->", pipeLen)
+		log.Println("ExecuteCmdPipe: want output ->", getOutput)
 
 		return stack[0].Wait()
 	}
 
-	pipeLen = len(stack)-1
-    pipes = make([]*io.PipeWriter, pipeLen)
+	pipeLen = len(stack) - 1
+	pipes = make([]*io.PipeWriter, pipeLen)
 
-    i := 0
-    for ; i < pipeLen; i++ {
-        stdinPipe, stdoutPipe := io.Pipe()
-        
-        stack[i].Stdout = stdoutPipe
-        stack[i].Stderr = &errorBuffer
+	i := 0
 
-     	stack[i+1].Stdin = stdinPipe
-        
-        pipes[i] = stdoutPipe
-    }
-    
-    if getOutput {
+	for ; i < pipeLen; i++ {
+		stdinPipe, stdoutPipe := io.Pipe()
+		stack[i].Stdout = stdoutPipe
+		stack[i].Stderr = &errorBuffer
+		stack[i+1].Stdin = stdinPipe
+		pipes[i] = stdoutPipe
+	}
+
+	if getOutput {
 		stack[i].Stdout = outputBuffer
 	} else {
 		stack[i].Stdout = os.Stdout
 	}
-    
-    stack[i].Stderr = os.Stderr
 
-    log.Println("ExecuteCmdPipe: stack ->", stack)
-  	log.Println("ExecuteCmdPipe: pipes ->", pipes)
-  	log.Println("ExecuteCmdPipe: pipeLen     ->", pipeLen)
-  	log.Println("ExecuteCmdPipe: want output ->", getOutput)
-
-    if err := executePipe(stack, pipes); err != nil {
-        return fmt.Errorf("executePipe(%s): %v", errorBuffer.Bytes(), err)
-    }
-    
-    return err
+	stack[i].Stderr = os.Stderr
+
+	log.Println("ExecuteCmdPipe: stack ->", stack)
+	log.Println("ExecuteCmdPipe: pipes ->", pipes)
+	log.Println("ExecuteCmdPipe: pipeLen     ->", pipeLen)
+	log.Println("ExecuteCmdPipe: want output ->", getOutput)
+
+	if err := executePipe(stack, pipes); err != nil {
+		return fmt.Errorf("executePipe(%s): %v", errorBuffer.Bytes(), err)
+	}
+
+	return err
+
 }
 
 // executePipe is a helper recursive function for ExecuteCmdPipe
-func executePipe(stack []*exec.Cmd, pipes []*io.PipeWriter) (err error) {
-    if stack[0].Process == nil {
-        if err = stack[0].Start(); err != nil {
-            return err
-        }
-    }
-    
-    if len(stack) > 1 {
-        if err = stack[1].Start(); err != nil {
-             return err
-        }
-        
-        defer func() {
-            if err == nil {
-                pipes[0].Close()
-                err = executePipe(stack[1:], pipes[1:])
-            }
-        }()
-    }
-    
-    return stack[0].Wait()
+func executePipe(stack []*exec.Cmd, pipes []*io.PipeWriter) (err error) {
+	if stack[0].Process == nil {
+		if err = stack[0].Start(); err != nil {
+			return err
+		}
+	}
+
+	if len(stack) > 1 {
+		if err = stack[1].Start(); err != nil {
+			return err
+		}
+
+		defer func() {
+			if err == nil {
+				pipes[0].Close()
+				err = executePipe(stack[1:], pipes[1:])
+			}
+		}()
+	}
+
+	return stack[0].Wait()
 }
 
 // RunInteractiveShell runs a shellcommand interactively
@@ -179,58 +178,58 @@ func RunInteractiveShell(input string, wait bool, getOutput bool) (string, error
 	if err != nil {
 		return "", err
 	}
-	
+
 	if len(args) == 0 {
 		return "", errors.New("No arguments")
 	}
 
 	commands := strings.Split(input, "|")
 
-	// Shut down the screen because we're going to interact 
+	// Shut down the screen because we're going to interact
 	// directly with the shell and defer the screen backup
 	screenb := screen.TempFini()
 	defer screen.TempStart(screenb)
-	
-   	outputBuffer := &bytes.Buffer{}
 
-	stack := make([]*exec.Cmd, len(commands)) 
+	outputBuffer := &bytes.Buffer{}
+
+	stack := make([]*exec.Cmd, len(commands))
 
 	for i := range commands {
 		iArgs, err := shellquote.Split(commands[i])
 		if err != nil {
 			return "", err
 		}
-		
+
 		stack[i] = exec.Command(iArgs[0], iArgs[1:]...)
 	}
-	
-   	log.Println("RunInteractiveShell: stack ->", stack)
+
+	log.Println("RunInteractiveShell: stack ->", stack)
 
 	c := make(chan os.Signal, 1)
-   	signal.Notify(c, os.Interrupt)
-   	go func() {
-   		for range c {
-   			for i := range args {
-   				if stack[i].Process != nil {
-   					stack[i].Process.Kill()
-   				}
-   			}
-   		}
-   	}()
-	
-   	err = executeCmdPipe(outputBuffer, getOutput, stack...)
-   	if err != nil {
-		log.Println("RunInteractiveShell: got error ->", err)
-   	}
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		for range c {
+			for i := range args {
+				if stack[i].Process != nil {
+					stack[i].Process.Kill()
+				}
+			}
+		}
+	}()
 
-   	log.Println("RunInteractiveShell: outputBuffer ->", outputBuffer)
-   			
-	if wait {
-		// This is just so we don't return right away and let the user press enter to return
-		screen.TermMessage("")
+	err = executeCmdPipe(outputBuffer, getOutput, stack...)
+	if err != nil {
+		log.Println("RunInteractiveShell: got error ->", err)
 	}
-   	
-	return outputBuffer.String(), err;
+
+	log.Println("RunInteractiveShell: outputBuffer ->", outputBuffer)
+
+	if wait {
+		// This is just so we don't return right away and let the user press enter to return
+		screen.TermMessage("")
+	}
+
+	return outputBuffer.String(), err
 }
 
 // UserCommand runs the shell command


### PR DESCRIPTION
Today I was working in my fzf plugin and wanted to create a command so that I can grep the current directory for a given a string and pipe the result to fzf
```bash
grep --line-buffered --color=never -rnw {some_pattern} * | fzf
```
but the `shell.RunInteractiveShell` keep not working and only returning the first part.

After some research on the behavior of the `RunInteractiveShell` it was obvious that it only supported one command at a time. This is _ok_, I guess that the use case of this function is not make it a _mini shell_, for that there's the TermEmulator. 

But nevertheless, I think is really nice to have this functionality in shell mode, as it give you power to run almost any command, fast and within the editor view (eg. searching for patterns and piping result somewhere).


I implemented it as it accepts as pipes as the user wants. I think the code for the singular case can be joined into the general case with some conditionals, but the proposed solutions works. Can be done in a future refactor if wanted.

Just for the hypes, here's the functionality working:

![micro_shell_fork_fast](https://user-images.githubusercontent.com/9470158/79694907-d84d0e80-8273-11ea-9eeb-882f1a1ca4fa.gif)