### PR TITLE
Add .inl as a C++ file extension

### DIFF
--- a/runtime/syntax/c++.yaml
+++ b/runtime/syntax/c++.yaml
@@ -1,7 +1,7 @@
 filetype: c++
 
 detect: 
-    filename: "\\.c(c|pp|xx)$|\\.h(h|pp|xx)$|\\.ii?$|\\.(def)$"
+    filename: "\\.c(c|pp|xx)$|\\.h(h|pp|xx)$|\\.inl$|\\.ii?$|\\.(def)$"
 
 rules:
     - identifier: "\\b[A-Z_][0-9A-Z_]+\\b"


### PR DESCRIPTION
`.inl` is a file extension sometimes used by header-only libraries as an inline implementation file. One example is [GLM](https://github.com/g-truc/glm).