### PR TITLE
Adds command "tabmove ±n", for better tab management

### DIFF
--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -194,8 +194,7 @@ func (h *BufPane) TabMoveCmd(args []string) {
 	}
 
 	// Restrain position to within the valid range
-	idxTo = util.Min(idxTo, len(Tabs.List)-1)
-	idxTo = util.Max(idxTo, 0)
+	idxTo = util.Clamp(0, len(tabs.List)-1)
 
 	activeTab := Tabs.List[idxFrom]
 	Tabs.RemoveTab(activeTab.ID())

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -194,7 +194,7 @@ func (h *BufPane) TabMoveCmd(args []string) {
 	}
 
 	// Restrain position to within the valid range
-	idxTo = util.Clamp(0, len(tabs.List)-1)
+	idxTo = util.Clamp(idxTo, 0, len(tabs.List)-1)
 
 	activeTab := Tabs.List[idxFrom]
 	Tabs.RemoveTab(activeTab.ID())

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -194,7 +194,7 @@ func (h *BufPane) TabMoveCmd(args []string) {
 	}
 
 	// Restrain position to within the valid range
-	idxTo = util.Clamp(idxTo, 0, len(tabs.List)-1)
+	idxTo = util.Clamp(idxTo, 0, len(Tabs.List)-1)
 
 	activeTab := Tabs.List[idxFrom]
 	Tabs.RemoveTab(activeTab.ID())

--- a/runtime/help/commands.md
+++ b/runtime/help/commands.md
@@ -62,6 +62,11 @@ quotes here but these are not necessary when entering the command in micro.
 
 * `tab 'filename'`: opens the given file in a new tab.
 
+* `tabmove '[-+]?n'`: Moves the active tab to another slot. `n` is an integer.
+   If `n` is prefixed with `-` or `+`, then it represents a relative position
+   (e.g. `tabmove +2` moves the tab to the right by `2`). If `n` has no prefix,
+   it represents an absolute position (e.g. `tabmove 2` moves the tab to slot `2`).
+
 * `tabswitch 'tab'`: This command will switch to the specified tab. The `tab`
    can either be a tab number, or a name of a tab.
 


### PR DESCRIPTION
I'm used to being able to switch and swap tabs all the time and couldn't find a way to do it in here, yet. I haven't made this a default for anything (was thinking `Alt-<` and `Alt->` could do left/right) ~~and haven't put it in any documentation, yet~~ (now I have!)

Some usage info I _did_ type up, though:

----

Tab Move
---------

Moves active tab to another slot while maintaining its focus.

### Usage

`> tabmove ±?n`

1. `±` is an *optional* character, either `+` or `-`
	- if it prefixes `n`, `n` will describe a relative position (left and right, respectively)
2. `n` is an integer.
	- if not prefixed by `±`, describes an absolute position (resolving to the closest slot available)

### Examples

`> tabmove 20`	moves active tab to slot `min(numSlots, 20)`
`> tabmove 3` 	moves active tab to slot `min(numSlots, 3)`
`> tabmove 0` 	moves active tab to slot `0`
`> tabmove -2`  moves active tab left by (at most) `2` 
`> tabmove +1`  moves active tab right by (at most) `1`
`> tabmove +20` moves active tab right by (at most) `20`

### Notes

I'm used to this command in Vim and VSCode, but it's missing from `micro`, so I added it.

### Action Items	

- [x] Get command working
- [x] Custom keybinding for `command:tabmove ±1`
- [x] Documentation