### PR TITLE
Fix unbind of a rune

### DIFF
--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -249,6 +249,7 @@ func UnbindKey(k string) error {
 		if a, ok := defaults[k]; ok {
 			BindKey(k, a)
 		} else if _, ok := config.Bindings[k]; ok {
+			BufUnmap(key)
 			delete(config.Bindings, k)
 		}
 

--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -139,6 +139,17 @@ func BufMapMouse(k MouseEvent, action string) {
 	}
 }
 
+// BufUnmap unmaps a key or mouse event from any action
+func BufUnmap(k Event) {
+	delete(BufKeyBindings, k)
+	delete(BufKeyStrings, k)
+
+	switch e := k.(type) {
+	case MouseEvent:
+		delete(BufMouseBindings, e)
+	}
+}
+
 // The BufPane connects the buffer and the window
 // It provides a cursor (or multiple) and defines a set of actions
 // that can be taken on the buffer


### PR DESCRIPTION
Fix problem with non-working unbind of a rune key.
E.g. after the following commands:

bind "n" "FindNext"
unbind "n"

Observed result: "n" key still triggers FindNext action
Expected result: "n" key inserts "n" rune