### PR TITLE
Fix end line number in HighlightMatches

### DIFF
--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -152,14 +152,14 @@ func (b *SharedBuffer) MarkModified(start, end int) {
 		return
 	}
 
-	start = util.Clamp(start, 0, len(b.lines))
-	end = util.Clamp(end, 0, len(b.lines))
+	start = util.Clamp(start, 0, len(b.lines)-1)
+	end = util.Clamp(end, 0, len(b.lines)-1)
 
 	l := -1
 	for i := start; i <= end; i++ {
 		l = util.Max(b.Highlighter.ReHighlightStates(b, i), l)
 	}
-	b.Highlighter.HighlightMatches(b, start, l+1)
+	b.Highlighter.HighlightMatches(b, start, l)
 }
 
 // DisableReload disables future reloads of this sharedbuffer

--- a/pkg/highlight/highlighter.go
+++ b/pkg/highlight/highlighter.go
@@ -336,11 +336,11 @@ func (h *Highlighter) HighlightStates(input LineStates) {
 	}
 }
 
-// HighlightMatches sets the matches for each line in between startline and endline
+// HighlightMatches sets the matches for each line from startline to endline
 // It sets all other matches in the buffer to nil to conserve memory
 // This assumes that all the states are set correctly
 func (h *Highlighter) HighlightMatches(input LineStates, startline, endline int) {
-	for i := startline; i < endline; i++ {
+	for i := startline; i <= endline; i++ {
 		if i >= input.LinesNum() {
 			break
 		}


### PR DESCRIPTION
There is a bit of mess in the usage of HighlightMatches: in some places
we assume that it updates lines from startline to endline inclusive,
in other places we assume it's non-inclusive.
This fix makes it always inclusive.

In particular, it fixes a bug: when we open a file which has no
newline at the end, the last line isn't highlighted.