### PR TITLE
Initial support for highlighting all search matches

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -924,9 +924,8 @@ func (h *BufPane) FindPrevious() bool {
 	return true
 }
 
+// ToggleHighlightSearch toggles highlighting of the last search matches
 func (h *BufPane) ToggleHighlightSearch() bool {
-	// We could just highlight our lastSearch. But we want to allow users
-	// to override hlsearch pattern via HighlightCustomPattern() from Lua.
 	if h.lastHlSearch != "" {
 		if !h.highlightSearch {
 			h.HighlightCustomPattern("hlsearch", h.lastHlSearch)

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -846,6 +846,17 @@ func (h *BufPane) find(useRegex bool) bool {
 				h.Cursor.GotoLoc(h.Cursor.CurSelection[1])
 				h.lastSearch = resp
 				h.lastSearchRegex = useRegex
+
+				if h.Buf.Settings["hlsearch"].(bool) {
+					regex := resp
+					if !useRegex {
+						regex = regexp.QuoteMeta(regex)
+					}
+					if h.Buf.Settings["ignorecase"].(bool) {
+						regex = "(?i)" + regex
+					}
+					h.HighlightCustomPattern("hlsearch", regex)
+				}
 			} else {
 				h.Cursor.ResetSelection()
 				InfoBar.Message("No matches found")
@@ -911,6 +922,21 @@ func (h *BufPane) FindPrevious() bool {
 	}
 	h.Relocate()
 	return true
+}
+
+func (h *BufPane) ToggleHighlightSearch() bool {
+	// We could just highlight our lastSearch. But we want to allow users
+	// to override hlsearch pattern via HighlightCustomPattern() from Lua.
+	if h.lastHlSearch != "" {
+		if !h.highlightSearch {
+			h.HighlightCustomPattern("hlsearch", h.lastHlSearch)
+		} else {
+			h.HighlightCustomPattern("hlsearch", "")
+		}
+		return true
+	} else {
+		return false
+	}
 }
 
 // Undo undoes the last action

--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -196,8 +196,11 @@ type BufPane struct {
 	lastSearch      string
 	lastSearchRegex bool
 
+	// Should we highlight the last search matches
 	highlightSearch bool
-	lastHlSearch    string
+	// Last highlighted search pattern. Usually it is the same as lastSearch
+	// but we allow users to override hlsearch pattern via HighlightCustomPattern() from Lua
+	lastHlSearch string
 
 	// Should the current multiple cursor selection search based on word or
 	// based on selection (false for selection, true for word)
@@ -534,6 +537,17 @@ func (h *BufPane) SetActive(b bool) {
 
 }
 
+// HighlightCustomPattern highlights a custom regex pattern with colors of the given
+// colorscheme group.
+//
+// Custom patterns are highlighted independently of syntax highlighting. They are overlayed
+// on top of syntax highlighting. Each next custom pattern is overlayed on top of previous
+// custom patterns.
+//
+// Multiple custom patterns for the same group are not supported.
+//
+// If regex is an empty string, HighlightCustomPattern clears custom highlighting for the
+// given group.
 func (h *BufPane) HighlightCustomPattern(group, regex string) error {
 	if regex != "" {
 		// validate the regex before doing anything

--- a/internal/action/infopane.go
+++ b/internal/action/infopane.go
@@ -123,6 +123,7 @@ var InfoNones = []string{
 	"HalfPageUp",
 	"HalfPageDown",
 	"ToggleHelp",
+	"ToggleHighlightSearch",
 	"ToggleKeyMenu",
 	"ToggleDiffGutter",
 	"ToggleRuler",

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -195,6 +195,7 @@ var defaultCommonSettings = map[string]interface{}{
 	"fastdirty":      false,
 	"fileformat":     "unix",
 	"filetype":       "unknown",
+	"hlsearch":       false,
 	"ignorecase":     false,
 	"indentchar":     " ",
 	"keepautoindent": false,

--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -368,6 +368,12 @@ func (w *BufWindow) drawLineNum(lineNumStyle tcell.Style, softwrapped bool, maxL
 // If there is no change to the current highlight style it just returns that
 func (w *BufWindow) getStyle(style tcell.Style, bloc buffer.Loc) (tcell.Style, bool) {
 	if group, ok := w.Buf.Match(bloc.Y)[bloc.X]; ok {
+		if group.String() == "hlsearch" {
+			if s, ok := config.Colorscheme["hlsearch"]; !ok {
+				s = config.DefStyle.Reverse(true)
+				return s, true
+			}
+		}
 		s := config.GetColor(group.String())
 		return s, true
 	}

--- a/pkg/highlight/highlighter.go
+++ b/pkg/highlight/highlighter.go
@@ -94,6 +94,11 @@ func NewHighlighter(def *Def) *Highlighter {
 	return h
 }
 
+// SetDef changes highlighter syntax definition to `def`
+func (h *Highlighter) SetDef(def *Def) {
+	h.Def = def
+}
+
 // LineMatch represents the syntax highlighting matches for one line. Each index where the coloring is changed is marked with that
 // color's group (represented as one byte)
 type LineMatch map[int]Group

--- a/runtime/help/keybindings.md
+++ b/runtime/help/keybindings.md
@@ -218,6 +218,7 @@ StartOfTextToggle
 ParagraphPrevious
 ParagraphNext
 ToggleHelp
+ToggleHighlightSearch
 ToggleDiffGutter
 ToggleRuler
 JumpLine

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -132,6 +132,14 @@ Here are the available options:
 	default value: `unknown`. This will be automatically overridden depending
     on the file you open.
 
+* `hlsearch`: highlight all search matches after a successful search.
+   Once it is highlighted, it can be turned off and on with a key bound to
+   `ToggleHighlightSearch` action. Note that `ToggleHighlightSearch` doesn't
+   change `hlsearch` setting, it only affects the last search. After the
+   next search the highlighting is turned on again.
+
+	default value: `false`
+
 * `ignorecase`: perform case-insensitive searches.
 
 	default value: `false`


### PR DESCRIPTION
Ref #1533 

Highlighting all search matches implemented via reusing the syntax highlighter functionality.

In this initial version it is implemented via dynamic adding/removing of custom regex patterns to the Highlighter's syntax def. This is just a quick temporary hack. Instead we should add/remove them to a separate custom highlighting layer independent of file syntax highlighting.
- If "syntax" option is true, custom highlighting should be overlayed on top of syntax highlighting.
- If "syntax" option is false, only custom highlighting should be displayed.

This overlaying can be implemented inside Highlighter. Or perhaps we can use 2 separate Highlighter instances for syntax and custom highlighting respectively, and overlay them e.g. in displayBuffer().

**UPDATE:** this is already implemented (see below).

### TODO:

- Issues which should go away after replacing the hack with a proper implementation as described above (_UPDATE:_ already done):
  - [x] It doesn't highlight matches which are inside syntax regions, e.g. inside a quoted string or a comment.
  - [x] It doesn't work when syntax highlighting is turned off ("syntax" option set to false).
  - [x] Search highlighting disappears after saving the file.
- Issues which are actually general highlighting issues (i.e. observed with syntax highlighting as well), just more easily noticeable when using search highlighting:
  - [x] If search match is at the end of line, then not only the match but also the newline is highlighted. See #1664. Fixed by #1705 
  - [x] If cursorline is enabled, search matches in the current line are not highlighted. See #1665. Fixed by #1697.
  - [x] Some lines may not be highlighted. Fixed by #1662  
  - [x] With very small files, search highlighting is often not fully displayed until the next key or mouse event. Fixed by #1675 
- Other issues:
  - [x] Currently it requires `hlsearch` color setting in colorscheme file for proper highlighting. So, to make it nice, we should either add `hlsearch` to all our colorschemes, or support some default color setting for it (which one?). (_UPDATE:_ added default color setting same as for selection)

## How to use it:

Set "hlsearch" option to true (it is set to false by default):

`set hlsearch true`

Now, after searching, all search results will be highlighted.
To toggle highlighting of the last search via a hotkey, bind it to ToggleHighlightSearch action, e.g.:

`bind Alt-h ToggleHighlightSearch`

By default, search results are highlighted with the same colors as the selection (i.e. reverse default colors). To make it look nicer, you can add "hlsearch" color setting to the colorscheme file, e.g.:

`color-link hlsearch "0,180"`

## Advanced usage:

A generic BufPane method HighlightCustomPattern is available to Lua:

`func (h *BufPane) HighlightCustomPattern(group, regex string) error`

It highlights all matches of the given `regex` pattern with colors of the given highlight `group` from colorscheme file. So, it allows highlighting multiple different patterns with different colors.
If another custom pattern is already highlighted with `group`, it is replaced with `regex` pattern.
If `regex` is an empty string, it clears highlighting with `group`.

Example init.lua:
```
local config = import("micro/config")
local regexp = import("regexp")

function hlsearchWord(bp)
    if not bp.Cursor:HasSelection() then
        bp.Cursor:SelectWord()
    end
    bp:HighlightCustomPattern("hlsearch", regexp.QuoteMeta(bp.Cursor:GetSelection()))
end

function init()
    config.TryBindKey("Alt-s", "lua:initlua.hlsearchWord", true)
    config.MakeCommand("hlmatch", function(bp, args)
        bp:HighlightCustomPattern(args[2], args[1])
    end, config.NoComplete)
end
```

With this example, `Alt-s` highlights all occurrences of the selected text. If there is no selection, it highlights all occurrences of the word under cursor.
Also it adds `hlmatch` command which highlights arbitrary pattern with arbitrary colors. For example, this highlights all trailing whitespaces:

`hlmatch "\s+$" "0,lightred"`

(Yes, HighlightCustomPattern also allows specifying the color spec directly, instead of the group name from colorscheme file. It's just a trick but it works.)