### PR TITLE
README: Add Fedora install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ via `apt`:
 sudo apt install micro
 ```
 
+On Fedora, micro is available via `dnf`:
+
+```
+sudo dnf install micro
+```
+
 **Note for Linux:** for interfacing with the local system clipboard, `xclip` or `xsel`
 must be installed. Please see the section on [Linux clipboard support](https://github.com/zyedidia/micro#linux-clipboard-support)
 further below.


### PR DESCRIPTION
Current version is 2.0.1 so it's slightly behind the source but not much.
Wiki has to be updated too but I couldn't find a way to make a pull request to it.