### PR TITLE
[Feed back] add option unicodeBox and draw unicode box if true 

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -219,6 +219,7 @@ var defaultCommonSettings = map[string]interface{}{
 	"tabmovement":    false,
 	"tabsize":        float64(4),
 	"tabstospaces":   false,
+	"unicodeBox":     false,
 	"useprimary":     true,
 }
 

--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -682,8 +682,16 @@ func (w *BufWindow) displayStatusLine() {
 		w.sline.Display()
 	} else if w.Y+w.Height != infoY {
 		w.drawStatus = true
+		// use unicode box Horizontal or ascii dash for the statusbar
+		var dashChar rune = '-'       // ascii dash
+		var dashCharStyle bool = true // highlighting the status line
+		if config.GetGlobalOption("unicodeBox") == true {
+			dashChar = '─'        // unicode U+2500 Box Drawings Light Horizontal
+			dashCharStyle = false // no highlighting on the status line
+		}
+		// draw the statusbar line
 		for x := w.X; x < w.X+w.Width; x++ {
-			screen.SetContent(x, w.Y+w.Height-1, '-', nil, config.DefStyle.Reverse(true))
+			screen.SetContent(x, w.Y+w.Height-1, dashChar, nil, config.DefStyle.Reverse(dashCharStyle))
 		}
 	} else {
 		w.drawStatus = false
@@ -703,7 +711,13 @@ func (w *BufWindow) displayScrollBar() {
 		}
 		barstart := w.Y + int(float64(w.StartLine)/float64(w.Buf.LinesNum())*float64(w.Height))
 		for y := barstart; y < util.Min(barstart+barsize, w.Y+bufHeight); y++ {
-			screen.SetContent(scrollX, y, '|', nil, config.DefStyle.Reverse(true))
+			// use unicode box Vertical or ascii dash for the scrollbar line
+			var dashChar rune = '|' // ascii character
+			if config.GetGlobalOption("unicodeBox") == true {
+				dashChar = '│' // unicode U+2502 Box Drawings Light Vertical
+			}
+			// draw the scrollbar line
+			screen.SetContent(scrollX, y, dashChar, nil, config.DefStyle.Reverse(true))
 		}
 	}
 }

--- a/internal/display/uiwindow.go
+++ b/internal/display/uiwindow.go
@@ -26,9 +26,17 @@ func (w *UIWindow) drawNode(n *views.Node) {
 
 	for i, c := range cs {
 		if c.IsLeaf() && c.Kind == views.STVert {
+			// use unicode box Vertical or ascii dash for vertical line
+			var dashChar rune = '|'       // ascii character
+			var dashCharStyle bool = true // highlighting the vertical line
+			if config.GetGlobalOption("unicodeBox") == true {
+				dashChar = '│'        // unicode U+2502 Box Drawings Light Vertical
+				dashCharStyle = false // no highlighting on the vertical line
+			}
+			// draw the scrollbar line
 			if i != len(cs)-1 {
 				for h := 0; h < c.H; h++ {
-					screen.SetContent(c.X+c.W, c.Y+h, '|', nil, dividerStyle.Reverse(true))
+					screen.SetContent(c.X+c.W, c.Y+h, dashChar, nil, dividerStyle.Reverse(dashCharStyle))
 				}
 			}
 		} else {


### PR DESCRIPTION
issue #1673
This code does not let you choose the characters for the divider but the code could be changed so that it could take in more options if needed.

But to keep the options simple I only added one option `unicodeBox` if set too true it will use the box unicode values and removes the highlighting from the lines. 
The variables could be changed to better names.

Pushed here for feed back. 

`Go` code might not be the best as I am only a hobby programmer.

See picture below for tested example on mac OS in iterm2.


![Screenshot 2020-05-21 at 06 13 34](https://user-images.githubusercontent.com/1952659/82528880-a8727e80-9b31-11ea-8d46-b2da6ba684e9.png)
