### PR TITLE
Fix dropped redraw events

### DIFF
--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -363,6 +363,9 @@ func DoEvent() {
 	case <-shell.CloseTerms:
 	case event = <-events:
 	case <-screen.DrawChan():
+		for len(screen.DrawChan()) > 0 {
+			<-screen.DrawChan()
+		}
 	}
 
 	if action.InfoBar.HasPrompt {

--- a/internal/screen/screen.go
+++ b/internal/screen/screen.go
@@ -127,7 +127,7 @@ func TempStart(screenWasNil bool) {
 
 // Init creates and initializes the tcell screen
 func Init() {
-	drawChan = make(chan bool)
+	drawChan = make(chan bool, 8)
 
 	// Should we enable true color?
 	truecolor := os.Getenv("MICRO_TRUECOLOR") == "1"


### PR DESCRIPTION
This PR makes the draw channel buffered again (but keeps `screen.Redraw` non-blocking, so no worry about freezes), in order to fix the following issue.

If `screen.Redraw()` is called very quickly after a key or mouse event, it may send the redraw event while micro is not waiting for it but still processing the key or mouse event. Since `drawChan` is non-buffered and at the same time non-blocking, this redraw event will be simply lost, so the screen content will not be up-to-date.

An easy way to reproduce this problem is to use my PR #1663 which adds support for highlighting all search matches. Sometimes, especially with very small files, this search highlighting is not fully displayed until the next key or mouse event. The reason is that search highlighting is typically started after a Find or a hotkey, i.e. immediately after a key event, and with small files highlighting finishes very quickly..

However, I believe I sometimes (very rarely) observed this problem without #1663 as well. Sometimes (very rarely) after opening a file, syntax highlighting is not displayed until the next key or mouse event.

