### PR TITLE
set bash-fc file's syntax as shell

### DIFF
--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -1,7 +1,7 @@
 filetype: shell
 
 detect:
-    filename: "(\\.sh$|\\.bash|\\.ash|\\.bashrc|bashrc|\\.bash_aliases|bash_aliases|\\.bash_functions|bash_functions|\\.bash_profile|bash_profile|\\.profile|profile|Pkgfile|pkgmk.conf|profile|rc.conf|PKGBUILD|.ebuild\\$|APKBUILD)"
+    filename: "(\\.sh$|\\.bash|\\.ash|\\.bashrc|bashrc|\\.bash_aliases|bash_aliases|\\.bash_functions|bash_functions|\\.bash_profile|bash_profile|\\.profile|profile|bash-fc\\.|Pkgfile|pkgmk.conf|profile|rc.conf|PKGBUILD|.ebuild\\$|APKBUILD)"
     header: "^#!.*/(env +)?(ba)?(a)?sh( |$)"
 
 rules:

--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -1,7 +1,7 @@
 filetype: shell
 
 detect:
-    filename: "(\\.sh$|\\.bash|\\.ash|\\.bashrc|bashrc|\\.bash_aliases|bash_aliases|\\.bash_functions|bash_functions|\\.bash_profile|bash_profile|\\.profile|profile|bash-fc\\.|Pkgfile|pkgmk.conf|profile|rc.conf|PKGBUILD|.ebuild\\$|APKBUILD)"
+    filename: "(\\.sh$|\\.bash|\\.ash|bashrc|bash_aliases|bash_functions|profile|bash-fc\\.|Pkgfile|pkgmk.conf|rc.conf|PKGBUILD|.ebuild\\$|APKBUILD)"
     header: "^#!.*/(env +)?(ba)?(a)?sh( |$)"
 
 rules:


### PR DESCRIPTION
### bfc68b2: set bash-fc file's syntax as shell

Bash has a feature to edit command line in editor, by `edit-and-execute-command` (which is usually bound to `C-x C-e`) or built-in `fc` command.

For this feature, bash creates temporary file named `bash-fc.${some_random_suffix}`, of which syntax highlight language should be shell.

I added this filename pattern.

### d262fcf: remove dups from shell file matcher

As a bonus, I tidied up regex by removing some duplicated patterns.

If filename matches against `\.bashrc`, then it always matches against `bashrc` too, so we don't need to have former one.