### PR TITLE
Rewrite TOML syntax file

### DIFF
--- a/runtime/syntax/toml.yaml
+++ b/runtime/syntax/toml.yaml
@@ -4,39 +4,53 @@ detect:
     filename: "\\.toml"
 
 rules:
-    - statement: "(.*)[[:space:]]="
-    - special: "="
-
-      # Bracket thingies
-    - special: "(\\[|\\])"
-
-      # Numbers and strings
-    - constant.number: "\\b([0-9]+|0x[0-9a-fA-F]*)\\b|'.'"
-    - constant.number: "\\\\([0-7]{3}|x[A-Fa-f0-9]{2}|u[A-Fa-f0-9]{4}|U[A-Fa-f0-9]{8})"
-
+    # Punctuation
+    - symbol: '[=,\.]'
+    - symbol.brackets: '[{\[\]}]'
+    # Strings
     - constant.string:
-        start: "\""
-        end: "\""
-        skip: "\\\\."
+        start: '"""'
+        end: '\"{3,5}'
+        skip: '\\.'
         rules:
-            - constant.specialChar: "\\\\."
-
+            - constant.specialChar: '\\u[[:xdigit:]]{4}'
+            - constant.specialChar: '\\U[[:xdigit:]]{8}'
+            - constant.specialChar: '\\[btnfr"\\]'
+    - constant.string:
+        start: '"'
+        end: '"'
+        skip: '\\.'
+        rules:
+            - constant.specialChar: '\\u[[:xdigit:]]{4}'
+            - constant.specialChar: '\\U[[:xdigit:]]{8}'
+            - constant.specialChar: '\\[btnfr"\\]'
+    - constant.string:
+        start: "'''"
+        end: "'{3,5}"
+        rules: []
     - constant.string:
         start: "'"
         end: "'"
-        skip: "\\\\."
-        rules:
-            - constant.specialChar: "\\\\."
-
-    - constant.string:
-        start: "`"
-        end: "`"
-        rules:
-            - constant.specialChar: "\\\\."
-
+        rules: []
+    # Integer
+    - constant.number: '[+-]?(\d+_)*\d+\b'
+    - constant.number: '(0x([[:xdigit:]]+_)*[[:xdigit:]]+|0o([0-7]_)*[0-7]+|0b([01]+_)*[01]+)'
+    # Float
+    - constant.number: '[+-]?(\d+_)*\d+\.(\d+_)*\d+'
+    - constant.number: '[+-]?(\d+_)*\d+(\.(\d+_)*\d+)?[Ee][+-]?(\d+_)*\d+'
+    - constant.number: '(\+|-)(inf|nan)'
+    # Bare key, keys starting with a digit or dash are ambiguous with numbers and are skipped
+    - identifier: '\b[A-Za-z_][A-Za-z0-9_-]*\b'
+    # Boolean and inf, nan without sign
+    - constant.bool.true: '\btrue\b'
+    - constant.bool.false: '\bfalse\b'
+    - constant.number: '\b(inf|nan)\b'
+    # Date and Time
+    - constant: '\d+-\d{2}-\d{2}([T ]\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d{2}:\d{2}|Z)?)?'
+    - constant: '\d{2}:\d{2}:\d{2}(\.\d+)?'
+    # Comments
     - comment:
         start: "#"
         end: "$"
         rules:
             - todo: "(TODO|XXX|FIXME):?"
-


### PR DESCRIPTION
[TOML][TOML] recently released v1.0.0-rc.1. It is a lightweight language for config files. Since the syntax highlighting for TOML was originally written the specification changed quite much.

I rewrote the syntax file and made sure to include correct regexes for all value types (strings with escaping, hexadecimal/octal/binary numbers, date and time). Additionally the new syntax file covers many edge-cases from the specification. 

New highlighting of the example file:

![new-highlighting](https://user-images.githubusercontent.com/2781017/82812045-624f4f00-9e92-11ea-8fb1-2d982dee9127.png)

Old highlighting of the example file:

![old-highlighting](https://user-images.githubusercontent.com/2781017/82812055-67ac9980-9e92-11ea-96a1-aa59ff460d3c.png)
The datetime has multiple different colors, punctuation and keys within table headers are not highlighted at all.

This is a more complex example showing some of the advanced syntax of TOML:

![new-highlighting-difficult](https://user-images.githubusercontent.com/2781017/82812057-69765d00-9e92-11ea-94b6-bb9926596d3c.png)

```toml
str7 = """"This," she said, "is just a pointless statement.""""
int6 = 5_349_221
hex2 = 0xdeadbeef
flt5 = 1e06
flt6 = 1.23
odt4 = 1979-05-27 07:32:00Z
sharp-s = "This is a sharp s: \u00df"
```

Right now GitHub too shows wrong highlighting for this snippet.

Caveats:

* Bare keys starting with a digit or dash are not highlighted because they could be numbers. 
* Bare keys with the names `nan` and `inf` are highlighted as if they were floating point infinity or NaN.
* Bare keys with the name `true` or `false` are highlighted like booleans.

[TOML]: https://github.com/toml-lang/toml