### PR TITLE
Add pkgsrc instruction to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ for other operating systems. These packages are not guaranteed to be up-to-date.
     * `scoop install micro`.
 * OpenBSD: Available in the ports tree and also available as a binary package.
     * `pkd_add -v micro`.
+* NetBSD, macOS, Linux, Illumos, etc. with [pkgsrc](http://www.pkgsrc.org/)-current:
+    * `pkg_add micro`
 
 ### Building from source
 


### PR DESCRIPTION
I've packaged micro for [pkgsrc](http://www.pkgsrc.org/), a portable package manager. It's the default on NetBSD, SmartOS, and Minix but supports many other platforms too.

Perhaps something along these lines can be added to the wiki:

```markdown
## pkgsrc

On NetBSD or any other [pkgsrc](http://www.pkgsrc.org/)-supported platform
like Illumos, Linux, or macOS micro can be installed from source:

    $ cd /usr/pkgsrc/editors/micro
    $ bmake install

Or binary package, if available:

    # pkg_add micro
```