### PR TITLE
Add mksh to the set of supported shells

### DIFF
--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -2,7 +2,7 @@ filetype: shell
 
 detect:
     filename: "(\\.sh$|\\.bash|\\.ash|bashrc|bash_aliases|bash_functions|profile|bash-fc\\.|Pkgfile|pkgmk.conf|rc.conf|PKGBUILD|.ebuild\\$|APKBUILD)"
-    header: "^#!.*/(env +)?(ba)?(a)?sh( |$)"
+    header: "^#!.*/(env +)?(ba)?(a)?(mk)?sh( |$)"
 
 rules:
     # Numbers


### PR DESCRIPTION
It's common practice to have shell scripts in /etc/periodic and similar without the .sh extension.
mksh(1) is a modern fork of public domain ksh that is often used instead of sh for features like pipefall and logic math on $? and similar, and instead of bash by people that prefer the ksh family of shells.

This patch simply adds support for detecting `#/bin/mksh` the same way bash, ash etc is handled.