### PR TITLE
python.yaml: add async as a keyword

### DIFF
--- a/runtime/syntax/python3.yaml
+++ b/runtime/syntax/python3.yaml
@@ -18,7 +18,7 @@ rules:
       # definitions
     - identifier: "def [a-zA-Z_0-9]+"
       # keywords
-    - statement: "\\b(and|as|assert|await|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|nonlocal|not|or|pass|raise|return|try|while|with|yield)\\b"
+    - statement: "\\b(and|as|assert|async|await|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|nonlocal|not|or|pass|raise|return|try|while|with|yield)\\b"
       # decorators
     - brightgreen: "@.*[(]"
       # operators


### PR DESCRIPTION
`await` is already a keyword, but `async` is not.