### PR TITLE
[Performance] Make determining whether a code point represents a combining mark faster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ bench-compare:
 	for i in 1 2 3; do \
 		go test -bench=. ./internal/...; \
 	done > benchmark_results
-	benchstat benchmark_results_baseline benchmark_results
+	benchstat -alpha 0.15 benchmark_results_baseline benchmark_results
 
 clean:
 	rm -f micro

--- a/internal/util/unicode.go
+++ b/internal/util/unicode.go
@@ -16,6 +16,16 @@ import (
 // For rendering, micro will display the combining characters. It's not perfect
 // but it's pretty good.
 
+var minMark = rune(unicode.Mark.R16[0].Lo)
+
+func isMark(r rune) bool {
+	// Fast path
+	if r < minMark {
+		return false
+	}
+	return unicode.In(r, unicode.Mark)
+}
+
 // DecodeCharacter returns the next character from an array of bytes
 // A character is a rune along with any accompanying combining runes
 func DecodeCharacter(b []byte) (rune, []rune, int) {
@@ -24,7 +34,7 @@ func DecodeCharacter(b []byte) (rune, []rune, int) {
 	c, s := utf8.DecodeRune(b)
 
 	var combc []rune
-	for unicode.In(c, unicode.Mark) {
+	for isMark(c) {
 		combc = append(combc, c)
 		size += s
 
@@ -43,7 +53,7 @@ func DecodeCharacterInString(str string) (rune, []rune, int) {
 	c, s := utf8.DecodeRuneInString(str)
 
 	var combc []rune
-	for unicode.In(c, unicode.Mark) {
+	for isMark(c) {
 		combc = append(combc, c)
 		size += s
 
@@ -61,7 +71,7 @@ func CharacterCount(b []byte) int {
 
 	for len(b) > 0 {
 		r, size := utf8.DecodeRune(b)
-		if !unicode.In(r, unicode.Mark) {
+		if !isMark(r) {
 			s++
 		}
 
@@ -77,7 +87,7 @@ func CharacterCountInString(str string) int {
 	s := 0
 
 	for _, r := range str {
-		if !unicode.In(r, unicode.Mark) {
+		if !isMark(r) {
 			s++
 		}
 	}

--- a/pkg/highlight/unicode.go
+++ b/pkg/highlight/unicode.go
@@ -5,6 +5,16 @@ import (
 	"unicode/utf8"
 )
 
+var minMark = rune(unicode.Mark.R16[0].Lo)
+
+func isMark(r rune) bool {
+	// Fast path
+	if r < minMark {
+		return false
+	}
+	return unicode.In(r, unicode.Mark)
+}
+
 // DecodeCharacter returns the next character from an array of bytes
 // A character is a rune along with any accompanying combining runes
 func DecodeCharacter(b []byte) (rune, []rune, int) {
@@ -13,7 +23,7 @@ func DecodeCharacter(b []byte) (rune, []rune, int) {
 	c, s := utf8.DecodeRune(b)
 
 	var combc []rune
-	for unicode.In(c, unicode.Mark) {
+	for isMark(c) {
 		combc = append(combc, c)
 		size += s
 
@@ -32,7 +42,7 @@ func DecodeCharacterInString(str string) (rune, []rune, int) {
 	c, s := utf8.DecodeRuneInString(str)
 
 	var combc []rune
-	for unicode.In(c, unicode.Mark) {
+	for isMark(c) {
 		combc = append(combc, c)
 		size += s
 
@@ -50,7 +60,7 @@ func CharacterCount(b []byte) int {
 
 	for len(b) > 0 {
 		r, size := utf8.DecodeRune(b)
-		if !unicode.In(r, unicode.Mark) {
+		if !isMark(r) {
 			s++
 		}
 
@@ -66,7 +76,7 @@ func CharacterCountInString(str string) int {
 	s := 0
 
 	for _, r := range str {
-		if !unicode.In(r, unicode.Mark) {
+		if !isMark(r) {
 			s++
 		}
 	}


### PR DESCRIPTION
The call `unicode.In(r, unicode.Mark)` introduced in 5c8a2332d94cae91b67712120cdb6c960a6b3819 is a performance hog. Profiling reveals that a double-digit percentage of Micro's total CPU time is spent inside that function. The reason is that the range table `unicode.Mark` has more than 100 entries, including many highly exotic code points not commonly thought of as "marks".

This PR essentially reverts 5c8a2332d94cae91b67712120cdb6c960a6b3819, except that instead of constructing a range table, it uses a hand-written function that only performs the necessary comparisons. This avoids a bunch of branching and iteration logic from `unicode.In`, which makes it even faster than the previous approach.

The benchmarks demonstrate that this is indeed a huge performance improvement (I had to increase the p-value threshold from 0.05 to 0.15 for benchstat to show this, as 3 benchmark runs are unfortunately still not sufficient to reach p-values that low in most situations):

```
name                           old time/op  new time/op  delta
CreateAndClose10Lines-4        41.3µs ± 1%  55.1µs ± 5%  +33.47%  (p=0.100 n=3+3)
CreateAndClose100Lines-4        122µs ± 4%   135µs ±12%     ~     (p=0.700 n=3+3)
CreateAndClose1000Lines-4       897µs ± 2%   887µs ± 1%     ~     (p=0.700 n=3+3)
CreateAndClose10000Lines-4     9.14ms ± 2%  9.06ms ± 1%     ~     (p=0.700 n=3+3)
CreateAndClose100000Lines-4    86.4ms ± 5%  82.9ms ± 0%     ~     (p=0.700 n=3+3)
CreateAndClose1000000Lines-4    825ms ± 7%   832ms ± 1%     ~     (p=0.700 n=3+3)
Read10Lines-4                  1.90µs ± 3%  1.90µs ± 1%     ~     (p=1.000 n=3+3)
Read100Lines-4                 12.5µs ± 5%  12.4µs ± 2%     ~     (p=1.000 n=3+3)
Read1000Lines-4                 122µs ± 6%   120µs ± 1%     ~     (p=1.000 n=3+3)
Read10000Lines-4               1.47ms ± 9%  1.37ms ± 1%     ~     (p=0.400 n=3+3)
Read100000Lines-4              14.3ms ± 4%  14.3ms ± 0%     ~     (p=0.700 n=3+3)
Read1000000Lines-4              148ms ± 8%   129ms ± 1%  -12.58%  (p=0.100 n=3+3)
Edit10Lines1Cursor-4            245µs ± 3%   158µs ± 0%  -35.53%  (p=0.100 n=3+3)
Edit100Lines1Cursor-4           120µs ± 4%    80µs ± 1%  -33.78%  (p=0.100 n=3+3)
Edit100Lines10Cursors-4        6.50ms ± 3%  4.65ms ± 1%  -28.41%  (p=0.100 n=3+3)
Edit1000Lines1Cursor-4         65.5µs ± 3%  41.9µs ± 1%  -36.06%  (p=0.100 n=3+3)
Edit1000Lines10Cursors-4       5.45ms ± 2%  3.96ms ± 0%  -27.39%  (p=0.100 n=3+3)
Edit1000Lines100Cursors-4       352ms ± 3%   257ms ± 0%  -27.08%  (p=0.100 n=3+3)
Edit10000Lines1Cursor-4         248µs ± 5%   181µs ± 1%  -26.97%  (p=0.100 n=3+3)
Edit10000Lines10Cursors-4      5.49ms ± 1%  4.16ms ± 0%  -24.20%  (p=0.100 n=3+3)
Edit10000Lines100Cursors-4      393ms ± 3%   289ms ± 0%  -26.51%  (p=0.100 n=3+3)
Edit10000Lines1000Cursors-4     33.4s ± 3%   24.7s ± 0%  -26.18%  (p=0.100 n=3+3)
Edit100000Lines1Cursor-4       2.30ms ±24%  1.96ms ± 0%  -14.85%  (p=0.100 n=3+3)
Edit100000Lines10Cursors-4     43.7ms ±24%  36.8ms ± 0%  -15.81%  (p=0.100 n=3+3)
Edit100000Lines100Cursors-4     707ms ± 1%   621ms ± 0%  -12.18%  (p=0.100 n=3+3)
Edit100000Lines1000Cursors-4    35.3s ± 5%   27.7s ± 0%  -21.56%  (p=0.100 n=3+3)
Edit1000000Lines1Cursor-4       433µs ± 1%   394µs ± 1%   -9.05%  (p=0.100 n=3+3)
Edit1000000Lines10Cursors-4     366ms ± 6%   342ms ± 0%   -6.71%  (p=0.100 n=3+3)
Edit1000000Lines100Cursors-4    4.17s ± 3%   3.94s ± 0%   -5.65%  (p=0.100 n=3+3)
Edit1000000Lines1000Cursors-4   74.8s ± 1%   65.2s ± 0%  -12.83%  (p=0.100 n=3+3)
```

Of course, this code is not perfectly equivalent to using `unicode.Mark`, but I don't think getting every single corner case for every exotic script correct is worth slowing Micro down by 20%.

It would be really nice if such performance regressions could be caught automatically by CI, but Travis doesn't provide a consistent runtime environment AFAIK. Do you know a better option? How are the nightly builds generated?

Also, why are the Unicode helper functions from the highlight package duplicated? Micro depends on that package, so why are they not simply imported?
