### PR TITLE
[Performance] Make determining rune width faster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,4 +25,6 @@ require (
 	layeh.com/gopher-luar v1.0.7
 )
 
+replace github.com/mattn/go-runewidth => github.com/p-e-w/go-runewidth v0.0.10-0.20200613030200-3e1705c5c059
+
 go 1.11

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+tw
 github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
+github.com/p-e-w/go-runewidth v0.0.10-0.20200613030200-3e1705c5c059 h1:/+h2b6i15wh4EWsFkfdNdBE1jjGA872tpXEyhPM5aYg=
+github.com/p-e-w/go-runewidth v0.0.10-0.20200613030200-3e1705c5c059/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/robertkrimen/otto v0.0.0-20191219234010-c382bd3c16ff h1:+6NUiITWwE5q1KO6SAfUX918c+Tab0+tGAM/mtdlUyA=


### PR DESCRIPTION
Similar to #1719, rune width lookups also make up a significant share of Micro's CPU consumption. The go-runewidth package allows for a fast path optimization in the same vein as the previous PR, and this PR switches to my fork of go-runewidth that implements this optimization. I intend to upstream this change, assuming the maintainer is interested.

This provides another substantial speedup for buffer operations:

```
name                           old time/op  new time/op  delta
CreateAndClose10Lines-4        48.7µs ±31%  50.7µs ±21%     ~     (p=1.000 n=3+3)
CreateAndClose100Lines-4        120µs ± 1%   129µs ±12%   +7.52%  (p=0.100 n=3+3)
CreateAndClose1000Lines-4       877µs ± 2%   892µs ± 1%     ~     (p=0.400 n=3+3)
CreateAndClose10000Lines-4     9.04ms ± 3%  9.09ms ± 0%     ~     (p=0.700 n=3+3)
CreateAndClose100000Lines-4    79.8ms ± 1%  83.4ms ± 0%   +4.52%  (p=0.100 n=3+3)
CreateAndClose1000000Lines-4    853ms ± 6%   830ms ± 0%     ~     (p=0.700 n=3+3)
Read10Lines-4                  1.93µs ± 3%  1.93µs ± 2%     ~     (p=1.000 n=3+3)
Read100Lines-4                 12.5µs ± 3%  12.6µs ± 1%     ~     (p=0.700 n=3+3)
Read1000Lines-4                 125µs ±10%   122µs ± 1%     ~     (p=0.700 n=3+3)
Read10000Lines-4               1.45ms ± 9%  1.37ms ± 0%     ~     (p=0.200 n=3+3)
Read100000Lines-4              14.4ms ± 1%  14.4ms ± 1%     ~     (p=1.000 n=3+3)
Read1000000Lines-4              133ms ± 7%   129ms ± 2%     ~     (p=0.700 n=3+3)
Edit10Lines1Cursor-4            159µs ± 1%   148µs ± 0%   -7.22%  (p=0.100 n=3+3)
Edit100Lines1Cursor-4          80.4µs ± 1%  71.4µs ± 1%  -11.25%  (p=0.100 n=3+3)
Edit100Lines10Cursors-4        5.06ms ± 1%  4.15ms ± 1%  -18.02%  (p=0.100 n=3+3)
Edit1000Lines1Cursor-4         44.1µs ± 1%  41.7µs ± 1%   -5.28%  (p=0.100 n=3+3)
Edit1000Lines10Cursors-4       4.13ms ± 1%  3.48ms ± 0%  -15.89%  (p=0.100 n=3+3)
Edit1000Lines100Cursors-4       275ms ± 5%   217ms ± 0%  -21.23%  (p=0.100 n=3+3)
Edit10000Lines1Cursor-4         181µs ± 2%   169µs ± 0%   -6.74%  (p=0.100 n=3+3)
Edit10000Lines10Cursors-4      4.40ms ± 1%  3.74ms ± 0%  -14.99%  (p=0.100 n=3+3)
Edit10000Lines100Cursors-4      305ms ± 3%   246ms ± 0%  -19.56%  (p=0.100 n=3+3)
Edit10000Lines1000Cursors-4     26.5s ± 3%   20.7s ± 0%  -21.90%  (p=0.100 n=3+3)
Edit100000Lines1Cursor-4       1.99ms ± 2%  1.96ms ± 0%     ~     (p=0.200 n=3+3)
Edit100000Lines10Cursors-4     37.4ms ± 1%  36.2ms ± 0%   -3.15%  (p=0.100 n=3+3)
Edit100000Lines100Cursors-4     660ms ± 7%   578ms ± 0%  -12.50%  (p=0.100 n=3+3)
Edit100000Lines1000Cursors-4    29.8s ± 5%   23.9s ± 0%  -19.59%  (p=0.100 n=3+3)
Edit1000000Lines1Cursor-4       394µs ± 1%   391µs ± 1%     ~     (p=0.400 n=3+3)
Edit1000000Lines10Cursors-4     357ms ± 8%   342ms ± 0%     ~     (p=0.200 n=3+3)
Edit1000000Lines100Cursors-4    4.01s ± 1%   3.88s ± 0%   -3.29%  (p=0.100 n=3+3)
Edit1000000Lines1000Cursors-4   69.2s ± 2%   60.8s ± 0%  -12.22%  (p=0.100 n=3+3)
```
