### PR TITLE
Update micro.desktop

### DIFF
--- a/assets/packaging/micro.desktop
+++ b/assets/packaging/micro.desktop
@@ -6,10 +6,10 @@ Comment=Edit text files in a terminal
 
 Icon=micro
 Type=Application
-Categories=terminal;TextEditor;
+Categories=Utility;TextEditor;Development;
 Keywords=text;editor;syntax;terminal;
 
-Exec=micro %U
+Exec=micro %F
 StartupNotify=false
 Terminal=true
 MimeType=text/plain;text/x-chdr;text/x-csrc;text/x-c++hdr;text/x-c++src;text/x-java;text/x-dsrc;text/x-pascal;text/x-perl;text/x-python;application/x-php;application/x-httpd-php3;application/x-httpd-php4;application/x-httpd-php5;application/xml;text/html;text/css;text/x-sql;text/x-diff;


### PR DESCRIPTION
`terminal` isn't a category recognized by freedesktop.org specs. I think `Utility` and `Development` will be fitting.
https://specifications.freedesktop.org/menu-spec/latest/apa.html#main-category-registry

The `%U` directive signalizes that micro can accept URLs as arguments, while `%F` is for file paths only.