### PR TITLE
Support for multiple modifiers in colorschemes

### DIFF
--- a/internal/config/colorscheme.go
+++ b/internal/config/colorscheme.go
@@ -117,16 +117,12 @@ func ParseColorscheme(text string) (map[string]tcell.Style, error) {
 
 // StringToStyle returns a style from a string
 // The strings must be in the format "extra foregroundcolor,backgroundcolor"
-// The 'extra' can be bold, reverse, or underline
+// The 'extra' can be bold, reverse, italic or underline
 func StringToStyle(str string) tcell.Style {
 	var fg, bg string
 	spaceSplit := strings.Split(str, " ")
 	var split []string
-	if len(spaceSplit) > 1 {
-		split = strings.Split(spaceSplit[1], ",")
-	} else {
-		split = strings.Split(str, ",")
-	}
+	split = strings.Split(spaceSplit[len(spaceSplit)-1], ",")
 	if len(split) > 1 {
 		fg, bg = split[0], split[1]
 	} else {

--- a/internal/config/colorscheme_test.go
+++ b/internal/config/colorscheme_test.go
@@ -26,6 +26,18 @@ func TestAttributeStringToStyle(t *testing.T) {
 	assert.NotEqual(t, 0, attr&tcell.AttrBold)
 }
 
+func TestMultiAttributesStringToStyle(t *testing.T) {
+	s := StringToStyle("bold italic underline cyan,brightcyan")
+
+	fg, bg, attr := s.Decompose()
+
+	assert.Equal(t, tcell.ColorTeal, fg)
+	assert.Equal(t, tcell.ColorAqua, bg)
+	assert.NotEqual(t, 0, attr&tcell.AttrBold)
+	assert.NotEqual(t, 0, attr&tcell.AttrItalic)
+	assert.NotEqual(t, 0, attr&tcell.AttrUnderline)
+}
+
 func TestColor256StringToStyle(t *testing.T) {
 	s := StringToStyle("128,60")
 


### PR DESCRIPTION
This PR changes the way micro parses colorschemes to allow the use of multiple modifiers, eg:
```
color-link comment "bold italic red"
```
Currently micro always treats the first or second (if exists) word in color-link as a color. Therefore, the code above will not work properly (it also means that you can use "bold red italic" and it will work).
With this PR micro always treats last word as a color.