### PR TITLE
Support reproducible builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,20 +15,20 @@ VSCODE_TESTS_BASE_URL = 'https://raw.githubusercontent.com/microsoft/vscode/e6a4
 
 # Builds micro after checking dependencies but without updating the runtime
 build:
-	go build -ldflags "-s -w $(GOVARS) $(ADDITIONAL_GO_LINKER_FLAGS)" ./cmd/micro
+	go build -trimpath -ldflags "-s -w $(GOVARS) $(ADDITIONAL_GO_LINKER_FLAGS)" ./cmd/micro
 
 build-dbg:
-	go build -ldflags "-s -w $(ADDITIONAL_GO_LINKER_FLAGS) $(DEBUGVAR)" ./cmd/micro
+	go build -trimpath -ldflags "-s -w $(ADDITIONAL_GO_LINKER_FLAGS) $(DEBUGVAR)" ./cmd/micro
 
 build-tags: fetch-tags
-	go build -ldflags "-s -w $(GOVARS) $(ADDITIONAL_GO_LINKER_FLAGS)" ./cmd/micro
+	go build -trimpath -ldflags "-s -w $(GOVARS) $(ADDITIONAL_GO_LINKER_FLAGS)" ./cmd/micro
 
 # Builds micro after building the runtime and checking dependencies
 build-all: runtime build
 
 # Builds micro without checking for dependencies
 build-quick:
-	go build -ldflags "-s -w $(GOVARS) $(ADDITIONAL_GO_LINKER_FLAGS)" ./cmd/micro
+	go build -trimpath -ldflags "-s -w $(GOVARS) $(ADDITIONAL_GO_LINKER_FLAGS)" ./cmd/micro
 
 # Same as 'build' but installs to $GOBIN afterward
 install:

--- a/tools/build-date.go
+++ b/tools/build-date.go
@@ -2,9 +2,23 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 	"time"
 )
 
 func main() {
-	fmt.Println(time.Now().Local().Format("January 02, 2006"))
+	var buildTime time.Time
+	epoch := os.Getenv("SOURCE_DATE_EPOCH")
+	if epoch != "" {
+		i, err := strconv.Atoi(epoch)
+		if err != nil {
+			fmt.Errorf("SOURCE_DATE_EPOCH is not a valid integer")
+			os.Exit(1)
+		}
+		buildTime = time.Unix(int64(i), 0)
+	} else {
+		buildTime = time.Now().Local()
+	}
+	fmt.Println(buildTime.Format("January 02, 2006"))
 }


### PR DESCRIPTION
The current distribution of the binaries are not reproducible as build paths along with build times are embedded into the binaries. These two patches allows users to override the build time with `SOURCE_DATE_EPOCH` and removes build paths from the binaries.



https://reproducible-builds.org/
https://reproducible-builds.org/docs/build-path/
https://reproducible-builds.org/docs/source-date-epoch/