### PR TITLE
Fix erased vertical dividing line

### DIFF
--- a/internal/display/uiwindow.go
+++ b/internal/display/uiwindow.go
@@ -38,15 +38,14 @@ func (w *UIWindow) drawNode(n *views.Node) {
 	}
 
 	for i, c := range cs {
-		if c.IsLeaf() && c.Kind == views.STVert {
+		if c.Kind == views.STVert {
 			if i != len(cs)-1 {
 				for h := 0; h < c.H; h++ {
 					screen.SetContent(c.X+c.W, c.Y+h, divchar, combc, dividerStyle)
 				}
 			}
-		} else {
-			w.drawNode(c)
 		}
+		w.drawNode(c)
 	}
 }
 


### PR DESCRIPTION
Fix the 1st part of #1773: the dividing line between vertical splits is not displayed if the split on the left contains other splits, i.e. is not a leaf node.