### PR TITLE
Fix non-working split resize with mouse drag

### DIFF
--- a/internal/action/tab.go
+++ b/internal/action/tab.go
@@ -220,9 +220,8 @@ func (t *Tab) HandleEvent(event tcell.Event) {
 			}
 
 			if wasReleased {
-				resizeID := t.GetMouseSplitID(buffer.Loc{mx, my})
-				if resizeID != 0 {
-					t.resizing = t.GetNode(uint64(resizeID))
+				t.resizing = t.GetMouseSplitNode(buffer.Loc{mx, my})
+				if t.resizing != nil {
 					return
 				}
 

--- a/internal/display/uiwindow.go
+++ b/internal/display/uiwindow.go
@@ -54,32 +54,32 @@ func (w *UIWindow) Display() {
 	w.drawNode(w.root)
 }
 
-func (w *UIWindow) GetMouseSplitID(vloc buffer.Loc) uint64 {
-	var mouseLoc func(*views.Node) uint64
-	mouseLoc = func(n *views.Node) uint64 {
+func (w *UIWindow) GetMouseSplitNode(vloc buffer.Loc) *views.Node {
+	var mouseLoc func(*views.Node) *views.Node
+	mouseLoc = func(n *views.Node) *views.Node {
 		cs := n.Children()
 		for i, c := range cs {
 			if c.Kind == views.STVert {
 				if i != len(cs)-1 {
 					if vloc.X == c.X+c.W && vloc.Y >= c.Y && vloc.Y < c.Y+c.H {
-						return c.ID()
+						return c
 					}
 				}
 			} else if c.Kind == views.STHoriz {
 				if i != len(cs)-1 {
 					if vloc.Y == c.Y+c.H-1 && vloc.X >= c.X && vloc.X < c.X+c.W {
-						return c.ID()
+						return c
 					}
 				}
 			}
 		}
 		for _, c := range cs {
 			m := mouseLoc(c)
-			if m != 0 {
+			if m != nil {
 				return m
 			}
 		}
-		return 0
+		return nil
 	}
 	return mouseLoc(w.root)
 }


### PR DESCRIPTION
Fix the 2nd part of #1773: resize via mouse drag doesn't work if the split on the left contains other splits, i.e. is not a leaf node.

The problem is that only leaf nodes have unique id. For non-leaf nodes ID() returns 0. So we shouldn't search the node by id.
So replace GetMouseSplitID() with GetMouseSplitNode().