### PR TITLE
Allow Julia multiline strings and comments

### DIFF
--- a/runtime/syntax/julia.yaml
+++ b/runtime/syntax/julia.yaml
@@ -33,11 +33,16 @@ rules:
         rules: []
 
     - constant.string:
-        start: "'''"
-        end: "'''"
+        start: "\"[^\"]|\"$"
+        end: "\""
         rules: []
 
     - comment:
-        start: "#"
+        start: "#[^=]|#$"
         end: "$"
+        rules: []
+
+    - comment:
+        start: "#="
+        end: "=#"
         rules: []


### PR DESCRIPTION
Few minor improvements to Julia syntax highlighting:

* Triple single quotes were erroneously highlighted as a multiline string - this is in fact not valid Julia syntax
* Now highlights multiline strings, even when delimited by a single `"` 
* Now also highlights multiline comments