### PR TITLE
Improve Zig syntax definitions

### DIFF
--- a/runtime/syntax/zig.yaml
+++ b/runtime/syntax/zig.yaml
@@ -4,34 +4,51 @@ detect:
     filename: "\\.zig$"
 
 rules:
-    # function definition
-    - identifier: "fn [a-z0-9_]+"
       # Reserved words
-    - statement: "\\b(align|and|allowzero|anyerror|asm|async|await|break|cancel|catch|comptime|const|continue|defer|else|enum|errdefer|error|export|extern|false|fn|for|if|inline|nakedcc|noalias|null|or|orelse|packed|promise|pub|resume|return|linksection|stdcallcc|struct|suspend|switch|test|threadlocal|true|try|undefined|union|unreachable|use|var|volatile|while)\\b"
+    - statement: "\\b(align|allowzero|and|asm|async|await|break|callconv|catch|comptime|const|continue|defer|else|errdefer|error|export|extern|fn|for|if|inline|noalias|noinline|nosuspend|or|orelse|packed|pub|resume|return|linksection|suspend|switch|test|threadlocal|try|undefined|unreachable|usingnamespace|var|volatile|while)\\b"
       # builtin functions
-    - special: "@+[a-z_]+"
-      # Constants
-    - constant: "[A-Z][A-Z_]+([0-9]+)?"
-      # Numbers (hexadecimal + decimal)
+    - special: "@[a-zA-Z_]+"
+      # Primitive Types
+    - type: "\\b(anyframe|anytype|anyerror|bool|comptime_int|comptime_float|enum|f(16|32|64|128)|isize|noreturn|struct|type|union|usize|void)\\b"
+    - type: "\\b(c_u?(short|int|long(long)?)|c_longdouble|c_void)\\b"
+    - type: "\\b((i|u)[0-9]+)\\b"
+
+     # Operators
+    - symbol.operator: "[-!|=;%.+^*:&?<>~]"
+
+     # Parenthesis
+    - symbol.brackets: "[(){}]|\\[|\\]"
+
+     # Constants
+    - constant: "\\b(null)\\b"
     - constant.number: "\\b(0x[A-F0-9]+|[0-9]+)\\b"
-      # Primitive Types / Derived Data Types
-    - type: "\\b([A-Z][a-z]+|(i8|u8|i16|u16|i32|u32|i64|u64|i128|u128|isize|usize|c_short|c_ushort|c_int|c_uint|c_long|c_ulong|c_longlong|c_ulonglong|c_longdouble|c_void|f16|f32|f64|f128|bool|void|noreturn|type|anyerror|comptime_int|comptime_float))\\b"
+    - constant.number: "\\b(0b[01_]+|0o[0-7_]+|[0-9_]+|0x[a-fA-F0-9_]+)\\b"
+    - constant.bool: "\\b(true|false)\\b"
 
     - constant.string:
         start: "\""
         end: "\""
         skip: "\\\\."
         rules:
-            - constant.specialChar: "\\\\."
+            - constant.specialChar: "\\\\([nrt\\\\'\"]|x[a-fA-F0-9]{2}|u{[a-fA-F0-9]+})"
 
+    - constant.string:
+        start: "'"
+        end: "'"
+        skip: "\\\\."
+        rules:
+            - error: "..+"
+            - constant.specialChar: "\\\\([nrt\\\\'\"]|x[a-fA-F0-9]{2}|u{[a-fA-F0-9]+})"
+
+    - constant.string:
+        start: "\\\\\\\\"
+        end: "$"
+        skip: "\\\\."
+        rules:
+            - constant.specialChar: "\\\\([nrt\\\\'\"]|x[a-fA-F0-9]{2}|u{[a-fA-F0-9]+})"
+    
     - comment:
         start: "//"
         end: "$"
-        rules:
-            - todo: "(TODO|XXX|FIXME):?"
-
-    - comment:
-        start: "/\\*"
-        end: "\\*/"
         rules:
             - todo: "(TODO|XXX|FIXME):?"

--- a/runtime/syntax/zig.yaml
+++ b/runtime/syntax/zig.yaml
@@ -5,7 +5,7 @@ detect:
 
 rules:
       # Reserved words
-    - statement: "\\b(align|allowzero|and|asm|async|await|break|callconv|catch|comptime|const|continue|defer|else|errdefer|error|export|extern|fn|for|if|inline|noalias|noinline|nosuspend|or|orelse|packed|pub|resume|return|linksection|suspend|switch|test|threadlocal|try|undefined|unreachable|usingnamespace|var|volatile|while)\\b"
+    - statement: "\\b(align|allowzero|and|asm|async|await|break|callconv|catch|comptime|const|continue|defer|else|errdefer|error|export|extern|fn|for|if|inline|noalias|noinline|nosuspend|or|orelse|packed|pub|resume|return|linksection|suspend|switch|test|threadlocal|try|unreachable|usingnamespace|var|volatile|while)\\b"
       # builtin functions
     - special: "@[a-zA-Z_]+"
       # Primitive Types
@@ -20,7 +20,7 @@ rules:
     - symbol.brackets: "[(){}]|\\[|\\]"
 
      # Constants
-    - constant: "\\b(null)\\b"
+    - constant: "\\b(null|undefined)\\b"
     - constant.number: "\\b(0b[01_]+|0o[0-7_]+|[0-9_]+|0x[a-fA-F0-9_]+)\\b"
     - constant.bool: "\\b(true|false)\\b"
 

--- a/runtime/syntax/zig.yaml
+++ b/runtime/syntax/zig.yaml
@@ -21,7 +21,6 @@ rules:
 
      # Constants
     - constant: "\\b(null)\\b"
-    - constant.number: "\\b(0x[A-F0-9]+|[0-9]+)\\b"
     - constant.number: "\\b(0b[01_]+|0o[0-7_]+|[0-9_]+|0x[a-fA-F0-9_]+)\\b"
     - constant.bool: "\\b(true|false)\\b"
 


### PR DESCRIPTION
Adds the following improvements for the Zig syntax definitions:
- Update keywords, as some got removed and some others added
- Allow upper cases in special `@builtin` names. Previously this caused incorrect highlighting for builtins like `@ptrCast`.
- Operator, bracket coloring
- Allow any integer bitness
- Boolean and number (including binary, octal and hexadecimal) constants
- Improved string constants, specifying the exact allowed escape sequences
- Add support for multi-line string literals (these are handled by treating every line of a multiline string literal seperately). [The starting specifier is not a typo](https://xkcd.com/1638/), as multiline string literals are started by \\\\.
- Removed special coloring for functions and SCREAMING_SNAKE_CASE. The latter is commonly only used when interfacing with (c) libraries which use that style (as Zig constants are usually also in normal snake_case) so i think its okay to remove it. For the former, i simply followed what other styles seemed to be doing.
- Removed invalid multiline comment syntax
