### PR TITLE
Add statusline.inactive and statusline.suggestions color groups

### DIFF
--- a/internal/display/infowindow.go
+++ b/internal/display/infowindow.go
@@ -243,7 +243,9 @@ func (i *InfoWindow) Display() {
 		done := false
 
 		statusLineStyle := config.DefStyle.Reverse(true)
-		if style, ok := config.Colorscheme["statusline"]; ok {
+		if style, ok := config.Colorscheme["statusline.suggestions"]; ok {
+			statusLineStyle = style
+		} else if style, ok := config.Colorscheme["statusline"]; ok {
 			statusLineStyle = style
 		}
 		keymenuOffset := 0

--- a/internal/display/statusline.go
+++ b/internal/display/statusline.go
@@ -102,7 +102,9 @@ func (s *StatusLine) Display() {
 	// autocomplete suggestions (for the buffer, not for the infowindow)
 	if b.HasSuggestions && len(b.Suggestions) > 1 {
 		statusLineStyle := config.DefStyle.Reverse(true)
-		if style, ok := config.Colorscheme["statusline"]; ok {
+		if style, ok := config.Colorscheme["statusline.suggestions"]; ok {
+			statusLineStyle = style
+		} else if style, ok := config.Colorscheme["statusline"]; ok {
 			statusLineStyle = style
 		}
 		keymenuOffset := 0
@@ -163,8 +165,16 @@ func (s *StatusLine) Display() {
 	rightText = formatParser.ReplaceAllFunc(rightText, formatter)
 
 	statusLineStyle := config.DefStyle.Reverse(true)
-	if style, ok := config.Colorscheme["statusline"]; ok {
-		statusLineStyle = style
+	if s.win.IsActive() {
+		if style, ok := config.Colorscheme["statusline"]; ok {
+			statusLineStyle = style
+		}
+	} else {
+		if style, ok := config.Colorscheme["statusline.inactive"]; ok {
+			statusLineStyle = style
+		} else if style, ok := config.Colorscheme["statusline"]; ok {
+			statusLineStyle = style
+		}
 	}
 
 	leftLen := util.StringWidth(leftText, util.CharacterCount(leftText), 1)


### PR DESCRIPTION
Add optional `statusline.inactive` and `statusline.suggestions` color groups for displaying statuslines of inactive split panes and the suggestions menu with colors different from the statusline of the active pane.
If not defined in the colorscheme, the `statusline` color group is used.

I'm using it this way:

```
color-link statusline "bold 16,248"
color-link statusline.inactive "16,248"
color-link statusline.suggestions "16,248"
```

In this example the statusline colors are all the same (black on grey) but the active pane statusline has bold text while inactive panes and suggestions have normal text.