### PR TITLE
Fix Crystal syntax highlighting

### DIFF
--- a/runtime/syntax/crystal.yaml
+++ b/runtime/syntax/crystal.yaml
@@ -5,10 +5,14 @@ detect:
 
 rules:
     # Asciibetical list of reserved words
-    - statement: "\\b(BEGIN|END|abstract|alias|and|begin|break|case|class|def|defined\\?|do|else|elsif|end|ensure|enum|false|for|fun|if|in|include|lib|loop|macro|module|next|nil|not|of|or|pointerof|private|protected|raise|redo|require|rescue|retry|return|self|sizeof|spawn|struct|super|then|true|type|undef|union|uninitialized|unless|until|when|while|yield)\\b"
+    - statement: "\\b(abstract|alias|as|asm|begin|break|case|class|def|do|else|elsif|end|ensure|enum|extend|for|fun|if|in|include|instance_sizeof|lib|loop|macro|module|next|of|out|pointerof|private|protected|raise|require|rescue|return|select|self|sizeof|spawn|struct|super|then|type|typeof|uninitialized|union|unless|until|verbatim|when|while|with|yield)\\b"
       # Constants
-    - constant: "(\\$|@|@@)?\\b[A-Z]+[0-9A-Z_a-z]*"
+    - constant: "\\b(true|false|nil)\\b"
     - constant.number: "\\b[0-9]+\\b"
+      # Ones that can't be in the same regex because they include non-words.
+      # The nil? one has to be after the constants.
+    - statement: "\\b(nil\\?|as(\\?|\\b)|is_a\\?|responds_to\\?)"
+    - type: "(\\$|@|@@)?\\b[A-Z]+[0-9A-Z_a-z]*"
       # Crystal "symbols"
     - constant:  "([ 	]|^):[0-9A-Z_]+\\b"
       # Some unique things we want to stand out


### PR DESCRIPTION
Don't highlight things that don't exist, add some missing keywords,
and highlight true/false/nil as constants instead of keywords.

Source for keyword list: https://github.com/crystal-lang/crystal/wiki/Crystal-for-Rubyists#available-keywords

The things I'm including that aren't on there are a few things in the prelude that have special treatment by the type checker and stuff despite not technically being keywords.