### PR TITLE
Overall syntax highlighting improvements for C++

### DIFF
--- a/runtime/syntax/cpp.yaml
+++ b/runtime/syntax/cpp.yaml
@@ -4,12 +4,12 @@ detect:
     filename: "(\\.c(c|pp|xx)$|\\.h(h|pp|xx)$|\\.ii?$|\\.(def)$)"
 
 rules:
-    - identifier: "\\b[a-zA-Z_][0-9a-zA-Z_]*\\b"
+    - identifier: "\\b[A-Z_][0-9A-Z_]*\\b"
     - type: "\\b(float|double|bool|char|int|short|long|enum|void|struct|union|typedef|(un)?signed|inline)\\b"
-    - type: "\\b((s?size)|((u_?)?int(8|16|32|64|ptr))|char(8|16|32))_t|wchar_t\\b"
+    - type: "\\b(((s?size)|((u_?)?int(8|16|32|64|ptr))|char(8|16|32))_t|wchar_t)\\b"
     - type: "\\b(final|override)\\b"
     - type.keyword: "\\b(auto|volatile|const(expr|eval|init)?|mutable|register|thread_local|static|extern|decltype|explicit|virtual)\\b"
-    - statement: "\\b(class|namespace|template|typename|this|nullptr|friend|using|public|protected|private|noexcept)\\b"
+    - statement: "\\b(class|namespace|template|typename|this|friend|using|public|protected|private|noexcept)\\b"
     - statement: "\\b((const|dynamic|reinterpret|static)_cast)\\b"
     - statement: "\\b(concept|requires)\\b"
     - statement: "\\b(import|export|module)\\b"
@@ -25,12 +25,16 @@ rules:
     - statement: "(__attribute__[[:space:]]*\\(\\([^)]*\\)\\)|__(aligned|asm|builtin|hidden|inline|packed|restrict|section|typeof|weak)__)"
 
       # Operator Color
-    - symbol.operator: "([.:;,+*~|=!\\%]|<|>|/|-|&|\\b(sizeof|alignof|typeid|(and|or|xor|not)(_eq)?|bitor|compl|bitand)\\b)"
+    - symbol.operator: "([.:;,+*~|=!?\\%]|<|>|/|-|&|\\b(sizeof|alignof|typeid|(and|or|xor|not)(_eq)?|bitor|compl|bitand)\\b)"
       # Parenthetical Color
     - symbol.brackets: "[(){}]|\\[|\\]"
-
-    - constant.number: "(\\b[0-9]+\\b|\\b0x[0-9A-Fa-f]+\\b)"
-    - constant.bool: "(\\b(true|false|NULL)\\b)"
+      # Integer Literals
+    - constant.number: "(\\b([1-9][0-9']*|0[0-7']*|0[Xx][0-9a-fA-F']+|0[Bb][01]+)([Uu]?[Ll][Ll]?|[Ll][Ll]?[Uu]?)?\\b)"
+      # Decimal Floating-point Literals
+    - constant.number: "(\\b([0-9']*[.][0-9']*([Ee][+-]?[0-9']+)?|[0-9']+[Ee][+-]?[0-9']+)[FfLl]?\\b)"
+      # Hexadecimal Floating-point Literals
+    - constant.number: "(\\b0[Xx]([0-9a-zA-Z']+[.][0-9a-zA-Z']*|[0-9a-zA-Z']*[.][0-9a-zA-Z']+)[Pp][+-]?[0-9']+[FfLl]?\\b)"
+    - constant.bool: "(\\b(true|false|NULL|nullptr)\\b)"
 
     - constant.string:
         start: "\""

--- a/runtime/syntax/cpp.yaml
+++ b/runtime/syntax/cpp.yaml
@@ -4,25 +4,33 @@ detect:
     filename: "(\\.c(c|pp|xx)$|\\.h(h|pp|xx)$|\\.ii?$|\\.(def)$)"
 
 rules:
-    - identifier: "\\b[A-Z_][0-9A-Z_]+\\b"
-    - type: "\\b(auto|float|double|bool|char|int|short|long|sizeof|enum|void|static|const|constexpr|struct|union|typedef|extern|(un)?signed|inline)\\b"
-    - type: "\\b((s?size)|((u_?)?int(8|16|32|64|ptr)))_t\\b"
-    - statement: "\\b(class|namespace|template|public|protected|private|typename|this|friend|virtual|using|mutable|volatile|register|explicit)\\b"
+    - identifier: "\\b[a-zA-Z_][0-9a-zA-Z_]*\\b"
+    - type: "\\b(float|double|bool|char|int|short|long|enum|void|struct|union|typedef|(un)?signed|inline)\\b"
+    - type: "\\b((s?size)|((u_?)?int(8|16|32|64|ptr))|char(8|16|32))_t|wchar_t\\b"
+    - type: "\\b(final|override)\\b"
+    - type.keyword: "\\b(auto|volatile|const(expr|eval|init)?|mutable|register|thread_local|static|extern|decltype|explicit|virtual)\\b"
+    - statement: "\\b(class|namespace|template|typename|this|nullptr|friend|using|public|protected|private|noexcept)\\b"
+    - statement: "\\b((const|dynamic|reinterpret|static)_cast)\\b"
+    - statement: "\\b(concept|requires)\\b"
+    - statement: "\\b(import|export|module)\\b"
     - statement: "\\b(for|if|while|do|else|case|default|switch)\\b"
-    - statement: "\\b(try|throw|catch|operator|new|delete)\\b"
+    - statement: "\\b(try|throw|catch|operator|new|delete|static_assert)\\b"
     - statement: "\\b(goto|continue|break|return)\\b"
-    - preproc: "^[[:space:]]*#[[:space:]]*(define|pragma|include|(un|ifn?)def|endif|el(if|se)|if|warning|error)"
+    - preproc: "^[[:space:]]*#[[:space:]]*(define|pragma|include|(un|ifn?)def|endif|el(if|se)|if|warning|error)|_Pragma"
+
+      # Conditionally-supported/extension keywords
+    - statement: "\\b(asm|fortran)\\b"
 
       # GCC builtins
     - statement: "(__attribute__[[:space:]]*\\(\\([^)]*\\)\\)|__(aligned|asm|builtin|hidden|inline|packed|restrict|section|typeof|weak)__)"
 
       # Operator Color
-    - symbol.operator: "([.:;,+*|=!\\%]|<|>|/|-|&)"
+    - symbol.operator: "([.:;,+*~|=!\\%]|<|>|/|-|&|\\b(sizeof|alignof|typeid|(and|or|xor|not)(_eq)?|bitor|compl|bitand)\\b)"
       # Parenthetical Color
     - symbol.brackets: "[(){}]|\\[|\\]"
 
     - constant.number: "(\\b[0-9]+\\b|\\b0x[0-9A-Fa-f]+\\b)"
-    - constant.bool: "(\\b(true|false)\\b|NULL)"
+    - constant.bool: "(\\b(true|false|NULL)\\b)"
 
     - constant.string:
         start: "\""


### PR DESCRIPTION
Most of these changes are based on the information on cppreference.com; specifically from [here](https://en.cppreference.com/w/cpp/keyword), [here](https://en.cppreference.com/w/cpp/language/integer_literal), and [here](https://en.cppreference.com/w/cpp/language/floating_literal).

I didn't include coroutine-related language features, primarily because there is no good source of information about them other than the ISO C++ standard.

The changes included in this PR:
- add `constant.number` regexes that match exactly the floating-point and integer literals that the standard specifies
- add `~` and `?` as operators
- add `static_assert` as a keyword (statement)
- add keywords that are interchangeable with operators as operators
- add keywords `sizeof`, `alignof` and `typeid` as operators
- add the quasi-keywords `asm`, `fortran` and `final`, `override`
- add the keyword `nullptr` as a `constant.bool`
- add `_Pragma` as a preprocessor keyword
- add C++20 (concepts and modules) -related keywords
- add casting keywords
- add the keyword (specifier) `noexcept`
- remove `nothrow` (because it's no more special than `std::vector` is)
- add `wchar_t` and `charXX_t` types
- add cv type keywords as `type.keyword`s
- move some fitting keywords into `type.keywords` (mostly because they appear in/near type signatures etc.)