### PR TITLE
feat: also print runtime version

### DIFF
--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -91,7 +91,7 @@ func InitFlags() {
 		// If -version was passed
 		fmt.Println("Version:", util.Version)
 		fmt.Println("Commit hash:", util.CommitHash)
-		fmt.Println("Compiled on", util.CompileDate)
+		fmt.Println(fmt.Sprintf("Compiled on %s (go version %s)", util.CompileDate, runtime.Version()))
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
I personally find it's nice to also have the runtime version included.

I use my own go tree, so it looks like:

```
$ micro --version
Version: 2.0.8-dev.11
Commit hash: 21b60688
Compiled on September 16, 2020 (go version devel +790fa1c546 Wed Sep 16 04:37:14 2020 +0000)
```

But normally, it'd be like `(go version go1.15.1)`.