### PR TITLE
Fixed help-topic name in the Plugins doc

### DIFF
--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -418,7 +418,7 @@ your own plugins.
 Micro also has a built in plugin manager which you can invoke with the
 `> plugin ...` command, or in the shell with `micro -plugin ...`.
 
-For the valid commands you can use, see the `command` help topic.
+For the valid commands you can use, see the `commands` help topic.
 
 The manager fetches plugins from the channels (which is simply a list of plugin
 metadata) which it knows about. By default, micro only knows about the official


### PR DESCRIPTION
The help topic is called `commands` not `command`