### PR TITLE
Fix buffer.RuneAt

### DIFF
--- a/internal/buffer/autocomplete.go
+++ b/internal/buffer/autocomplete.go
@@ -69,11 +69,11 @@ func GetWord(b *Buffer) ([]byte, int) {
 	l := b.LineBytes(c.Y)
 	l = util.SliceStart(l, c.X)
 
-	if c.X == 0 || util.IsWhitespace(b.RuneAt(c.Loc)) {
+	if c.X == 0 || util.IsWhitespace(b.RuneAt(c.Loc.Move(-1, b))) {
 		return []byte{}, -1
 	}
 
-	if util.IsNonAlphaNumeric(b.RuneAt(c.Loc)) {
+	if util.IsNonAlphaNumeric(b.RuneAt(c.Loc.Move(-1, b))) {
 		return []byte{}, c.X
 	}
 

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -511,11 +511,12 @@ func (b *Buffer) RuneAt(loc Loc) rune {
 		for len(line) > 0 {
 			r, _, size := util.DecodeCharacter(line)
 			line = line[size:]
-			i++
 
 			if i == loc.X {
 				return r
 			}
+
+			i++
 		}
 	}
 	return '\n'

--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -109,7 +109,7 @@ func (b *Buffer) saveToFile(filename string, withSudo bool) error {
 
 	if b.Settings["eofnewline"].(bool) {
 		end := b.End()
-		if b.RuneAt(Loc{end.X, end.Y}) != '\n' {
+		if b.RuneAt(Loc{end.X - 1, end.Y}) != '\n' {
 			b.insert(end, []byte{'\n'})
 		}
 	}


### PR DESCRIPTION
Fix `buffer.RuneAt` returning the rune not at the given location (as the documentation claims) but just before it.