### PR TITLE
Add Scala syntax highlighting for .sbt files

### DIFF
--- a/runtime/syntax/scala.yaml
+++ b/runtime/syntax/scala.yaml
@@ -1,7 +1,7 @@
 filetype: scala
 
 detect:
-    filename: "\\.scala$"
+    filename: "\\.scala$|\\.sbt$"
 
 rules:
     - type: "\\b(boolean|byte|char|double|float|int|long|new|short|this|transient|void)\\b"


### PR DESCRIPTION
The Scala Build Tool sbt uses Scala as configuration language.