### PR TITLE
Make more libraries available

### DIFF
--- a/cmd/micro/initlua.go
+++ b/cmd/micro/initlua.go
@@ -144,6 +144,9 @@ func luaImportMicroUtil() *lua.LTable {
 	ulua.L.SetField(pkg, "GetLeadingWhitespace", luar.New(ulua.L, util.LuaGetLeadingWhitespace))
 	ulua.L.SetField(pkg, "IsWordChar", luar.New(ulua.L, util.LuaIsWordChar))
 	ulua.L.SetField(pkg, "String", luar.New(ulua.L, util.String))
+	ulua.L.SetField(pkg, "Unzip", luar.New(ulua.L, util.Unzip))
+	ulua.L.SetField(pkg, "Version", luar.New(ulua.L, util.Version))
+	ulua.L.SetField(pkg, "SemVersion", luar.New(ulua.L, util.SemVersion))
 	ulua.L.SetField(pkg, "CharacterCountInString", luar.New(ulua.L, util.CharacterCountInString))
 	ulua.L.SetField(pkg, "RuneStr", luar.New(ulua.L, func(r rune) string {
 		return string(r)

--- a/internal/lua/lua.go
+++ b/internal/lua/lua.go
@@ -1,6 +1,7 @@
 package lua
 
 import (
+	"archive/zip"
 	"bytes"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"math"
 	"math/rand"
 	"net"
+	"net/http"
 	"os"
 	"path"
 	"path/filepath"
@@ -74,6 +76,10 @@ func Import(pkg string) *lua.LTable {
 		return importUtf8()
 	case "humanize":
 		return importHumanize()
+	case "net/http", "http":
+		return importHTTP()
+	case "archive/zip":
+		return importArchiveZip()
 	default:
 		return nil
 	}
@@ -383,6 +389,7 @@ func importOs() *lua.LTable {
 	L.SetField(pkg, "Symlink", luar.New(L, os.Symlink))
 	L.SetField(pkg, "TempDir", luar.New(L, os.TempDir))
 	L.SetField(pkg, "Truncate", luar.New(L, os.Truncate))
+	L.SetField(pkg, "UserHomeDir", luar.New(L, os.UserHomeDir))
 
 	return pkg
 }
@@ -567,6 +574,25 @@ func importHumanize() *lua.LTable {
 
 	L.SetField(pkg, "Bytes", luar.New(L, humanize.Bytes))
 	L.SetField(pkg, "Ordinal", luar.New(L, humanize.Ordinal))
+
+	return pkg
+}
+
+func importHTTP() *lua.LTable {
+	pkg := L.NewTable()
+
+	L.SetField(pkg, "Get", luar.New(L, http.Get))
+	L.SetField(pkg, "Post", luar.New(L, http.Post))
+
+	return pkg
+}
+
+func importArchiveZip() *lua.LTable {
+	pkg := L.NewTable()
+
+	L.SetField(pkg, "OpenReader", luar.New(L, zip.OpenReader))
+	L.SetField(pkg, "NewReader", luar.New(L, zip.NewReader))
+	L.SetField(pkg, "NewWriter", luar.New(L, zip.NewWriter))
 
 	return pkg
 }

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -285,6 +285,7 @@ The packages and functions are listed below (in Go type signatures):
        string is a word character.
     - `String(b []byte) string`: converts a byte array to a string.
     - `RuneStr(r rune) string`: converts a rune to a string.
+    - `Unzip(src, dest string) error`: unzips a file to given folder.
 
 This may seem like a small list of available functions but some of the objects
 returned by the functions have many methods. The Lua plugin may access any
@@ -358,6 +359,8 @@ strings
 regexp
 errors
 time
+archive/zip
+net/http
 ```
 
 For documentation for each of these functions, see the Go standard


### PR DESCRIPTION
I started implementing a new plugin for this awesome project however I realized there's a lack of imported functions. So this PR makes few more libaries available when developing a plugin.

- os.UserHomeDir
- http.Get
- http.Post
- zip.OpenReader
- zip.NewReader
- zip.NewWriter

Also I added `Unzip` function to `util.go`. Since it's my very initial contribution please let me know if I missed something.

Here is the [PR](https://github.com/micro-editor/plugin-channel/pull/57) for the plugin channel and here is the [repo](https://github.com/wakatime/micro-wakatime) for the plugin.