### PR TITLE
Highlight racket files as lisp

### DIFF
--- a/runtime/syntax/lisp.yaml
+++ b/runtime/syntax/lisp.yaml
@@ -1,7 +1,7 @@
 filetype: lisp
 
 detect: 
-    filename: "(emacs|zile)$|\\.(el|li?sp|scm|ss)$"
+    filename: "(emacs|zile)$|\\.(el|li?sp|scm|ss|rkt)$"
 
 rules:
     - default: "\\([a-z-]+"


### PR DESCRIPTION
Add syntax highlighting for [racket](racket-lang.org), a (variant of scheme which is a) variant of lisp which uses the .rkt extension.