### PR TITLE
Improve patch file detection by adding a header rule.

### DIFF
--- a/runtime/syntax/patch.yaml
+++ b/runtime/syntax/patch.yaml
@@ -1,7 +1,8 @@
 filetype: patch
 
-detect: 
+detect:
     filename: "\\.(patch|diff)$"
+    header: "^diff"
 
 rules:
     - brightgreen: "^\\+.*"


### PR DESCRIPTION
This change allows syntax highlighting for the following use case (as an example).
"git diff | micro -readonly true"
