### PR TITLE
Don't automatically disable readonly option

### DIFF
--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -238,7 +238,9 @@ func NewBufferFromFileAtLoc(path string, btype BufType, cursorLoc Loc) (*Buffer,
 		buf = NewBuffer(file, util.FSize(file), filename, cursorLoc, btype)
 	}
 
-	buf.SetOptionNative("readonly", readonly)
+	if readonly {
+		buf.SetOptionNative("readonly", true)
+	}
 
 	return buf, nil
 }


### PR DESCRIPTION
Fix the regression after 3b34a02: setting readonly option to true
in onBufferOpen lua callback doesn't work, since it is automatically
reset to false if write permission is not denied.