### PR TITLE
fix the missing break in JumpToMatchingBrace

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1195,6 +1195,7 @@ func (h *BufPane) JumpToMatchingBrace() bool {
 				} else {
 					h.Cursor.GotoLoc(matchingBrace.Move(1, h.Buf))
 				}
+				break
 			} else {
 				return false
 			}


### PR DESCRIPTION
In JumpToMatchingBrace, the loop should stop immediately after finding the matching bracket.
It causes multiple jumps in certain situations:
`(I  [  ]{  }) => (  I[  ]{  })`