### PR TITLE
Update selection to behave like cursor-line

### DIFF
--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -530,10 +530,12 @@ func (w *BufWindow) displayBuffer() {
 						(bloc.GreaterEqual(c.CurSelection[0]) && bloc.LessThan(c.CurSelection[1]) ||
 							bloc.LessThan(c.CurSelection[0]) && bloc.GreaterEqual(c.CurSelection[1])) {
 						// The current character is selected
-						style = config.DefStyle.Reverse(true)
 
 						if s, ok := config.Colorscheme["selection"]; ok {
-							style = s
+							fg, _, _ := s.Decompose()
+							style = style.Background(fg)
+						} else {
+							style = config.DefStyle.Reverse(true)
 						}
 					}
 

--- a/internal/display/infowindow.go
+++ b/internal/display/infowindow.go
@@ -97,10 +97,12 @@ func (i *InfoWindow) displayBuffer() {
 				(bloc.GreaterEqual(activeC.CurSelection[0]) && bloc.LessThan(activeC.CurSelection[1]) ||
 					bloc.LessThan(activeC.CurSelection[0]) && bloc.GreaterEqual(activeC.CurSelection[1])) {
 				// The current character is selected
-				style = i.defStyle().Reverse(true)
 
 				if s, ok := config.Colorscheme["selection"]; ok {
-					style = s
+					fg, _, _ := s.Decompose()
+					style = style.Background(fg)
+				} else {
+					style = i.defStyle().Reverse(true)
 				}
 
 			}

--- a/runtime/help/colors.md
+++ b/runtime/help/colors.md
@@ -20,7 +20,8 @@ set colorscheme twilight
 Micro comes with a number of colorschemes by default. The colorschemes that you
 can display will depend on what kind of color support your terminal has.
 
-Omit color-link default "[fg color],[bg color]" will make the background color match the terminal's, and transparency if set.
+Omitting `color-link default "[fg color],[bg color]"` will make the background
+color match the terminal's, and transparency if set.
 
 Modern terminals tend to have a palette of 16 user-configurable colors (these
 colors can often be configured in the terminal preferences), and additional
@@ -164,7 +165,7 @@ marked with a `-paper` suffix.
 
 Here is a list of the colorscheme groups that you can use:
 
-* default (color of the background and foreground for unhighlighted text)
+* default (Color of the background and foreground for unstyled text)
 * comment
 * identifier
 * constant
@@ -176,7 +177,7 @@ Here is a list of the colorscheme groups that you can use:
 * underlined
 * error
 * todo
-* selection (Color of the text selection)
+* selection (Specify foreground color to change background of selection. If not set uses default reverse)
 * statusline (Color of the statusline)
 * tabbar (Color of the tabbar that lists open files)
 * indent-char (Color of the character which indicates tabs if the option is
@@ -187,9 +188,9 @@ Here is a list of the colorscheme groups that you can use:
 * diff-added
 * diff-modified
 * diff-deleted
-* cursor-line
+* cursor-line (Specify foreground color to change background of cursor line)
 * current-line-number
-* color-column
+* color-column (Specify foreground color to change background of configured color column)
 * ignore
 * scrollbar
 * divider (Color of the divider between vertical splits)


### PR DESCRIPTION
Addresses #1961 in a way, as I discovered how `cursor-line` & `color-column` work it made sense to update `selection` to work the same way (while also keeping the default reverse behavior if unspecified)

Also updated help documentation to make clearer this behavior.