### PR TITLE
Fix weird behavior of JumpToMatchingBrace in some ill cases

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+
 	shellquote "github.com/kballard/go-shellquote"
 	"github.com/zyedidia/micro/v2/internal/buffer"
 	"github.com/zyedidia/micro/v2/internal/clipboard"
@@ -1195,15 +1196,12 @@ func (h *BufPane) JumpToMatchingBrace() bool {
 				} else {
 					h.Cursor.GotoLoc(matchingBrace.Move(1, h.Buf))
 				}
-				break
-			} else {
-				return false
+				h.Relocate()
+				return true
 			}
 		}
 	}
-
-	h.Relocate()
-	return true
+	return false
 }
 
 // SelectAll selects the entire buffer


### PR DESCRIPTION
It should not return false immediately when no matching brace is found. This makes the jump fails in certain case: `[  )I]` =/=> `[I  )]`.
When there is no brace near the cursor, the last statement is also executed. This may cause problems when chaining commands.