### PR TITLE
Added multiline strings to the Scala syntax highlighter

### DIFF
--- a/runtime/syntax/scala.yaml
+++ b/runtime/syntax/scala.yaml
@@ -8,6 +8,10 @@ rules:
     - statement: "\\b(match|val|var|break|case|catch|continue|default|do|else|finally|for|if|return|switch|throw|try|while)\\b"
     - statement: "\\b(def|object|case|trait|lazy|implicit|abstract|class|extends|with|final|implements|override|import|instanceof|interface|native|package|private|protected|public|static|strictfp|super|synchronized|throws|volatile|sealed)\\b"
     - constant.string:
+        start: "\"\"\""
+        end: "\"\"\""
+        rules: []
+    - constant.string:
         start: "\""
         end: "\""
         skip: "\\\\."


### PR DESCRIPTION
In Scala multiline strings are constructed just like in Python:

```
val multiline = """This
is
a
multiline
string
"""