### PR TITLE
Fix non-working TryBindKey and UnbindKey

### DIFF
--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -238,7 +238,7 @@ func findEvent(k string) (Event, error) {
 // Returns true if the keybinding already existed and a possible error
 func TryBindKey(k, v string, overwrite bool) (bool, error) {
 	var e error
-	var parsed map[string]string
+	var parsed map[string]interface{}
 
 	filename := filepath.Join(config.ConfigDir, "bindings.json")
 	createBindingsIfNotExist(filename)
@@ -288,7 +288,7 @@ func TryBindKey(k, v string, overwrite bool) (bool, error) {
 // UnbindKey removes the binding for a key from the bindings.json file
 func UnbindKey(k string) error {
 	var e error
-	var parsed map[string]string
+	var parsed map[string]interface{}
 
 	filename := filepath.Join(config.ConfigDir, "bindings.json")
 	createBindingsIfNotExist(filename)


### PR DESCRIPTION
Fixed regression: since merging `keybindings` branch, `TryBindKey` and `UnbindKey` and accordingly `bind` and `unbind` commands don't work (fail to unmarshal bindings.json).

This is just a quick fixup to make `TryBindKey` and `UnbindKey` work again. They still work with "buffer" bindings only. So still the only way the user can modify command line and terminal keybindings is via editing bindings.json. It would be good to make `TryBindKey` work with any bindings, but I'm not sure how to do that without breaking compatibility with existing plugins etc.