### PR TITLE
add settings option "findontype" to allow disabling search-on-type

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -847,21 +847,24 @@ func (h *BufPane) find(useRegex bool) bool {
 	if useRegex {
 		prompt = "Find (regex): "
 	}
-	InfoBar.Prompt(prompt, "", "Find", func(resp string) {
-		// Event callback
-		match, found, _ := h.Buf.FindNext(resp, h.Buf.Start(), h.Buf.End(), h.searchOrig, true, useRegex)
-		if found {
-			h.Cursor.SetSelectionStart(match[0])
-			h.Cursor.SetSelectionEnd(match[1])
-			h.Cursor.OrigSelection[0] = h.Cursor.CurSelection[0]
-			h.Cursor.OrigSelection[1] = h.Cursor.CurSelection[1]
-			h.Cursor.GotoLoc(match[1])
-		} else {
-			h.Cursor.GotoLoc(h.searchOrig)
-			h.Cursor.ResetSelection()
+	var eventCallback func(resp string)
+	if h.Buf.Settings["findontype"].(bool) {
+		eventCallback = func(resp string) {
+			match, found, _ := h.Buf.FindNext(resp, h.Buf.Start(), h.Buf.End(), h.searchOrig, true, useRegex)
+			if found {
+				h.Cursor.SetSelectionStart(match[0])
+				h.Cursor.SetSelectionEnd(match[1])
+				h.Cursor.OrigSelection[0] = h.Cursor.CurSelection[0]
+				h.Cursor.OrigSelection[1] = h.Cursor.CurSelection[1]
+				h.Cursor.GotoLoc(match[1])
+			} else {
+				h.Cursor.GotoLoc(h.searchOrig)
+				h.Cursor.ResetSelection()
+			}
+			h.Relocate()
 		}
-		h.Relocate()
-	}, func(resp string, canceled bool) {
+	}
+	InfoBar.Prompt(prompt, "", "Find", eventCallback, func(resp string, canceled bool) {
 		// Finished callback
 		if !canceled {
 			match, found, err := h.Buf.FindNext(resp, h.Buf.Start(), h.Buf.End(), h.searchOrig, true, useRegex)

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -269,6 +269,7 @@ var defaultCommonSettings = map[string]interface{}{
 	"fastdirty":      false,
 	"fileformat":     "unix",
 	"filetype":       "unknown",
+	"findontype":     true,
 	"ignorecase":     true,
 	"indentchar":     " ",
 	"keepautoindent": false,

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -159,6 +159,10 @@ Here are the available options:
 	default value: `unknown`. This will be automatically overridden depending
     on the file you open.
 
+* `findontype`: enable search-on-type in "Find" prompt (pattern input)
+
+	default value: `true`
+
 * `ignorecase`: perform case-insensitive searches.
 
 	default value: `true`
@@ -423,6 +427,7 @@ so that you can see what the formatting should look like.
     "fastdirty": false,
     "fileformat": "unix",
     "filetype": "unknown",
+    "findontype": true,
     "ftoptions": true,
     "ignorecase": false,
     "indentchar": " ",


### PR DESCRIPTION
Search-on-type in "Find" prompt causes freezing for large files (> 50 MB) if pattern is not close to current position, or non-existent.
And it even searches on cursor-change, which requires another PR to fix.
But for whatever reason we should be able to disable it with settings.