### PR TITLE
Add onExecuteTextEvent hook

### DIFF
--- a/internal/buffer/eventhandler.go
+++ b/internal/buffer/eventhandler.go
@@ -247,6 +247,15 @@ func (eh *EventHandler) Execute(t *TextEvent) {
 	}
 
 	ExecuteTextEvent(t, eh.buf)
+
+	b, err := config.RunPluginFnBool("onExecuteTextEvent", luar.New(ulua.L, eh.buf), luar.New(ulua.L, t))
+	if err != nil {
+		screen.TermMessage(err)
+	}
+
+	if !b {
+		return
+	}
 }
 
 // Undo the first event in the undo stack


### PR DESCRIPTION
@zyedidia I've added the `onExecuteTextEvent` hook (fires after `ExecuteTextEvent`) to complement the `onBeforeTextEvent` hook (fires before `ExecuteTextEvent`).