### PR TITLE
Improve C syntax highlighting

### DIFF
--- a/runtime/syntax/c.yaml
+++ b/runtime/syntax/c.yaml
@@ -5,7 +5,7 @@ detect:
 
 rules:
     - identifier: "\\b[A-Z_][0-9A-Z_]+\\b"
-    - type: "\\b(float|double|char|int|short|long|sizeof|enum|void|static|const|struct|union|typedef|extern|(un)?signed|inline)\\b"
+    - type: "\\b(auto|float|double|char|int|short|long|sizeof|enum|void|static|const|struct|union|typedef|extern|(un)?signed|inline)\\b"
     - type: "\\b((s?size)|((u_?)?int(8|16|32|64|ptr)))_t\\b"
     - type.extended: "\\b(bool)\\b"
     - statement: "\\b(volatile|register)\\b"
@@ -18,7 +18,12 @@ rules:
       # Operator Color
     - symbol.operator: "([.:;,+*|=!\\%]|<|>|/|-|&)"
     - symbol.brackets: "[(){}]|\\[|\\]"
-    - constant.number: "(\\b[0-9]+\\b|\\b0x[0-9A-Fa-f]+\\b)"
+      # Integer Constants
+    - constant.number: "(\\b([1-9][0-9]*|0[0-7]*|0[Xx][0-9A-Fa-f]+|0[Bb][01]+)([Uu]?[Ll][Ll]?|[Ll][Ll]?[Uu]?)?\\b)"
+      # Decimal Floating Constants
+    - constant.number: "(\\b(([0-9]*[.][0-9]+|[0-9]+[.][0-9]*)([Ee][+-]?[0-9]+)?|[0-9]+[Ee][+-]?[0-9]+)[FfLl]?\\b)"
+      # Hexadecimal Floating Constants
+    - constant.number: "(\\b0[Xx]([0-9A-Za-z]*[.][0-9A-Za-z]+|[0-9A-Za-z]+[.][0-9A-Za-z]*)[Pp][+-]?[0-9]+[FfLl]?\\b)"
     - constant.number: "NULL"
 
     - constant.string:


### PR DESCRIPTION
Improve C syntax highlighting:
* Currently number constants have very basic support: https://github.com/zyedidia/micro/blob/ba98b558d97aa8396e222c31bd8d8f0fa6ca4977/runtime/syntax/c.yaml#L21 Even floating constants are not supported. I made `constant.number` more complete and conforming to [the spec](https://en.cppreference.com/w/c/language/expressions#Constants_and_literals), while taking inspiration from the already existing [C++ syntax highlighting](https://github.com/zyedidia/micro/blob/HEAD/runtime/syntax/cpp.yaml).
* `auto` is a valid keyword per [the spec](https://en.cppreference.com/w/c/keyword).