### PR TITLE
Add Gemini syntax file

### DIFF
--- a/runtime/syntax/gemini.yaml
+++ b/runtime/syntax/gemini.yaml
@@ -1,0 +1,19 @@
+filetype: gemini
+
+detect:
+    filename: "\\.(gmi|gemini)$"
+
+rules:
+      # link lines
+    - constant: "^=>[[:space:]].*"
+      # preformatted text lines
+    - special:
+        start: "^```"
+        end: "^```"
+        rules: []
+      # heading lines
+    - special:  "^#{1,3}.*"
+      # unordered list items
+    - identifier: "^\\*[[:space:]]"
+      # quote lines
+    - statement:  "^>.*"


### PR DESCRIPTION
The `text/gemini` media type is defined in [Gemini specification](https://gemini.circumlunar.space/docs/specification.html).
Gemini syntax highlighting for other editors:
- [gemini-vim-syntax](https://tildegit.org/sloum/gemini-vim-syntax) - vim
- [gemini.el](https://git.carcosa.net/jmcbray/gemini.el) - emacs
- [gemini.kak](https://github.com/kakoune-editor/kakoune-extra-filetypes/blob/master/rc/gemini.kak) - kakoune
- [gemini.nanorc](https://github.com/yzzyx-network/nanorc/blob/master/gemini.nanorc) - nano
- [gemini-language-support](https://github.com/aaronjanse/gemini-language-support) - vscode