### PR TITLE
Add .tsx support for Typescript syntax

### DIFF
--- a/runtime/syntax/typescript.yaml
+++ b/runtime/syntax/typescript.yaml
@@ -1,7 +1,7 @@
 filetype: typescript
 
 detect:
-    filename: "\\.(ts|tsx)$"
+    filename: "\\.tsx?$"
 
 rules:
     - constant.number: "\\b[-+]?([1-9][0-9]*|0[0-7]*|0x[0-9a-fA-F]+)([uU][lL]?|[lL][uU]?)?\\b"

--- a/runtime/syntax/typescript.yaml
+++ b/runtime/syntax/typescript.yaml
@@ -1,7 +1,7 @@
 filetype: typescript
 
 detect:
-    filename: "\\.ts$"
+    filename: "\\.(ts|tsx)$"
 
 rules:
     - constant.number: "\\b[-+]?([1-9][0-9]*|0[0-7]*|0x[0-9a-fA-F]+)([uU][lL]?|[lL][uU]?)?\\b"


### PR DESCRIPTION
This will use the same syntax highlighting for .tsx files as for .ts files.