### PR TITLE
docs: update Arch Linux installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ for other operating systems. These packages are not guaranteed to be up-to-date.
 * Linux: Available in distro-specific package managers.
     * `apt install micro` (Ubuntu 20.04 `focal`, and Debian `unstable | testing | buster-backports`). At the moment, this package (2.0.1-1) is outdated and has a known bug where debug mode is enabled.
     * `dnf install micro` (Fedora).
-    * `yay -S micro` (Arch Linux).
+    * `pacman -S micro` (Arch Linux).
     * `eopkg install micro` (Solus).
     * See [wiki](https://github.com/zyedidia/micro/wiki/Installing-Micro) for details about CRUX, Termux.
 * Windows: [Chocolatey](https://chocolatey.org) and [Scoop](https://github.com/lukesampson/scoop).


### PR DESCRIPTION
micro has been promoted to Community repo (https://archlinux.org/packages/community/x86_64/micro/) becoming the preferred install method.