### PR TITLE
Removed .v extension from verilog and added to v

### DIFF
--- a/runtime/syntax/v.yaml
+++ b/runtime/syntax/v.yaml
@@ -1,6 +1,7 @@
 filetype: v
 
 detect:
+    filename: "\\.(v)$"
 
 rules:
     # Conditionals and control flow

--- a/runtime/syntax/verilog.yaml
+++ b/runtime/syntax/verilog.yaml
@@ -1,7 +1,7 @@
 filetype: verilog
 
 detect:
-    filename: "\\.(v|vh|sv|svh)$"
+    filename: "\\.(vh|sv|svh)$"
 
 rules:
     - preproc: "\\b(module|package|program|endmodule|endpackage|endprogram)\\b"


### PR DESCRIPTION
The ```.v``` extension was used by Verilog and not Vlang. I removed this from ```verilog.yaml``` and added to ```v.yaml```