### PR TITLE
Added lines and percentage statusbar directives

### DIFF
--- a/internal/display/statusline.go
+++ b/internal/display/statusline.go
@@ -47,6 +47,12 @@ var statusInfo = map[string]func(*buffer.Buffer) string{
 		}
 		return ""
 	},
+	"lines": func(b *buffer.Buffer) string {
+		return strconv.Itoa(b.LinesNum())
+	},
+	"percentage": func(b *buffer.Buffer) string {
+		return strconv.Itoa((b.GetActiveCursor().Y + 1) * 100 / b.LinesNum())
+	},
 }
 
 func SetStatusInfoFnLua(fn string) {

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -333,7 +333,7 @@ Here are the available options:
 
 * `statusformatl`: format string definition for the left-justified part of the
    statusline. Special directives should be placed inside `$()`. Special
-   directives include: `filename`, `modified`, `line`, `col`, `opt`, `bind`.
+   directives include: `filename`, `modified`, `line`, `col`, `lines`, `percentage`, `opt`, `bind`.
    The `opt` and `bind` directives take either an option or an action afterward
    and fill in the value of the option or the key bound to the action.
 


### PR DESCRIPTION
- "lines" for the number of lines in the buffer
- "percentage" for the percentage of the file at the current line

Fixes zyedidia/micro#2049


**Note:**
I am not an experienced Go developer (this is my first time messing with Go code). I tried looking for contribution guidelines but found none, so I tried to match the style of surrounding code.
I found no clear test suite to run, but my changes built without errors and work as intended.

![image](https://user-images.githubusercontent.com/5877043/110117582-0ef61f80-7d87-11eb-9730-18d5c1aee5ba.png)
