### PR TITLE
Softwrap improvements

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -36,8 +36,8 @@ func (h *BufPane) ScrollDown(n int) {
 func (h *BufPane) ScrollAdjust() {
 	v := h.GetView()
 	end := h.SLocFromLoc(h.Buf.End())
-	if h.Diff(v.StartLine, end) < h.BufHeight()-1 {
-		v.StartLine = h.Scroll(end, -h.BufHeight()+1)
+	if h.Diff(v.StartLine, end) < h.BufView().Height-1 {
+		v.StartLine = h.Scroll(end, -h.BufView().Height+1)
 	}
 	h.SetView(v)
 }
@@ -117,7 +117,7 @@ func (h *BufPane) ScrollDownAction() bool {
 // Center centers the view on the cursor
 func (h *BufPane) Center() bool {
 	v := h.GetView()
-	v.StartLine = h.Scroll(h.SLocFromLoc(h.Cursor.Loc), -h.BufHeight()/2)
+	v.StartLine = h.Scroll(h.SLocFromLoc(h.Cursor.Loc), -h.BufView().Height/2)
 	h.SetView(v)
 	h.ScrollAdjust()
 	return true
@@ -1290,20 +1290,20 @@ func (h *BufPane) Start() bool {
 // End moves the viewport to the end of the buffer
 func (h *BufPane) End() bool {
 	v := h.GetView()
-	v.StartLine = h.Scroll(h.SLocFromLoc(h.Buf.End()), -h.BufHeight()+1)
+	v.StartLine = h.Scroll(h.SLocFromLoc(h.Buf.End()), -h.BufView().Height+1)
 	h.SetView(v)
 	return true
 }
 
 // PageUp scrolls the view up a page
 func (h *BufPane) PageUp() bool {
-	h.ScrollUp(h.BufHeight())
+	h.ScrollUp(h.BufView().Height)
 	return true
 }
 
 // PageDown scrolls the view down a page
 func (h *BufPane) PageDown() bool {
-	h.ScrollDown(h.BufHeight())
+	h.ScrollDown(h.BufView().Height)
 	h.ScrollAdjust()
 	return true
 }
@@ -1313,7 +1313,7 @@ func (h *BufPane) SelectPageUp() bool {
 	if !h.Cursor.HasSelection() {
 		h.Cursor.OrigSelection[0] = h.Cursor.Loc
 	}
-	h.MoveCursorUp(h.BufHeight())
+	h.MoveCursorUp(h.BufView().Height)
 	h.Cursor.SelectTo(h.Cursor.Loc)
 	h.Relocate()
 	return true
@@ -1324,7 +1324,7 @@ func (h *BufPane) SelectPageDown() bool {
 	if !h.Cursor.HasSelection() {
 		h.Cursor.OrigSelection[0] = h.Cursor.Loc
 	}
-	h.MoveCursorDown(h.BufHeight())
+	h.MoveCursorDown(h.BufView().Height)
 	h.Cursor.SelectTo(h.Cursor.Loc)
 	h.Relocate()
 	return true
@@ -1339,7 +1339,7 @@ func (h *BufPane) CursorPageUp() bool {
 		h.Cursor.ResetSelection()
 		h.Cursor.StoreVisualX()
 	}
-	h.MoveCursorUp(h.BufHeight())
+	h.MoveCursorUp(h.BufView().Height)
 	h.Relocate()
 	return true
 }
@@ -1353,20 +1353,20 @@ func (h *BufPane) CursorPageDown() bool {
 		h.Cursor.ResetSelection()
 		h.Cursor.StoreVisualX()
 	}
-	h.MoveCursorDown(h.BufHeight())
+	h.MoveCursorDown(h.BufView().Height)
 	h.Relocate()
 	return true
 }
 
 // HalfPageUp scrolls the view up half a page
 func (h *BufPane) HalfPageUp() bool {
-	h.ScrollUp(h.BufHeight() / 2)
+	h.ScrollUp(h.BufView().Height / 2)
 	return true
 }
 
 // HalfPageDown scrolls the view down half a page
 func (h *BufPane) HalfPageDown() bool {
-	h.ScrollDown(h.BufHeight() / 2)
+	h.ScrollDown(h.BufView().Height / 2)
 	h.ScrollAdjust()
 	return true
 }

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -36,8 +36,8 @@ func (h *BufPane) ScrollDown(n int) {
 func (h *BufPane) ScrollAdjust() {
 	v := h.GetView()
 	end := h.SLocFromLoc(h.Buf.End())
-	if h.Diff(v.StartLine, end) < v.Height-1 {
-		v.StartLine = h.Scroll(end, -v.Height+1)
+	if h.Diff(v.StartLine, end) < h.BufHeight()-1 {
+		v.StartLine = h.Scroll(end, -h.BufHeight()+1)
 	}
 	h.SetView(v)
 }
@@ -117,7 +117,7 @@ func (h *BufPane) ScrollDownAction() bool {
 // Center centers the view on the cursor
 func (h *BufPane) Center() bool {
 	v := h.GetView()
-	v.StartLine = h.Scroll(h.SLocFromLoc(h.Cursor.Loc), -v.Height/2)
+	v.StartLine = h.Scroll(h.SLocFromLoc(h.Cursor.Loc), -h.BufHeight()/2)
 	h.SetView(v)
 	h.ScrollAdjust()
 	return true
@@ -1251,22 +1251,20 @@ func (h *BufPane) Start() bool {
 // End moves the viewport to the end of the buffer
 func (h *BufPane) End() bool {
 	v := h.GetView()
-	v.StartLine = h.Scroll(h.SLocFromLoc(h.Buf.End()), -v.Height+1)
+	v.StartLine = h.Scroll(h.SLocFromLoc(h.Buf.End()), -h.BufHeight()+1)
 	h.SetView(v)
 	return true
 }
 
 // PageUp scrolls the view up a page
 func (h *BufPane) PageUp() bool {
-	v := h.GetView()
-	h.ScrollUp(v.Height)
+	h.ScrollUp(h.BufHeight())
 	return true
 }
 
 // PageDown scrolls the view down a page
 func (h *BufPane) PageDown() bool {
-	v := h.GetView()
-	h.ScrollDown(v.Height)
+	h.ScrollDown(h.BufHeight())
 	h.ScrollAdjust()
 	return true
 }
@@ -1276,7 +1274,7 @@ func (h *BufPane) SelectPageUp() bool {
 	if !h.Cursor.HasSelection() {
 		h.Cursor.OrigSelection[0] = h.Cursor.Loc
 	}
-	h.Cursor.UpN(h.GetView().Height)
+	h.Cursor.UpN(h.BufHeight())
 	h.Cursor.SelectTo(h.Cursor.Loc)
 	h.Relocate()
 	return true
@@ -1287,7 +1285,7 @@ func (h *BufPane) SelectPageDown() bool {
 	if !h.Cursor.HasSelection() {
 		h.Cursor.OrigSelection[0] = h.Cursor.Loc
 	}
-	h.Cursor.DownN(h.GetView().Height)
+	h.Cursor.DownN(h.BufHeight())
 	h.Cursor.SelectTo(h.Cursor.Loc)
 	h.Relocate()
 	return true
@@ -1302,7 +1300,7 @@ func (h *BufPane) CursorPageUp() bool {
 		h.Cursor.ResetSelection()
 		h.Cursor.StoreVisualX()
 	}
-	h.Cursor.UpN(h.GetView().Height)
+	h.Cursor.UpN(h.BufHeight())
 	h.Relocate()
 	return true
 }
@@ -1316,22 +1314,20 @@ func (h *BufPane) CursorPageDown() bool {
 		h.Cursor.ResetSelection()
 		h.Cursor.StoreVisualX()
 	}
-	h.Cursor.DownN(h.GetView().Height)
+	h.Cursor.DownN(h.BufHeight())
 	h.Relocate()
 	return true
 }
 
 // HalfPageUp scrolls the view up half a page
 func (h *BufPane) HalfPageUp() bool {
-	v := h.GetView()
-	h.ScrollUp(v.Height / 2)
+	h.ScrollUp(h.BufHeight() / 2)
 	return true
 }
 
 // HalfPageDown scrolls the view down half a page
 func (h *BufPane) HalfPageDown() bool {
-	v := h.GetView()
-	h.ScrollDown(v.Height / 2)
+	h.ScrollDown(h.BufHeight() / 2)
 	h.ScrollAdjust()
 	return true
 }

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -123,10 +123,49 @@ func (h *BufPane) Center() bool {
 	return true
 }
 
+// MoveCursorUp is not an action
+func (h *BufPane) MoveCursorUp(n int) {
+	if !h.Buf.Settings["softwrap"].(bool) {
+		h.Cursor.UpN(n)
+	} else {
+		vloc := h.VLocFromLoc(h.Cursor.Loc)
+		sloc := h.Scroll(vloc.SLoc, -n)
+		if sloc == vloc.SLoc {
+			// we are at the beginning of buffer
+			h.Cursor.Loc = h.Buf.Start()
+			h.Cursor.LastVisualX = 0
+		} else {
+			vloc.SLoc = sloc
+			vloc.VisualX = h.Cursor.LastVisualX
+			h.Cursor.Loc = h.LocFromVLoc(vloc)
+		}
+	}
+}
+
+// MoveCursorDown is not an action
+func (h *BufPane) MoveCursorDown(n int) {
+	if !h.Buf.Settings["softwrap"].(bool) {
+		h.Cursor.DownN(n)
+	} else {
+		vloc := h.VLocFromLoc(h.Cursor.Loc)
+		sloc := h.Scroll(vloc.SLoc, n)
+		if sloc == vloc.SLoc {
+			// we are at the end of buffer
+			h.Cursor.Loc = h.Buf.End()
+			vloc = h.VLocFromLoc(h.Cursor.Loc)
+			h.Cursor.LastVisualX = vloc.VisualX
+		} else {
+			vloc.SLoc = sloc
+			vloc.VisualX = h.Cursor.LastVisualX
+			h.Cursor.Loc = h.LocFromVLoc(vloc)
+		}
+	}
+}
+
 // CursorUp moves the cursor up
 func (h *BufPane) CursorUp() bool {
 	h.Cursor.Deselect(true)
-	h.Cursor.Up()
+	h.MoveCursorUp(1)
 	h.Relocate()
 	return true
 }
@@ -134,7 +173,7 @@ func (h *BufPane) CursorUp() bool {
 // CursorDown moves the cursor down
 func (h *BufPane) CursorDown() bool {
 	h.Cursor.Deselect(true)
-	h.Cursor.Down()
+	h.MoveCursorDown(1)
 	h.Relocate()
 	return true
 }
@@ -212,7 +251,7 @@ func (h *BufPane) SelectUp() bool {
 	if !h.Cursor.HasSelection() {
 		h.Cursor.OrigSelection[0] = h.Cursor.Loc
 	}
-	h.Cursor.Up()
+	h.MoveCursorUp(1)
 	h.Cursor.SelectTo(h.Cursor.Loc)
 	h.Relocate()
 	return true
@@ -223,7 +262,7 @@ func (h *BufPane) SelectDown() bool {
 	if !h.Cursor.HasSelection() {
 		h.Cursor.OrigSelection[0] = h.Cursor.Loc
 	}
-	h.Cursor.Down()
+	h.MoveCursorDown(1)
 	h.Cursor.SelectTo(h.Cursor.Loc)
 	h.Relocate()
 	return true
@@ -1274,7 +1313,7 @@ func (h *BufPane) SelectPageUp() bool {
 	if !h.Cursor.HasSelection() {
 		h.Cursor.OrigSelection[0] = h.Cursor.Loc
 	}
-	h.Cursor.UpN(h.BufHeight())
+	h.MoveCursorUp(h.BufHeight())
 	h.Cursor.SelectTo(h.Cursor.Loc)
 	h.Relocate()
 	return true
@@ -1285,7 +1324,7 @@ func (h *BufPane) SelectPageDown() bool {
 	if !h.Cursor.HasSelection() {
 		h.Cursor.OrigSelection[0] = h.Cursor.Loc
 	}
-	h.Cursor.DownN(h.BufHeight())
+	h.MoveCursorDown(h.BufHeight())
 	h.Cursor.SelectTo(h.Cursor.Loc)
 	h.Relocate()
 	return true
@@ -1300,7 +1339,7 @@ func (h *BufPane) CursorPageUp() bool {
 		h.Cursor.ResetSelection()
 		h.Cursor.StoreVisualX()
 	}
-	h.Cursor.UpN(h.BufHeight())
+	h.MoveCursorUp(h.BufHeight())
 	h.Relocate()
 	return true
 }
@@ -1314,7 +1353,7 @@ func (h *BufPane) CursorPageDown() bool {
 		h.Cursor.ResetSelection()
 		h.Cursor.StoreVisualX()
 	}
-	h.Cursor.DownN(h.BufHeight())
+	h.MoveCursorDown(h.BufHeight())
 	h.Relocate()
 	return true
 }

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -196,6 +196,12 @@ type Buffer struct {
 	// the buffer module cannot directly call the display's API (it would mean
 	// a circular dependency between packages).
 	OptionCallback func(option string, nativeValue interface{})
+
+	// The display module registers its own GetVisualX function for getting
+	// the correct visual x location of a cursor when softwrap is used.
+	// This is hacky. Maybe it would be better to move all the visual x logic
+	// from buffer to display, but it would require rewriting a lot of code.
+	GetVisualX func(loc Loc) int
 }
 
 // NewBufferFromFileAtLoc opens a new buffer with a given cursor location

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -189,6 +189,13 @@ type Buffer struct {
 	cursors     []*Cursor
 	curCursor   int
 	StartCursor Loc
+
+	// OptionCallback is called after a buffer option value is changed.
+	// The display module registers its OptionCallback to ensure the buffer window
+	// is properly updated when needed. This is a workaround for the fact that
+	// the buffer module cannot directly call the display's API (it would mean
+	// a circular dependency between packages).
+	OptionCallback func(option string, nativeValue interface{})
 }
 
 // NewBufferFromFileAtLoc opens a new buffer with a given cursor location

--- a/internal/buffer/cursor.go
+++ b/internal/buffer/cursor.go
@@ -67,6 +67,10 @@ func (c *Cursor) GotoLoc(l Loc) {
 
 // GetVisualX returns the x value of the cursor in visual spaces
 func (c *Cursor) GetVisualX() int {
+	if c.buf.GetVisualX != nil {
+		return c.buf.GetVisualX(c.Loc)
+	}
+
 	if c.X <= 0 {
 		c.X = 0
 		return 0

--- a/internal/buffer/settings.go
+++ b/internal/buffer/settings.go
@@ -41,6 +41,10 @@ func (b *Buffer) SetOptionNative(option string, nativeValue interface{}) error {
 		b.Type.Readonly = nativeValue.(bool)
 	}
 
+	if b.OptionCallback != nil {
+		b.OptionCallback(option, nativeValue)
+	}
+
 	return nil
 }
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -297,6 +297,7 @@ var defaultCommonSettings = map[string]interface{}{
 	"tabsize":        float64(4),
 	"tabstospaces":   false,
 	"useprimary":     true,
+	"wordwrap":       false,
 }
 
 func GetInfoBarOffset() int {

--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -35,7 +35,8 @@ type BufWindow struct {
 func NewBufWindow(x, y, width, height int, buf *buffer.Buffer) *BufWindow {
 	w := new(BufWindow)
 	w.View = new(View)
-	w.X, w.Y, w.Width, w.Height, w.Buf = x, y, width, height, buf
+	w.X, w.Y, w.Width, w.Height = x, y, width, height
+	w.SetBuffer(buf)
 	w.active = true
 
 	w.sline = NewStatusLine(w)
@@ -45,6 +46,16 @@ func NewBufWindow(x, y, width, height int, buf *buffer.Buffer) *BufWindow {
 
 func (w *BufWindow) SetBuffer(b *buffer.Buffer) {
 	w.Buf = b
+	b.OptionCallback = func(option string, nativeValue interface{}) {
+		if option == "softwrap" {
+			if nativeValue.(bool) {
+				w.StartCol = 0
+			} else {
+				w.StartLine.Row = 0
+			}
+			w.Relocate()
+		}
+	}
 }
 
 func (w *BufWindow) GetView() *View {

--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -54,7 +54,14 @@ func (w *BufWindow) SetBuffer(b *buffer.Buffer) {
 				w.StartLine.Row = 0
 			}
 			w.Relocate()
+
+			for _, c := range w.Buf.GetCursors() {
+				c.LastVisualX = c.GetVisualX()
+			}
 		}
+	}
+	b.GetVisualX = func(loc buffer.Loc) int {
+		return w.VLocFromLoc(loc).VisualX
 	}
 }
 
@@ -68,7 +75,15 @@ func (w *BufWindow) SetView(view *View) {
 
 func (w *BufWindow) Resize(width, height int) {
 	w.Width, w.Height = width, height
+	w.updateDisplayInfo()
+
 	w.Relocate()
+
+	if w.Buf.Settings["softwrap"].(bool) {
+		for _, c := range w.Buf.GetCursors() {
+			c.LastVisualX = c.GetVisualX()
+		}
+	}
 }
 
 func (w *BufWindow) SetActive(b bool) {

--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -94,16 +94,18 @@ func (w *BufWindow) IsActive() bool {
 	return w.active
 }
 
-// BufWidth returns the width of the actual buffer displayed in the window,
-// which is usually less than the window width due to the gutter, ruler or scrollbar
-func (w *BufWindow) BufWidth() int {
-	return w.bufWidth
-}
-
-// BufHeight returns the height of the actual buffer displayed in the window,
-// which is usually less than the window height due to the statusline
-func (w *BufWindow) BufHeight() int {
-	return w.bufHeight
+// BufView returns the width, height and x,y location of the actual buffer.
+// It is not exactly the same as the whole window which also contains gutter,
+// ruler, scrollbar and statusline.
+func (w *BufWindow) BufView() View {
+	return View{
+		X:         w.gutterOffset,
+		Y:         0,
+		Width:     w.bufWidth,
+		Height:    w.bufHeight,
+		StartLine: w.StartLine,
+		StartCol:  w.StartCol,
+	}
 }
 
 func (w *BufWindow) updateDisplayInfo() {

--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -208,12 +208,17 @@ func (w *BufWindow) Relocate() bool {
 	// horizontal relocation (scrolling)
 	if !b.Settings["softwrap"].(bool) {
 		cx := activeC.GetVisualX()
+		rw := runewidth.RuneWidth(activeC.RuneUnder(activeC.X))
+		if rw == 0 {
+			rw = 1 // tab or newline
+		}
+
 		if cx < w.StartCol {
 			w.StartCol = cx
 			ret = true
 		}
-		if cx+w.gutterOffset+1 > w.StartCol+w.Width {
-			w.StartCol = cx - w.Width + w.gutterOffset + 1
+		if cx+w.gutterOffset+rw > w.StartCol+w.Width {
+			w.StartCol = cx - w.Width + w.gutterOffset + rw
 			ret = true
 		}
 	}

--- a/internal/display/infowindow.go
+++ b/internal/display/infowindow.go
@@ -72,6 +72,9 @@ func (i *InfoWindow) LocFromVisual(vloc buffer.Loc) buffer.Loc {
 	return buffer.Loc{c.GetCharPosInLine(l, vloc.X-n), 0}
 }
 
+func (i *InfoWindow) BufWidth() int  { return i.Width }
+func (i *InfoWindow) BufHeight() int { return 1 }
+
 func (i *InfoWindow) Scroll(s SLoc, n int) SLoc       { return s }
 func (i *InfoWindow) Diff(s1, s2 SLoc) int            { return 0 }
 func (i *InfoWindow) SLocFromLoc(loc buffer.Loc) SLoc { return SLoc{0, 0} }

--- a/internal/display/infowindow.go
+++ b/internal/display/infowindow.go
@@ -72,8 +72,16 @@ func (i *InfoWindow) LocFromVisual(vloc buffer.Loc) buffer.Loc {
 	return buffer.Loc{c.GetCharPosInLine(l, vloc.X-n), 0}
 }
 
-func (i *InfoWindow) BufWidth() int  { return i.Width }
-func (i *InfoWindow) BufHeight() int { return 1 }
+func (i *InfoWindow) BufView() View {
+	return View{
+		X:         0,
+		Y:         0,
+		Width:     i.Width,
+		Height:    1,
+		StartLine: SLoc{0, 0},
+		StartCol:  0,
+	}
+}
 
 func (i *InfoWindow) Scroll(s SLoc, n int) SLoc        { return s }
 func (i *InfoWindow) Diff(s1, s2 SLoc) int             { return 0 }

--- a/internal/display/infowindow.go
+++ b/internal/display/infowindow.go
@@ -75,9 +75,11 @@ func (i *InfoWindow) LocFromVisual(vloc buffer.Loc) buffer.Loc {
 func (i *InfoWindow) BufWidth() int  { return i.Width }
 func (i *InfoWindow) BufHeight() int { return 1 }
 
-func (i *InfoWindow) Scroll(s SLoc, n int) SLoc       { return s }
-func (i *InfoWindow) Diff(s1, s2 SLoc) int            { return 0 }
-func (i *InfoWindow) SLocFromLoc(loc buffer.Loc) SLoc { return SLoc{0, 0} }
+func (i *InfoWindow) Scroll(s SLoc, n int) SLoc        { return s }
+func (i *InfoWindow) Diff(s1, s2 SLoc) int             { return 0 }
+func (i *InfoWindow) SLocFromLoc(loc buffer.Loc) SLoc  { return SLoc{0, 0} }
+func (i *InfoWindow) VLocFromLoc(loc buffer.Loc) VLoc  { return VLoc{SLoc{0, 0}, loc.X} }
+func (i *InfoWindow) LocFromVLoc(vloc VLoc) buffer.Loc { return buffer.Loc{vloc.VisualX, 0} }
 
 func (i *InfoWindow) Clear() {
 	for x := 0; x < i.Width; x++ {

--- a/internal/display/softwrap.go
+++ b/internal/display/softwrap.go
@@ -36,17 +36,13 @@ type SoftWrap interface {
 }
 
 func (w *BufWindow) getRow(loc buffer.Loc) int {
-	width := w.Width - w.gutterOffset
-	if w.Buf.Settings["scrollbar"].(bool) && w.Buf.LinesNum() > w.Height {
-		width--
-	}
-	if width <= 0 {
+	if w.bufWidth <= 0 {
 		return 0
 	}
 	// TODO: this doesn't work quite correctly if there is an incomplete tab
 	// or wide character at the end of a row. See also issue #1979
 	x := util.StringWidth(w.Buf.LineBytes(loc.Y), loc.X, util.IntOpt(w.Buf.Settings["tabsize"]))
-	return x / width
+	return x / w.bufWidth
 }
 
 func (w *BufWindow) getRowCount(line int) int {

--- a/internal/display/softwrap.go
+++ b/internal/display/softwrap.go
@@ -30,27 +30,36 @@ func (s SLoc) GreaterThan(b SLoc) bool {
 	return s.Line == b.Line && s.Row > b.Row
 }
 
+// VLoc represents a location in the buffer as a visual location in the
+// linewrapped buffer.
+type VLoc struct {
+	SLoc
+	VisualX int
+}
+
 type SoftWrap interface {
 	Scroll(s SLoc, n int) SLoc
 	Diff(s1, s2 SLoc) int
 	SLocFromLoc(loc buffer.Loc) SLoc
+	VLocFromLoc(loc buffer.Loc) VLoc
+	LocFromVLoc(vloc VLoc) buffer.Loc
 }
 
-func (w *BufWindow) getRow(loc buffer.Loc) int {
+func (w *BufWindow) getVLocFromLoc(loc buffer.Loc) VLoc {
+	vloc := VLoc{SLoc: SLoc{loc.Y, 0}, VisualX: 0}
+
 	if loc.X <= 0 {
-		return 0
+		return vloc
 	}
 
 	if w.bufWidth <= 0 {
-		return 0
+		return vloc
 	}
 
 	tabsize := util.IntOpt(w.Buf.Settings["tabsize"])
 
 	line := w.Buf.LineBytes(loc.Y)
 	x := 0
-	visualx := 0
-	row := 0
 	totalwidth := 0
 
 	for len(line) > 0 {
@@ -60,7 +69,7 @@ func (w *BufWindow) getRow(loc buffer.Loc) int {
 		switch r {
 		case '\t':
 			ts := tabsize - (totalwidth % tabsize)
-			width = util.Min(ts, w.bufWidth-visualx)
+			width = util.Min(ts, w.bufWidth-vloc.VisualX)
 			totalwidth += ts
 		default:
 			width = runewidth.RuneWidth(r)
@@ -68,28 +77,81 @@ func (w *BufWindow) getRow(loc buffer.Loc) int {
 		}
 
 		// If a wide rune does not fit in the window
-		if visualx+width > w.bufWidth && visualx > 0 {
-			row++
-			visualx = 0
+		if vloc.VisualX+width > w.bufWidth && vloc.VisualX > 0 {
+			vloc.Row++
+			vloc.VisualX = 0
 		}
 
 		if x == loc.X {
-			return row
+			return vloc
 		}
 		x++
 		line = line[size:]
 
-		visualx += width
-		if visualx >= w.bufWidth {
-			row++
-			visualx = 0
+		vloc.VisualX += width
+		if vloc.VisualX >= w.bufWidth {
+			vloc.Row++
+			vloc.VisualX = 0
 		}
 	}
-	return row
+	return vloc
+}
+
+func (w *BufWindow) getLocFromVLoc(svloc VLoc) buffer.Loc {
+	loc := buffer.Loc{X: 0, Y: svloc.Line}
+
+	if w.bufWidth <= 0 {
+		return loc
+	}
+
+	tabsize := util.IntOpt(w.Buf.Settings["tabsize"])
+
+	line := w.Buf.LineBytes(svloc.Line)
+	vloc := VLoc{SLoc: SLoc{svloc.Line, 0}, VisualX: 0}
+
+	totalwidth := 0
+
+	for len(line) > 0 {
+		r, _, size := util.DecodeCharacter(line)
+
+		width := 0
+		switch r {
+		case '\t':
+			ts := tabsize - (totalwidth % tabsize)
+			width = util.Min(ts, w.bufWidth-vloc.VisualX)
+			totalwidth += ts
+		default:
+			width = runewidth.RuneWidth(r)
+			totalwidth += width
+		}
+
+		// If a wide rune does not fit in the window
+		if vloc.VisualX+width > w.bufWidth && vloc.VisualX > 0 {
+			if vloc.Row == svloc.Row {
+				return loc
+			}
+			vloc.Row++
+			vloc.VisualX = 0
+		}
+
+		vloc.VisualX += width
+		if vloc.Row == svloc.Row && vloc.VisualX > svloc.VisualX {
+			return loc
+		}
+		loc.X++
+		line = line[size:]
+
+		if vloc.VisualX >= w.bufWidth {
+			vloc.Row++
+			vloc.VisualX = 0
+		}
+	}
+	return loc
 }
 
 func (w *BufWindow) getRowCount(line int) int {
-	return w.getRow(buffer.Loc{X: util.CharacterCount(w.Buf.LineBytes(line)), Y: line}) + 1
+	eol := buffer.Loc{X: util.CharacterCount(w.Buf.LineBytes(line)), Y: line}
+	return w.getVLocFromLoc(eol).Row + 1
 }
 
 func (w *BufWindow) scrollUp(s SLoc, n int) SLoc {
@@ -184,5 +246,29 @@ func (w *BufWindow) SLocFromLoc(loc buffer.Loc) SLoc {
 	if !w.Buf.Settings["softwrap"].(bool) {
 		return SLoc{loc.Y, 0}
 	}
-	return SLoc{loc.Y, w.getRow(loc)}
+	return w.getVLocFromLoc(loc).SLoc
+}
+
+// VLocFromLoc takes a position in the buffer and returns the corresponding
+// visual location in the linewrapped buffer.
+func (w *BufWindow) VLocFromLoc(loc buffer.Loc) VLoc {
+	if !w.Buf.Settings["softwrap"].(bool) {
+		tabsize := util.IntOpt(w.Buf.Settings["tabsize"])
+
+		visualx := util.StringWidth(w.Buf.LineBytes(loc.Y), loc.X, tabsize)
+		return VLoc{SLoc{loc.Y, 0}, visualx}
+	}
+	return w.getVLocFromLoc(loc)
+}
+
+// LocFromVLoc takes a visual location in the linewrapped buffer and returns
+// the position in the buffer corresponding to this visual location.
+func (w *BufWindow) LocFromVLoc(vloc VLoc) buffer.Loc {
+	if !w.Buf.Settings["softwrap"].(bool) {
+		tabsize := util.IntOpt(w.Buf.Settings["tabsize"])
+
+		x := util.GetCharPosInLine(w.Buf.LineBytes(vloc.Line), vloc.VisualX, tabsize)
+		return buffer.Loc{x, vloc.Line}
+	}
+	return w.getLocFromVLoc(vloc)
 }

--- a/internal/display/window.go
+++ b/internal/display/window.go
@@ -33,6 +33,5 @@ type BWindow interface {
 	Window
 	SoftWrap
 	SetBuffer(b *buffer.Buffer)
-	BufWidth() int
-	BufHeight() int
+	BufView() View
 }

--- a/internal/display/window.go
+++ b/internal/display/window.go
@@ -33,4 +33,6 @@ type BWindow interface {
 	Window
 	SoftWrap
 	SetBuffer(b *buffer.Buffer)
+	BufWidth() int
+	BufHeight() int
 }

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -365,6 +365,11 @@ Here are the available options:
 
 	default value: `true`
 
+* `wordwrap`: wrap long lines by words, i.e. break at spaces. This option
+   only does anything if `softwrap` is on.
+
+	default value: `false`
+
 * `xterm`: micro will assume that the terminal it is running in conforms to
   `xterm-256color` regardless of what the `$TERM` variable actually contains.
    Enabling this option may cause unwanted effects if your terminal in fact


### PR DESCRIPTION
A number of improvements for softwrap and more:

- Implemented moving cursor up/down within a wrapped line (#1598)
- Implemented word wrapping (#264, #1644) - added `wordwrap` option, disabled by default
- Fixed horizontal scrolling issue after toggling softwrap on/off (#645)
- Fixed displaying tabs and wide runes which don't fit in the window (#1979)
- Fixed usage of a slightly incorrect buffer height value (wrt statusline) in scrolling actions
- Added `VLoc` abstraction for representing an arbitrary location in the buffer as a visual location in the linewrapped buffer

These changes depend on each other, so I've put them in a single PR.

Fixes #1598
Fixes #264
Fixes #1644
Fixes #645 
Fixes #1979 