### PR TITLE
Add highlighting for user-defined types 

### DIFF
--- a/runtime/syntax/c.yaml
+++ b/runtime/syntax/c.yaml
@@ -7,6 +7,7 @@ rules:
     - identifier: "\\b[A-Z_][0-9A-Z_]+\\b"
     - type: "\\b(auto|float|double|char|int|short|long|sizeof|enum|void|static|const|struct|union|typedef|extern|(un)?signed|inline)\\b"
     - type: "\\b((s?size)|((u_?)?int(8|16|32|64|ptr)))_t\\b"
+    - type: "\\b[a-z_][0-9a-z_]+(_t|_T)\\b"
     - type.extended: "\\b(bool)\\b"
     - statement: "\\b(volatile|register)\\b"
     - statement: "\\b(for|if|while|do|else|case|default|switch)\\b"

--- a/runtime/syntax/cpp.yaml
+++ b/runtime/syntax/cpp.yaml
@@ -7,6 +7,7 @@ rules:
     - identifier: "\\b[A-Z_][0-9A-Z_]*\\b"
     - type: "\\b(float|double|bool|char|int|short|long|enum|void|struct|union|typedef|(un)?signed|inline)\\b"
     - type: "\\b(((s?size)|((u_?)?int(8|16|32|64|ptr))|char(8|16|32))_t|wchar_t)\\b"
+    - type: "\\b[a-z_][0-9a-z_]+(_t|_T)\\b"
     - type: "\\b(final|override)\\b"
     - type.keyword: "\\b(auto|volatile|const(expr|eval|init)?|mutable|register|thread_local|static|extern|decltype|explicit|virtual)\\b"
     - statement: "\\b(class|namespace|template|typename|this|friend|using|public|protected|private|noexcept)\\b"


### PR DESCRIPTION
The following modifications provides automatic C/C++ syntax highlighting of user-defined types [ending with either "_t" or "_T"](https://stackoverflow.com/questions/231760/what-does-a-type-followed-by-t-underscore-t-represent), as is seen in editors/viewers such as Nano, Stack Overflow, or within GitHub itself.