### PR TITLE
Add desktop-id to Appstream Metainfo

### DIFF
--- a/data/com.github.zyedidia.micro.metainfo.xml
+++ b/data/com.github.zyedidia.micro.metainfo.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component>
 	<id>com.github.zyedidia.micro</id>
+	<launchable type="desktop-id">micro.desktop</launchable>
 	<name>Micro Text Editor</name>
 	<summary>A modern and intuitive terminal-based text editor</summary>
 	<metadata_license>MIT</metadata_license>


### PR DESCRIPTION
It's needed for tools like appstream-generator to detect the associated desktop file.

See also: https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Application.html#tag-dapp-launchable