### PR TITLE
find: select prefilled text

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -932,6 +932,9 @@ func (h *BufPane) find(useRegex bool) bool {
 		eventCallback(pattern)
 	}
 	InfoBar.Prompt(prompt, pattern, "Find", eventCallback, findCallback)
+	if pattern != "" {
+		InfoBar.SelectAll()
+	}
 	return true
 }
 


### PR DESCRIPTION
The new feature of prefilling the search bar with the selected text (added in #2115) has an annoying side effect: if we do have some text selected but we want to search for some other pattern, not the selected text,
then we have to manually delete the prefilled text before we can start entering our wanted search pattern.

A simple solution is to select the prefilled text, so that we can replace it with our pattern right away just by typing, without any additional keystrokes.