### PR TITLE
Fix typo in tutorial.md

### DIFF
--- a/runtime/help/tutorial.md
+++ b/runtime/help/tutorial.md
@@ -53,7 +53,7 @@ following in `bindings.json`:
 
 ```json
 {
-    "Ctrl-r": "redo"
+    "Ctrl-r": "Redo"
 }
 ```
 


### PR DESCRIPTION
Fixed the typo in the keybinding section.
The below JSON file is incorrect:
```
{
    "Ctrl-r": "redo"
}
```
and it should be 
```
{
    "Ctrl-r": "Redo"
}
```
Also, really love Micro! Thanks so much for making it :)