### PR TITLE
display: make Key Menu reflect real bindings

### DIFF
--- a/internal/display/infowindow.go
+++ b/internal/display/infowindow.go
@@ -1,6 +1,8 @@
 package display
 
 import (
+	"fmt"
+
 	runewidth "github.com/mattn/go-runewidth"
 	"github.com/zyedidia/micro/v2/internal/buffer"
 	"github.com/zyedidia/micro/v2/internal/config"
@@ -178,10 +180,30 @@ func (i *InfoWindow) displayBuffer() {
 	}
 }
 
-var keydisplay = []string{"^Q Quit, ^S Save, ^O Open, ^G Help, ^E Command Bar, ^K Cut Line", "^F Find, ^Z Undo, ^Y Redo, ^A Select All, ^D Duplicate Line, ^T New Tab"}
+func keydisplayGen() []string {
+	return []string{
+		fmt.Sprintf("%s %s, %s %s, %s %s, %s %s, %s %s, %s %s",
+			findBinding("Quit", true), "Quit",
+			findBinding("Save", true), "Save",
+			findBinding("OpenFile", true), "Open",
+			findBinding("ToggleHelp", true), "Help",
+			findBinding("CommandMode", true), "Command Bar",
+			findBinding("CutLine", true), "Cut Line",
+		),
+		fmt.Sprintf("%s %s, %s %s, %s %s, %s %s, %s %s, %s %s",
+			findBinding("Find", true), "Find",
+			findBinding("Undo", true), "Undo",
+			findBinding("Redo", true), "Redo",
+			findBinding("SelectAll", true), "Select All",
+			findBinding("DuplicateLine", true), "Duplicate Line",
+			findBinding("AddTab", true), "New Tab",
+		),
+	}
+}
 
 func (i *InfoWindow) displayKeyMenu() {
 	// TODO: maybe make this based on the actual keybindings
+	keydisplay := keydisplayGen()
 
 	for y := 0; y < len(keydisplay); y++ {
 		for x := 0; x < i.Width; x++ {

--- a/internal/display/statusline.go
+++ b/internal/display/statusline.go
@@ -141,12 +141,7 @@ func (s *StatusLine) Display() {
 			return []byte(fmt.Sprint(s.FindOpt(string(option))))
 		} else if bytes.HasPrefix(name, []byte("bind")) {
 			binding := string(name[5:])
-			for k, v := range config.Bindings["buffer"] {
-				if v == binding {
-					return []byte(k)
-				}
-			}
-			return []byte("null")
+			return []byte(findBinding(binding, false))
 		} else {
 			if fn, ok := statusInfo[string(name)]; ok {
 				return []byte(fn(s.win.Buf))

--- a/internal/display/util.go
+++ b/internal/display/util.go
@@ -1,0 +1,51 @@
+package display
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/zyedidia/micro/v2/internal/config"
+)
+
+// try to make a keybinding more "friendly"
+// specifically:
+// all letters are capitalized
+// Ctrl- becomes ^
+// Alt- becomes !
+func friendlyBinding(k string) string {
+	k = strings.ToUpper(k)
+	k = strings.Replace(k, "CTRL-", "^", -1)
+	k = strings.Replace(k, "ALT-", "!", -1)
+	return k
+}
+
+// find a buffer binding by key
+// has stable results
+// "friendli-fies" the result if set to do so
+// returns "??" if none found
+func findBinding(action string, friendly bool) string {
+	cat := "buffer"
+	// sort the keys
+	// if you don't sort the keys, the order of iterating a map is not guaranteed
+	// this means that with >1 binding for a given command
+	// which one you get is random
+	keys := make([]string, len(config.Bindings[cat]))
+	i := 0
+	for k, _ := range config.Bindings[cat] {
+		keys[i] = k
+		i++
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		if config.Bindings[cat][k] == action {
+			if friendly {
+				return friendlyBinding(k)
+			} else {
+				return k
+			}
+		}
+	}
+	return "??"
+
+}


### PR DESCRIPTION
This changes the keybinding menu (alt-g) to reflect real keybindings.
Potentially contentious things:
* internal/display/util.go instead of maybe somewhere in config
* exact details of the "friendly" function
* exact API

This also patches the `$(bind:)` special of the status line.
Why does it need patching?

In go, when you iterate a map, the order is non-deterministic.
With the current handling of `$(bind:)`, if you have >1 binding for the action, which one you get is essentially random.
The way you solve this is to ensure a deterministic order by sorting the set of keys.

This needs to happen every invocation, in case the user changes a binding.
An alternative method would be to keep a cache that is updated whenever bindings are written to.

Lack of this specific feature is a commonly cited reason (to me, personally) of micro not being adopted (thus why it doesn't show up in the issues - it's non-users as of right now), so I figured I would at least offer a way to fix it.
There's already a TODO for it (I didn't remove it in this patch, see next paragraph), so it seems like something that's desirable.

I don't really have the time or energy to modify this patch to suit the exact needs/requirements for merging.
However, it can/should be reasonably trivial to move it anywhere / change some of these minor specifics.
Another thing that could be brushed up (perhaps later?) is the exact way `keydisplayGen` performs the generation.
Either way - please consider this code to be CC0/Unlicense/BSD0/Blue-Oak-Model 1.0.
I'd rather see it (as in the feature/behaviour on the overall) get merged, ideally with as little involvement from my end from this point on :)