### PR TITLE
Add alcritty and foot to the list of OSC 52 supporting terminals

### DIFF
--- a/runtime/help/copypaste.md
+++ b/runtime/help/copypaste.md
@@ -31,6 +31,10 @@ Here is a list of terminal emulators and their status:
 
 * `gnome-terminal`: does not support OSC 52.
 
+* `alacritty`: supported.
+
+* `foot`: supported.
+
 **Summary:** If you want copy and paste to work over SSH, then you
 should set `clipboard` to `terminal`, and make sure your terminal
 supports OSC 52.


### PR DESCRIPTION
Alacritty: https://github.com/alacritty/alacritty/blob/master/docs/escape_support.md#osc-operating-system-command---esc-
Foot: https://codeberg.org/dnkl/foot#supported-oscs