### PR TITLE
Update rust syntax: char literal

### DIFF
--- a/runtime/syntax/rust.yaml
+++ b/runtime/syntax/rust.yaml
@@ -24,14 +24,22 @@ rules:
     - constant.string:
         start: "\""
         end: "\""
-        skip: "\\\\."
+        skip: '\\.'
         rules:
-            - constant.specialChar: "\\\\."
+            - constant.specialChar: '\\.'
 
     - constant.string:
         start: "r#+\""
         end: "\"#+"
         rules: []
+
+    # Character literals
+    - constant.string:
+        start: "'"
+        end: "'"
+        skip: '\\.'
+        rules:
+            - constant.specialChar: '\\.'
 
     - comment:
         start: "//"
@@ -49,4 +57,3 @@ rules:
         start: "#!\\["
         end: "\\]"
         rules: []
-


### PR DESCRIPTION
Highlight character literals started with a single quote (').
Importantly this ensures correct highlighting for the character literal '"'.
Limitation: rust char literals contain exactly one character, however this isn't checked by the highlighter.

Closes #2160

cc @SwitchAxe: I have seen this bad highlighting a few times before. It's super annoying because the whole rest of the file is highlighted as a string.