### PR TITLE
plugins.md: update link to the internal documentation

### DIFF
--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -293,10 +293,10 @@ returned by the functions have many methods. The Lua plugin may access any
 public methods of an object returned by any of the functions above.
 Unfortunately it is not possible to list all the available functions on this
 page. Please go to the internal documentation at
-https://godoc.org/github.com/zyedidia/micro to see the full list of available
-methods. Note that only methods of types that are available to plugins via
-the functions above can be called from a plugin.  For an even more detailed
-reference see the source code on Github.
+https://pkg.go.dev/github.com/zyedidia/micro/v2/internal to see the full list
+of available methods. Note that only methods of types that are available to
+plugins via the functions above can be called from a plugin. For an even more
+detailed reference see the source code on Github.
 
 For example, with a BufPane object called `bp`, you could call the `Save`
 function in Lua with `bp:Save()`.


### PR DESCRIPTION
godoc.org now redirects to pkg.go.dev and it's not obvious how to locate the internal packages documentation at https://pkg.go.dev/github.com/zyedidia/micro.

See comments in #2071 and #2189