### PR TITLE
PHP: Add enum and keyword, and modify types

### DIFF
--- a/runtime/syntax/php.yaml
+++ b/runtime/syntax/php.yaml
@@ -17,7 +17,7 @@ rules:
     - comment: "<!--.+?-->"
     - default: "<\\?(php|=)\" end=\"\\?>"
     - identifier.class: "([a-zA-Z0-9_-]+)\\("
-    - type: "\\b(array|bool(ean)?|callable|callback|float|int(eger)?|iterable|object|resource|mixed|string|void)\\b"
+    - type: "\\b(array|bool|callable|float|int|iterable|object|mixed|string|void)\\b"
     - identifier.class: "[a-zA-Z\\\\]+::"
     - identifier: "\\b([A-Z][a-zA-Z0-9_]+)\\b"
     - identifier: "([A-Z0-9_]+)[;|\\s|\\)|,]"

--- a/runtime/syntax/php.yaml
+++ b/runtime/syntax/php.yaml
@@ -24,7 +24,7 @@ rules:
     - type.keyword: "\\b(global|final|public|private|protected|static|const|var)\\b"
     - statement: "\\b(abstract|catch|class|declare|do|else(if)?|end(declare|for(each)?|if|switch|while)|enum|finally|for(each)|function|if|interface|namespace|switch|trait|try|while)\\b"
     - identifier: "\\bnew\\s+([a-zA-Z0-9\\\\]+)"
-    - special: "\\b(as|and|break|case|clone|continue|default|die|fn|echo|empty|eval|exit|extends|goto|or|include(_once)?|implements|instanceof|insteadof|isset|list|new|print|return|require(_once)?|unset|use|throw|xor|yield(\\s+from))\\b"
+    - special: "\\b(as|and|break|case|clone|continue|default|die|fn|echo|empty|eval|exit|extends|goto|or|include(_once)?|implements|instanceof|insteadof|isset|list|match|new|print|return|require(_once)?|unset|use|throw|xor|yield(\\s+from))\\b"
     - constant.bool: "\\b(true|false|null|TRUE|FALSE|NULL)\\b"
     - constant: "[\\s|=|\\s|\\(|/|+|-|\\*|\\[]"
     - constant.number: "[0-9]"

--- a/runtime/syntax/php.yaml
+++ b/runtime/syntax/php.yaml
@@ -22,7 +22,7 @@ rules:
     - identifier: "\\b([A-Z][a-zA-Z0-9_]+)\\b"
     - identifier: "([A-Z0-9_]+)[;|\\s|\\)|,]"
     - type.keyword: "\\b(global|final|public|private|protected|static|const|var)\\b"
-    - statement: "\\b(abstract|catch|class|declare|do|else(if)?|end(declare|for(each)?|if|switch|while)|finally|for(each)|function|if|interface|namespace|switch|trait|try|while)\\b"
+    - statement: "\\b(abstract|catch|class|declare|do|else(if)?|end(declare|for(each)?|if|switch|while)|enum|finally|for(each)|function|if|interface|namespace|switch|trait|try|while)\\b"
     - identifier: "\\bnew\\s+([a-zA-Z0-9\\\\]+)"
     - special: "\\b(as|and|break|case|clone|continue|default|die|fn|echo|empty|eval|exit|extends|goto|or|include(_once)?|implements|instanceof|insteadof|isset|list|new|print|return|require(_once)?|unset|use|throw|xor|yield(\\s+from))\\b"
     - constant.bool: "\\b(true|false|null|TRUE|FALSE|NULL)\\b"


### PR DESCRIPTION
`enum` keyword added in PHP 8.1.  See [PHP: Basic enumerations - Manual](https://www.php.net/manual/language.enumerations.basics.php).
`match` keyword added in PHP 8.2.  See [PHP: match - Manual](https://www.php.net/match).

The decremented keywords (`boolean` and `integer`) are aliases for the type name and are not valid as keywords for type declaration.

```php
<?php

function f1(): int {} // Valid type declaration as primitive type name
function f2(): integer {} // Valid type declaration, but that means "integer" class name
function f3(): resource {} // Valid type declaration, but that means "resource" class name
```

https://www.php.net/manual/reserved.other-reserved-words.php