### PR TITLE
Fix #2190: Document goto command in commands.md

### DIFF
--- a/runtime/help/commands.md
+++ b/runtime/help/commands.md
@@ -29,6 +29,10 @@ quotes here but these are not necessary when entering the command in micro.
 
 * `quit`: quits micro.
 
+* `goto 'line'`: jumps to the given line number. A negative number can be
+   passed to jump inward from the end of the file; for example, -5 jumps
+   to the 5th-last line in the file.
+
 * `replace 'search' 'value' 'flags'?`: This will replace `search` with `value`. 
    The `flags` are optional. Possible flags are:
    * `-a`: Replace all occurrences at once


### PR DESCRIPTION
It seems to already be documented in defaultkeys, on line 36:
```
| Ctrl-l                      | Jump to a line in the file (prompts with #)                                               |
```