### PR TITLE
Syntax Highlighting Support for FreeBSD Kernel Configuration Files

### DIFF
--- a/runtime/syntax/freebsd-kernel.yaml
+++ b/runtime/syntax/freebsd-kernel.yaml
@@ -4,10 +4,8 @@ detect:
     filename: "GENERIC$"
 
 rules:
-    - identifier: "^(cpu|ident|options|makeoptions|device)"
-    - special: ""
+    - identifier: "^(cpu|ident|options|makeoptions|device|include)"
     - statement: "\\s\\S*"
-    - preproc: "^(include)"
 
     - comment:
         start: "#"

--- a/runtime/syntax/freebsd-kernel.yaml
+++ b/runtime/syntax/freebsd-kernel.yaml
@@ -1,0 +1,16 @@
+filetype: freebsd-kernel
+
+detect:
+    filename: "GENERIC$"
+
+rules:
+    - identifier: "^(cpu|ident|options|makeoptions|device)"
+    - special: ""
+    - statement: "\\s\\S*"
+    - preproc: "^(include)"
+
+    - comment:
+        start: "#"
+        end: "$"
+        rules:
+            - todo: "(TODO|XXX|FIXME):?"


### PR DESCRIPTION
This simple patch adds a syntax highlighting file for FreeBSD kernel configuration files. This is a feature I have found myself wanting as I use FreeBSD as my daily driver, and have been compiling kernels from there.