### PR TITLE
Fix some issues with default colors in colorschemes

### DIFF
--- a/internal/config/colorscheme.go
+++ b/internal/config/colorscheme.go
@@ -129,12 +129,12 @@ func StringToStyle(str string) tcell.Style {
 	bg = strings.TrimSpace(bg)
 
 	var fgColor, bgColor tcell.Color
-	if fg == "" {
+	if fg == "" || fg == "default" {
 		fgColor, _, _ = DefStyle.Decompose()
 	} else {
 		fgColor = StringToColor(fg)
 	}
-	if bg == "" {
+	if bg == "" || bg == "default" {
 		_, bgColor, _ = DefStyle.Decompose()
 	} else {
 		bgColor = StringToColor(bg)

--- a/internal/config/colorscheme.go
+++ b/internal/config/colorscheme.go
@@ -35,8 +35,6 @@ func GetColor(color string) tcell.Style {
 		}
 	} else if style, ok := Colorscheme[color]; ok {
 		st = style
-	} else {
-		st = StringToStyle(color)
 	}
 
 	return st


### PR DESCRIPTION
Fix some issues caused by the fact that when a syntax group color is set to "default" or not set at all, it defaults not to the colorscheme's default colors but to the terminal's default colors.

For example, if we are using micro's `default` colorscheme in a terminal which uses a black-on-white theme, then:
- dots and commas in Go files (`symbol` syntax group in go.yaml) are displayed black on a dark background, i.e. barely visible
- "bool" type in C files (`type.extended` syntax group in c.yaml) is displayed black on a dark background, i.e. barely visible