### PR TITLE
Fix Minor Error

### DIFF
--- a/runtime/help/keybindings.md
+++ b/runtime/help/keybindings.md
@@ -30,8 +30,8 @@ following in the `bindings.json` file.
 
 ```json
 {
-	"Ctrl-y": "Undo",
-	"Ctrl-z": "Redo"
+	"Ctrl-z": "Undo",
+	"Ctrl-y": "Redo"
 }
 ```
 


### PR DESCRIPTION
The Keybindings given for `Ctrl-Z` and `Ctrl-Y` were flipped.