### PR TITLE
Fix edge case when comment is at start of line

### DIFF
--- a/runtime/syntax/nim.yaml
+++ b/runtime/syntax/nim.yaml
@@ -18,7 +18,7 @@ rules:
     - constant.number: "\\b0[bB][01][01_]+\\b"
     - constant.number: "\\b[0-9_]((\\.?)[0-9_]+)?[eE][+\\-][0-9][0-9_]+\\b"
     - constant.string: "\"(\\\\.|[^\"])*\"|'(\\\\.|[^'])*'"
-    - comment: "[[:space:]]*[^\\\\]#.*$"
+    - comment: "[[:space:]]*(?:[^\\\\]|^)#.*$"
     - comment:
         start: "\\#\\["
         end: "\\]\\#"


### PR DESCRIPTION
Currently the syntax highlighting for comments is broken when comment is at the start of the line.
before PR
![image](https://user-images.githubusercontent.com/19339842/136149820-0cdfd7b2-74c3-4778-9f23-c223321ab2e0.png)
after PR

![image](https://user-images.githubusercontent.com/19339842/136149923-19a944c3-2c5a-45a2-8b41-ba252d8e7dcd.png)
