### PR TITLE
Add new python 3.10 keywords

### DIFF
--- a/runtime/syntax/python3.yaml
+++ b/runtime/syntax/python3.yaml
@@ -18,7 +18,7 @@ rules:
       # definitions
     - identifier: "def [a-zA-Z_0-9]+"
       # keywords
-    - statement: "\\b(and|as|assert|async|await|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|nonlocal|not|or|pass|raise|return|try|while|with|yield)\\b"
+    - statement: "\\b(and|as|assert|async|await|break|case|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|match|nonlocal|not|or|pass|raise|return|try|while|with|yield)\\b"
       # decorators
     - brightgreen: "@.*[(]"
       # operators


### PR DESCRIPTION
Keywords from the new python 3.10.0 feature **Structural Pattern Matching (PEP 634)** - `match` and `case`