### PR TITLE
Clarified some documentation

### DIFF
--- a/runtime/help/commands.md
+++ b/runtime/help/commands.md
@@ -22,7 +22,9 @@ quotes here but these are not necessary when entering the command in micro.
    `key` that already exist.
 
 * `help 'topic'?`: opens the corresponding help topic. If no topic is provided
-   opens the default help screen.
+   opens the default help screen. Help topics are stored as `.md` files in the
+   `runtime/help` directory of the source tree, which is embedded in the final
+   binary.
 
 * `save 'filename'?`: saves the current buffer. If the file is provided it
    will 'save as' the filename.

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -267,7 +267,7 @@ Here are the available options:
     default value: `false`
 
 * `rmtrailingws`: micro will automatically trim trailing whitespaces at ends of
-   lines.
+   lines. Note: This setting overrides `keepautoindent`
 
 	default value: `false`
 

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -176,7 +176,12 @@ Here are the available options:
 
 	default value: `true`
 
-* `indentchar`: sets the indentation character.
+* `indentchar`: sets the indentation character. This will not be inserted into
+  files; it is only a visual indicator that whitespace is present. If set to a
+  printing character, it functions as a subset of the "show invisibles"
+  setting available in many other text editors. The color of this character is
+  determined by the `indent-char` field in the current theme rather than the
+  default text color.
 
 	default value: ` ` (space)
 


### PR DESCRIPTION
I added details to the entries for the `indentchar` and `rmtrainingws` settings and the `help` command.

I had to figure out exactly how some of these settings worked myself, so I thought it might be nice to put in the documentation to save others the trouble.