### PR TITLE
Python syntax: multiline string should be constant.string, not comment

### DIFF
--- a/runtime/syntax/python2.yaml
+++ b/runtime/syntax/python2.yaml
@@ -34,7 +34,7 @@ rules:
         end: "\"\"\""
         rules: []
 
-    - comment:
+    - constant.string:
         start: "'''"
         end: "'''"
         rules: []

--- a/runtime/syntax/python3.yaml
+++ b/runtime/syntax/python3.yaml
@@ -18,7 +18,7 @@ rules:
       # definitions
     - identifier: "def [a-zA-Z_0-9]+"
       # keywords
-    - statement: "\\b(and|as|assert|async|await|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|nonlocal|not|or|pass|raise|return|try|while|with|yield)\\b"
+    - statement: "\\b(and|as|assert|async|await|break|case|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|match|nonlocal|not|or|pass|raise|return|try|while|with|yield)\\b"
       # decorators
     - brightgreen: "@.*[(]"
       # operators

--- a/runtime/syntax/python3.yaml
+++ b/runtime/syntax/python3.yaml
@@ -36,7 +36,7 @@ rules:
         end: "\"\"\""
         rules: []
 
-    - comment:
+    - constant.string:
         start: "'''"
         end: "'''"
         rules: []


### PR DESCRIPTION
`'''` delimits multiline strings, not comments