### PR TITLE
Fix linter help formatting

### DIFF
--- a/runtime/plugins/linter/help/linter.md
+++ b/runtime/plugins/linter/help/linter.md
@@ -5,24 +5,24 @@ and parses the resulting output so that the messages and line numbers
 can be viewed from within micro. By default, the plugin supports the
 following filetypes and linters:
 
-* c: gcc
-* c++: g++
-* d: dmd
-* go: go build
-* haskell: hlint
-* java: javac
-* javascript: jshint
-* javascript: eslint
-* literate: lit
-* lua: luacheck
-* nim: nim
-* objective-c: clang
-* python: pyflakes
-* python: mypy
-* python: pylint
-* shell: shfmt
-* swift: swiftc (MacOS and Linux only)
-* yaml: yamllint
+* **c**: gcc
+* **c++**: g++
+* **d**: dmd
+* **go**: go build
+* **haskell**: hlint
+* **java**: javac
+* **javascript**: jshint
+* **javascript**: eslint
+* **literate**: lit
+* **lua**: luacheck
+* **nim**: nim
+* **objective-c**: clang
+* **python**: pyflakes
+* **python**: mypy
+* **python**: pylint
+* **shell**: shfmt
+* **swift**: swiftc (MacOS and Linux only)
+* **yaml**: yamllint
 
 If the linter plugin is enabled and the file corresponds to one of
 these filetypes, each time the buffer is saved, or when the `> lint`
@@ -34,31 +34,31 @@ From inside another micro plugin, the function `linter.makeLinter` can
 be called to register a new filetype. Here is the spec for the `makeLinter`
 function:
 
-* `linter.makeLinter(name, filetype, cmd, args, errorformat, os, whitelist, domatch, loffset, coffset, callback)`
+`linter.makeLinter(name, filetype, cmd, args, errorformat, os, whitelist, domatch, loffset, coffset, callback)`
 
-> name: name of the linter
-> filetype: filetype to check for to use linter
-> cmd: main linter process that is executed
-> args: arguments to pass to the linter process
-    use %f to refer to the current file name
-    use %d to refer to the current directory name
-> errorformat: how to parse the linter/compiler process output
+* **name**: name of the linter
+* **filetype**: filetype to check for to use linter
+* **cmd**: main linter process that is executed
+* **args**: arguments to pass to the linter process
+    * use %f to refer to the current file name
+    * use %d to refer to the current directory name
+* **errorformat**: how to parse the linter/compiler process output
     %f: file, %l: line number, %m: error/warning message
-> os: list of OSs this linter is supported or unsupported on
+* **os**: list of OSs this linter is supported or unsupported on
     optional param, default: {}
-> whitelist: should the OS list be a blacklist (do not run the linter for these OSs)
+* **whitelist**: should the OS list be a blacklist (do not run the linter for these OSs)
            or a whitelist (only run the linter for these OSs)
     optional param, default: false (should blacklist)
-> domatch: should the filetype be interpreted as a lua pattern to match with
+* **domatch**: should the filetype be interpreted as a lua pattern to match with
          the actual filetype, or should the linter only activate on an exact match
     optional param, default: false (require exact match)
-> loffset: line offset will be added to the line number returned by the linter
+* **loffset**: line offset will be added to the line number returned by the linter
          useful if the linter returns 0-indexed lines
     optional param, default: 0
-> coffset: column offset will be added to the col number returned by the linter
+* **coffset**: column offset will be added to the col number returned by the linter
          useful if the linter returns 0-indexed columns
     optional param, default: 0
-> callback: function to call before executing the linter, if it returns
+* **callback**: function to call before executing the linter, if it returns
           false the lint is canceled. The callback is passed the buf.
     optional param, default: nil
 


### PR DESCRIPTION
While working on including a linter for Terraform files I noticed that the help was poorly formatted. These changes should make it a little more readable.

This is how it looked before the changes:
![image](https://user-images.githubusercontent.com/39650930/142209425-1b46dc67-f2a8-4bb0-8036-f59b96eec0d2.png)
 