### PR TITLE
Fix the syntax for Raku variables.

### DIFF
--- a/runtime/syntax/raku.yaml
+++ b/runtime/syntax/raku.yaml
@@ -1,16 +1,16 @@
 filetype: raku
 
-detect: 
+detect:
     filename: "(\\.p6$|\\.pl6$|\\.pm6$|\\.raku$|\\.rakumod$|\\.rakudoc$)"
 
 rules:
     - type: "\\b(accept|alarm|atan2|bin(d|mode)|c(aller|h(dir|mod|op|own|root)|lose(dir)?|onnect|os|rypt)|d(bm(close|open)|efined|elete|ie|o|ump)|e(ach|of|val|x(ec|ists|it|p))|f(cntl|ileno|lock|ork)|get(c|login|peername|pgrp|ppid|priority|pwnam|(host|net|proto|serv)byname|pwuid|grgid|(host|net)byaddr|protobynumber|servbyport)|([gs]et|end)(pw|gr|host|net|proto|serv)ent|getsock(name|opt)|gmtime|goto|grep|hex|index|int|ioctl|join|keys|kill|last|length|link|listen|local(time)?|log|lstat|m|mkdir|msg(ctl|get|snd|rcv)|next|oct|open(dir)?|ord|pack|pipe|pop|printf?|push|q|qq|qx|rand|re(ad(dir|link)?|cv|do|name|quire|set|turn|verse|winddir)|rindex|rmdir|s|scalar|seek|seekdir|se(lect|mctl|mget|mop|nd|tpgrp|tpriority|tsockopt)|shift|shm(ctl|get|read|write)|shutdown|sin|sleep|socket(pair)?|sort|spli(ce|t)|sprintf|sqrt|srand|stat|study|substr|symlink|sys(call|read|tem|write)|tell(dir)?|time|tr|y|truncate|umask|un(def|link|pack|shift)|utime|values|vec|wait(pid)?|wantarray|warn|write)\\b"
     - statement: "\\b(continue|else|elsif|do|for|foreach|if|unless|until|while|eq|ne|lt|gt|le|ge|cmp|x|my|sub|use|package|can|isa)\\b"
     - special: "\\b(has|is|class|role|given|when|BUILD|multi|returns|method|submethod|slurp|say|sub)\\b"
-    - identifier:
-        start: "[$@%]"
-        end: "( |\\\\W|-)"
-        rules: []
+
+    - identifier: "[$@%&](\\.|!|\\^)?([[:alpha:]]|_)"
+    - identifier: "[$@%&](\\.|!|^)?([[:alpha:]]|_)([[:alnum:]]|-|_)*([[:alnum:]]|_)"
+    - identifier: "[$@%&](\\?|\\*)([A-Z])([A-Z]|-)*([A-Z])"
 
     - constant.string: "\".*\"|qq\\|.*\\|"
     - default: "[sm]/.*/"


### PR DESCRIPTION
The current version has problems with the last argument and the brackets in this code:

```raku
sub myfunction(Int $x1, Int $x2){

}
```

Taken from:
https://github.com/hankache/raku.nanorc/blob/master/raku.nanorc