### PR TITLE
Raku syntax: Fix strings and comments

### DIFF
--- a/runtime/syntax/raku.yaml
+++ b/runtime/syntax/raku.yaml
@@ -12,14 +12,18 @@ rules:
     - identifier: "[$@%&](\\.|!|^)?([[:alpha:]]|_)([[:alnum:]]|-|_)*([[:alnum:]]|_)"
     - identifier: "[$@%&](\\?|\\*)([A-Z])([A-Z]|-)*([A-Z])"
 
-    - constant.string: "\".*\"|qq\\|.*\\|"
-    - default: "[sm]/.*/"
+    - comment: "#\ [^`|=]*"
+    - comment: "#[:alnum:].*"
+    - comment: "^#!/.*"
+
+    - constant.string: "\"([^\"]).*\""
+    - constant.string: "'([^']).*'"
+
     - preproc:
         start: "(^use| = new)"
         end: ";"
         rules: []
 
-    - comment: "#.*"
     - identifier.macro:
         start: "<<EOSQL"
         end: "EOSQL"

--- a/runtime/syntax/raku.yaml
+++ b/runtime/syntax/raku.yaml
@@ -16,8 +16,19 @@ rules:
     - comment: "#[:alnum:].*"
     - comment: "^#!/.*"
 
-    - constant.string: "\"([^\"]).*\""
-    - constant.string: "'([^']).*'"
+    - constant.string:
+        start: "\""
+        end: "\""
+        skip: "\\\\."
+        rules:
+            - constant.specialChar: "\\\\."
+
+    - constant.string:
+        start: "'"
+        end: "'"
+        skip: "\\\\."
+        rules:
+            - constant.specialChar: "\\\\."
 
     - preproc:
         start: "(^use| = new)"


### PR DESCRIPTION
Problematic code:
```raku
my @array1 = [
   "'", "a", "b"
];
my @array2 = [
   '"', 'a', 'b'
];
my @array3 = [
   "#", "a", "b"
];
```

I deleted "default" because it was breaking comments with urls after
of my changes.

Some parts were taken from:
https://github.com/hankache/raku.nanorc/blob/master/raku.nanorc