### PR TITLE
Raku syntax: fix comments

### DIFF
--- a/runtime/syntax/raku.yaml
+++ b/runtime/syntax/raku.yaml
@@ -12,10 +12,6 @@ rules:
     - identifier: "[$@%&](\\.|!|^)?([[:alpha:]]|_)([[:alnum:]]|-|_)*([[:alnum:]]|_)"
     - identifier: "[$@%&](\\?|\\*)([A-Z])([A-Z]|-)*([A-Z])"
 
-    - comment: "#\ [^`|=]*"
-    - comment: "#[:alnum:].*"
-    - comment: "^#!/.*"
-
     - constant.string:
         start: "\""
         end: "\""
@@ -40,3 +36,7 @@ rules:
         end: "EOSQL"
         rules: []
 
+    - comment:
+        start: "#"
+        end: "$"
+        rules: []


### PR DESCRIPTION
Code:
```raku
# sub xyz(Str is encoded("utf8")) returns int32 is native("asdf") { * }
```
Sorry, I missed that in the previous PR.