### PR TITLE
Add "filename" to "detect" section.

### DIFF
--- a/runtime/syntax/v.yaml
+++ b/runtime/syntax/v.yaml
@@ -1,6 +1,7 @@
 filetype: v
 
 detect:
+      filename: "\\.v$"
 
 rules:
       # Conditionals and control flow


### PR DESCRIPTION
For some reason Vlang's syntax highlighting didn't have a filename detection.