### PR TITLE
Fix cursor position change after CopyLine command

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1046,12 +1046,14 @@ func (h *BufPane) CopyLine() bool {
 	if h.Cursor.HasSelection() {
 		return false
 	}
+	origLoc := h.Cursor.Loc
 	h.Cursor.SelectLine()
 	h.Cursor.CopySelection(clipboard.ClipboardReg)
 	h.freshClip = true
 	InfoBar.Message("Copied line")
 
 	h.Cursor.Deselect(true)
+	h.Cursor.Loc = origLoc
 	h.Relocate()
 	return true
 }


### PR DESCRIPTION
Hello,

This pull request tries to fix the behavior reported on issue #2304, in case it's not intended.

Cursor's location is stored in a new variable, so it can be restored after line is copied.