### PR TITLE
Update WordRight command to move cursor to next word's first character

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -308,7 +308,7 @@ func (h *BufPane) SelectWordRight() bool {
 	if !h.Cursor.HasSelection() {
 		h.Cursor.OrigSelection[0] = h.Cursor.Loc
 	}
-	h.Cursor.WordRight()
+	h.Cursor.WordEnd()
 	h.Cursor.SelectTo(h.Cursor.Loc)
 	h.Relocate()
 	return true

--- a/internal/buffer/cursor.go
+++ b/internal/buffer/cursor.go
@@ -394,14 +394,15 @@ func (c *Cursor) SelectTo(loc Loc) {
 	}
 }
 
-// WordRight moves the cursor one word to the right
-func (c *Cursor) WordRight() {
+// WordEnd moves the cursor to the end of the next word or to the
+// end of the word currently under it
+func (c *Cursor) WordEnd() {
+	c.Right()
 	for util.IsWhitespace(c.RuneUnder(c.X)) {
 		if c.X == util.CharacterCount(c.buf.LineBytes(c.Y)) {
-			c.Right()
 			return
 		}
-		c.Right()
+		c.Left()
 	}
 	c.Right()
 	for util.IsWordChar(c.RuneUnder(c.X)) {
@@ -409,6 +410,34 @@ func (c *Cursor) WordRight() {
 			return
 		}
 		c.Right()
+	}
+}
+
+// skipRightWhiteSpaces moves the cursor until it reaches a non
+// white space character
+func (c *Cursor) skipRightWhiteSpaces() {
+	for util.IsWhitespace(c.RuneUnder(c.X)) {
+		if c.X == util.CharacterCount(c.buf.LineBytes(c.Y)) {
+			c.Right()
+			return
+		}
+		c.Right()
+	}
+}
+
+// WordRight moves the cursor one word to the right
+func (c *Cursor) WordRight() {
+	if !util.IsWordChar(c.RuneUnder(c.X)) {
+		c.Right()
+		c.skipRightWhiteSpaces()
+	} else {
+		for util.IsWordChar(c.RuneUnder(c.X)) {
+			if c.X == util.CharacterCount(c.buf.LineBytes(c.Y)) {
+				return
+			}
+			c.Right()
+		}
+		c.skipRightWhiteSpaces()
 	}
 }
 


### PR DESCRIPTION
Hello,

This pull request tries to fix the behavior reported on issue #2304, in case it's not intended.

It updates WordRight function to move cursor to next word's first letter instead of the white space before it. Since SelectWordRight function calls WordRight, this pull request also creates the WordEnd function, that moves cursor the current word's last character (or to the next word's last character, if character under cursor is a non-word character). This new function replaces WordRight call at SelectWordRight.