### PR TITLE
docs(README.md): add Pacstall to installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ for other operating systems. These packages are not guaranteed to be up-to-date.
     * `dnf install micro` (Fedora).
     * `pacman -S micro` (Arch Linux).
     * `eopkg install micro` (Solus).
+    * `pacstall -I micro` (Pacstall).
     * See [wiki](https://github.com/zyedidia/micro/wiki/Installing-Micro) for details about CRUX, Termux.
 * Windows: [Chocolatey](https://chocolatey.org) and [Scoop](https://github.com/lukesampson/scoop).
     * `choco install micro`.


### PR DESCRIPTION
Pacstall (https://pacstall.dev) is a package manager for Debian/Ubuntu. You can se unofficial pacscript at: https://github.com/pacstall/pacstall-programs/blob/master/packages/micro/micro.pacscript.