### PR TITLE
Add some missing final word boundaries in syntaxes

### DIFF
--- a/runtime/syntax/coffeescript.yaml
+++ b/runtime/syntax/coffeescript.yaml
@@ -18,11 +18,11 @@ rules:
     - constant.bool.true: "\\b(true|yes|on)\\b"
 
     - constant.number: "\\b[-+]?([1-9][0-9]*|0[0-7]*|0x[0-9a-fA-F]+)([uU][lL]?|[lL][uU]?)?\\b"
-    - constant.number: "\\b[-+]?([0-9]+\\.[0-9]*|[0-9]*\\.[0-9]+)([EePp][+-]?[0-9]+)?[fFlL]?"
-    - constant.number: "\\b[-+]?([0-9]+[EePp][+-]?[0-9]+)[fFlL]?"
+    - constant.number: "\\b[-+]?([0-9]+\\.[0-9]*|[0-9]*\\.[0-9]+)([EePp][+-]?[0-9]+)?[fFlL]?\\b"
+    - constant.number: "\\b[-+]?([0-9]+[EePp][+-]?[0-9]+)[fFlL]?\\b"
     - identifier: "@[A-Za-z0-9_]*"
 
-    - error: "\\b(enum|implements|interface|package|private|protected|public)"
+    - error: "\\b(enum|implements|interface|package|private|protected|public)\\b"
     - constant: "\\b(globalThis|Infinity|null|undefined|NaN)\\b"
     - constant: "\\b(null|undefined|NaN)\\b"
     - constant: "\\b(true|false|yes|no|on|off)\\b"

--- a/runtime/syntax/dart.yaml
+++ b/runtime/syntax/dart.yaml
@@ -5,8 +5,8 @@ detect:
 
 rules:
     - constant.number: "\\b[-+]?([1-9][0-9]*|0[0-7]*|0x[0-9a-fA-F]+)([uU][lL]?|[lL][uU]?)?\\b"
-    - constant.number: "\\b[-+]?([0-9]+\\.[0-9]*|[0-9]*\\.[0-9]+)([EePp][+-]?[0-9]+)?[fFlL]?"
-    - constant.number: "\\b[-+]?([0-9]+[EePp][+-]?[0-9]+)[fFlL]?"
+    - constant.number: "\\b[-+]?([0-9]+\\.[0-9]*|[0-9]*\\.[0-9]+)([EePp][+-]?[0-9]+)?[fFlL]?\\b"
+    - constant.number: "\\b[-+]?([0-9]+[EePp][+-]?[0-9]+)[fFlL]?\\b"
     - identifier: "[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[(]"
     - statement: "\\b(break|case|catch|continue|default|else|finally)\\b"
     - statement: "\\b(for|function|get|if|in|as|is|new|return|set|switch|final|await|async|sync)\\b"

--- a/runtime/syntax/elixir.yaml
+++ b/runtime/syntax/elixir.yaml
@@ -20,7 +20,7 @@ rules:
     - comment.bright: "##[^{].*$|##$"
 
     - type.keyword: "\\:[a-zA-Z][a-zA-Z0-9_]*"
-    - type.keyword: "\\b(describe|test)"
+    - type.keyword: "\\b(describe|test)\\b"
     - statement: "\\b(expected|assert|assert_raise|assert_in_delta|assert_received|catch_error|catch_throw|flunk|refute|refute_in_delta|refute_received)\\b"
     - symbol.tag: "^\\s*\\@[a-zA-Z][a-zA-Z0-9_]*\\b"
 

--- a/runtime/syntax/javascript.yaml
+++ b/runtime/syntax/javascript.yaml
@@ -6,8 +6,8 @@ detect:
 
 rules:
     - constant.number: "\\b[-+]?([1-9][0-9]*|0[0-7]*|0x[0-9a-fA-F]+)([uU][lL]?|[lL][uU]?)?\\b"
-    - constant.number: "\\b[-+]?([0-9]+\\.[0-9]*|[0-9]*\\.[0-9]+)([EePp][+-]?[0-9]+)?[fFlL]?"
-    - constant.number: "\\b[-+]?([0-9]+[EePp][+-]?[0-9]+)[fFlL]?"
+    - constant.number: "\\b[-+]?([0-9]+\\.[0-9]*|[0-9]*\\.[0-9]+)([EePp][+-]?[0-9]+)?[fFlL]?\\b"
+    - constant.number: "\\b[-+]?([0-9]+[EePp][+-]?[0-9]+)[fFlL]?\\b"
     #- identifier: "[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[(]"
     # ^ this is not correct usage of the identifier color
     - symbol.brackets: "(\\{|\\})"
@@ -22,7 +22,7 @@ rules:
     - statement: "\\b(get|if|import|from|in|of|instanceof|let|new|reject|resolve|return)\\b"
     - statement: "\\b(set|static|super|switch|this|throw|try|typeof|var|void|while|with|yield)\\b"
     # reserved but unassigned
-    - error: "\\b(enum|implements|interface|package|private|protected|public)"
+    - error: "\\b(enum|implements|interface|package|private|protected|public)\\b"
     - constant: "\\b(globalThis|Infinity|null|undefined|NaN)\\b"
     - constant: "\\b(null|undefined|NaN)\\b"
     - constant: "\\b(true|false)\\b"

--- a/runtime/syntax/json.yaml
+++ b/runtime/syntax/json.yaml
@@ -6,8 +6,8 @@ detect:
 
 rules:
     - constant.number: "\\b[-+]?([1-9][0-9]*|0[0-7]*|0x[0-9a-fA-F]+)([uU][lL]?|[lL][uU]?)?\\b"
-    - constant.number: "\\b[-+]?([0-9]+\\.[0-9]*|[0-9]*\\.[0-9]+)([EePp][+-]?[0-9]+)?[fFlL]?"
-    - constant.number: "\\b[-+]?([0-9]+[EePp][+-]?[0-9]+)[fFlL]?"
+    - constant.number: "\\b[-+]?([0-9]+\\.[0-9]*|[0-9]*\\.[0-9]+)([EePp][+-]?[0-9]+)?[fFlL]?\\b"
+    - constant.number: "\\b[-+]?([0-9]+[EePp][+-]?[0-9]+)[fFlL]?\\b"
     - constant: "\\b(null)\\b"
     - constant: "\\b(true|false)\\b"
     - constant.string: 

--- a/runtime/syntax/typescript.yaml
+++ b/runtime/syntax/typescript.yaml
@@ -5,8 +5,8 @@ detect:
 
 rules:
     - constant.number: "\\b[-+]?([1-9][0-9]*|0[0-7]*|0x[0-9a-fA-F]+)([uU][lL]?|[lL][uU]?)?\\b"
-    - constant.number: "\\b[-+]?([0-9]+\\.[0-9]*|[0-9]*\\.[0-9]+)([EePp][+-]?[0-9]+)?[fFlL]?"
-    - constant.number: "\\b[-+]?([0-9]+[EePp][+-]?[0-9]+)[fFlL]?"
+    - constant.number: "\\b[-+]?([0-9]+\\.[0-9]*|[0-9]*\\.[0-9]+)([EePp][+-]?[0-9]+)?[fFlL]?\\b"
+    - constant.number: "\\b[-+]?([0-9]+[EePp][+-]?[0-9]+)[fFlL]?\\b"
     - identifier: "[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[(]"
     - statement: "\\b(abstract|as|async|await|break|case|catch|class|const|constructor|continue)\\b"
     - statement: "\\b(debugger|declare|default|delete|do|else|enum|export|extends|finally|for|from)\\b"


### PR DESCRIPTION
This includes number constants and keywords which only had an initial word boundary, `\b`.

This fixes:

- `1.23e456fabcdef` being partially considered a number constant,
- `describeabcdef` being partially considered a keyword,
- `publicKey` being partially considered a keyword.

---

Some languages *not* included in this PR, because I do not know if this change is applicable to them:

- `gentoo-ebuild`,
- `lisp`,
- `pascal`,
- `perl`,
- `php`.