### PR TITLE
Julia syntax improvements

### DIFF
--- a/runtime/syntax/d.yaml
+++ b/runtime/syntax/d.yaml
@@ -10,7 +10,7 @@ rules:
     # Octal integer literals are deprecated
     - error: "(0[0-7_]*)(L[uU]?|[uU]L?)?"
     # Decimal integer literals
-    - constant.number: "([0-9]|[1-9][0-9_]*)(L[uU]?|[uU]L?)?"
+    - constant.number: "([0-9]|[1-9][0-9_]*)(L[uU]?|[uU]L?)?\\b"
     # Binary integer literals
     - constant: "(0[bB][01_]*)(L[uU]?|[uU]L?)?"
     # Decimal float literals

--- a/runtime/syntax/julia.yaml
+++ b/runtime/syntax/julia.yaml
@@ -19,13 +19,13 @@ rules:
       # decorators
     - identifier.macro: "@[A-Za-z0-9_]+"
       # operators
-    - symbol.operator: "[-+*/|=%<>&~^]|\\b(in|isa|where)\\b"
+    - symbol.operator: "[:+*|=!%~<>/\\-?&\\\\÷∈∉∘]|\\b(in|isa|where)\\b"
+      # for some reason having ^ in the same regex with the other operators broke things
+    - symbol.operator: "\\^"
       # parentheses
     - symbol.brackets: "([(){}]|\\[|\\])"
       # numbers
     - constant.number: "\\b([0-9]+(_[0-9]+)*|0x[0-9a-fA-F]+(_[0-9a-fA-F]+)*|0b[01]+(_[01]+)*|0o[0-7]+(_[0-7]+)*|Inf(16|32|64)?|NaN(16|32|64)?)\\b"
-
-    - constant.string: "\"(\\\\.|[^\"])*\"|'(\\\\.|[^']){1}'"
 
     - constant.string:
         start: "\"\"\""
@@ -33,16 +33,26 @@ rules:
         rules: []
 
     - constant.string:
-        start: "\"[^\"]|\"$"
+        start: "\""
         end: "\""
-        rules: []
+        skip: "\\\\."
+        rules:
+            - constant.specialChar: "\\\\([\"'abfnrtv\\\\]|[0-3]?[0-7]{1,2}|x[0-9A-Fa-f]{1,2}|u[0-9A-Fa-f]{1,4}|U[0-9A-Fa-f]{1,8})"
 
-    - comment:
-        start: "#[^=]|#$"
-        end: "$"
-        rules: []
+    - constant.string:
+        start: "'"
+        end: "'"
+        skip: "\\\\."
+        rules:
+            - error: "..+"
+            - constant.specialChar: "\\\\([\"'abfnrtv\\\\]|[0-3]?[0-7]{1,2}|x[0-9A-Fa-f]{1,2}|u[0-9A-Fa-f]{1,4}|U[0-9A-Fa-f]{1,8})"
 
     - comment:
         start: "#="
         end: "=#"
+        rules: []
+
+    - comment:
+        start: "#"
+        end: "$"
         rules: []


### PR DESCRIPTION
I modified the regular expressions to more accurately syntax highlight strings in julia. For some reason having the `^` operator in the same regex as other operators caused syntax highlighting for all operators to break after a string (as reported in #2397). Might be a bug somewhere in the syntax highlighter implementation itself? In any case, this workaround seems to fix it for now.
Here's a screenshot of the improvement (new version on the right):
![image](https://user-images.githubusercontent.com/10672443/165470702-8e1a4eb6-3676-4633-95cf-48a8a427af63.png)



I also snuck in a tiny fix for D syntax highlighting integer literals with underscores in them ([screenshot before / after](https://user-images.githubusercontent.com/10672443/165469588-80d5947b-cd70-4688-8b4b-7ed82e0834ae.png))

closes #2397