### PR TITLE
set truecolor support as a default

### DIFF
--- a/internal/screen/screen.go
+++ b/internal/screen/screen.go
@@ -137,10 +137,8 @@ func TempStart(screenWasNil bool) {
 func Init() error {
 	drawChan = make(chan bool, 8)
 
-	// Should we enable true color?
-	truecolor := os.Getenv("MICRO_TRUECOLOR") == "1"
-
-	if !truecolor {
+	// allow forceful opt-out of true colors
+	if os.Getenv("MICRO_TRUECOLOR") == "0" {
 		os.Setenv("TCELL_TRUECOLOR", "disable")
 	}
 

--- a/runtime/help/colors.md
+++ b/runtime/help/colors.md
@@ -48,9 +48,9 @@ color support comes in three flavors.
   16-color palette is ignored when using true-color mode (this means the
   colors while using the terminal emulator will be slightly off). Not all
   terminals support true color but at this point most do. True color
-  support in micro is off by default but can be enabled by setting the
-  environment variable `MICRO_TRUECOLOR` to 1.  In addition your terminal
-  must support it (usually indicated by setting `$COLORTERM` to `truecolor`).
+  support in micro is based on the value of `$COLORTERM` (with `truecolor` or
+  `24bit` or `24-bit` indicating support.) To forcefully disable this setting,
+  you can set the environment variable `MICRO_TRUECOLOR` to 0.
   True-color colorschemes in micro typically end with `-tc`, such as
   `solarized-tc`, `atom-dark`, `material-tc`, etc... If true color is not
   enabled but a true color colorscheme is used, micro will do its best to
@@ -85,10 +85,9 @@ These may vary widely based on the 16 colors selected for your terminal.
 ### True color
 
 True color requires your terminal to support it. This means that the
-environment variable `COLORTERM` should have the value `truecolor`, `24bit`,
-or `24-bit`. In addition, to enable true color in micro, the environment
-variable `MICRO_TRUECOLOR` must be set to 1. Note that you have to create
-and set this variable yourself.
+environment variable `COLORTERM` should have the value `truecolor` or `24bit`
+or `24-bit`. To forcefully disable true color support in micro, the environment
+variable `MICRO_TRUECOLOR` can be set to 0.
 
 * `solarized-tc`: this is the solarized colorscheme for true color.
 * `atom-dark`: this colorscheme is based off of Atom's "dark" colorscheme.


### PR DESCRIPTION
closes #1127  

by default, tcell is already reading COLORTERM, hence why the non-disabled part of the code works without actually calling/doing anything.  

this changes the default to supporting colorterm for users with COLORTERM, and allowing them to opt out with MICRO_TRUECOLOR=0 (or unsetting COLORTERM in their terminal, since that is a requirement of tcell).  

this is the opposite of the previous behaviour, where the default is no-truecolor and it has to be opted-into as well as having COLORTERM support, but i think in the modern age it makes more sense to support 'true' colors as a default. nevertheless, it is a 'breaking' change for users.  

the documentation has also been updated, but i notice now these two sections seem identical; perhaps one of them can be removed entirely, not sure.