### PR TITLE
Lua syntax highlighting: Various fixes

### DIFF
--- a/runtime/syntax/lua.yaml
+++ b/runtime/syntax/lua.yaml
@@ -4,12 +4,12 @@ detect:
     filename: "\\.lua$"
 
 rules:
-    - statement: "\\b(do|end|while|break|repeat|until|if|elseif|then|else|for|in|function|local|return)\\b"
+    - statement: "\\b(do|end|while|break|repeat|until|if|elseif|then|else|for|in|function|local|return|goto)\\b"
     - statement: "\\b(not|and|or)\\b"
     - statement: "\\b(debug|string|math|table|io|coroutine|os|utf8|bit32)\\b\\."
     - statement: "\\b(_ENV|_G|_VERSION|assert|collectgarbage|dofile|error|getfenv|getmetatable|ipairs|load|loadfile|module|next|pairs|pcall|print|rawequal|rawget|rawlen|rawset|require|select|setfenv|setmetatable|tonumber|tostring|type|unpack|xpcall)\\s*\\("
     - identifier: "io\\.\\b(close|flush|input|lines|open|output|popen|read|tmpfile|type|write)\\b"
-    - identifier: "math\\.\\b(abs|acos|asin|atan2|atan|ceil|cosh|cos|deg|exp|floor|fmod|frexp|huge|ldexp|log10|log|max|maxinteger|min|mininteger|modf|pi|pow|rad|random|randomseed|sinh|sqrt|tan|tointeger|type|ult)\\b"
+    - identifier: "math\\.\\b(abs|acos|asin|atan2|atan|ceil|cosh|cos|deg|exp|floor|fmod|frexp|huge|ldexp|log10|log|max|maxinteger|min|mininteger|modf|pi|pow|rad|random|randomseed|sin|sqrt|tan|tointeger|type|ult)\\b"
     - identifier: "os\\.\\b(clock|date|difftime|execute|exit|getenv|remove|rename|setlocale|time|tmpname)\\b"
     - identifier: "package\\.\\b(config|cpath|loaded|loadlib|path|preload|seeall|searchers|searchpath)\\b"
     - identifier: "string\\.\\b(byte|char|dump|find|format|gmatch|gsub|len|lower|match|pack|packsize|rep|reverse|sub|unpack|upper)\\b"
@@ -33,20 +33,19 @@ rules:
         end: "\""
         skip: "\\\\."
         rules:
-            - constant.specialChar: "\\\\."
+            - constant.specialChar: "\\\\([abfnrtvz\\'\"]|[0-9]{1,3}|x[0-9a-fA-F][0-9a-fA-F]|u\\{[0-9a-fA-F]+\\})"
 
     - constant.string:
         start: "'"
         end: "'"
         skip: "\\\\."
         rules:
-            - constant.specialChar: "\\\\."
+            - constant.specialChar: "\\\\([abfnrtvz\\'\"]|[0-9]{1,3}|x[0-9a-fA-F][0-9a-fA-F]|u\\{[0-9a-fA-F]+\\})"
 
     - constant.string:
         start: "\\[\\["
         end: "\\]\\]"
-        rules:
-            - constant.specialChar: "\\\\."
+        rules: []
 
 # support first few lengths of "long brackets" explicitly
 # brackets longer than that will give false positives
@@ -54,26 +53,22 @@ rules:
     - constant.string:
         start: "\\[=\\["
         end: "\\]=\\]"
-        rules:
-            - constant.specialChar: "\\\\."
+        rules: []
 
     - constant.string:
         start: "\\[==\\["
         end: "\\]==\\]"
-        rules:
-            - constant.specialChar: "\\\\."
+        rules: []
 
     - constant.string:
         start: "\\[===\\["
         end: "\\]===\\]"
-        rules:
-            - constant.specialChar: "\\\\."
+        rules: []
 
     - constant.string:
         start: "\\[====+\\["
         end: "\\]====+\\]"
-        rules:
-            - constant.specialChar: "\\\\."
+        rules: []
 
     - comment.block:
         start: "\\-\\-\\[\\["


### PR DESCRIPTION
- `goto` keyword
- `math.sin` (typo: was `math.sinh`)
- string escapes: long strings don't support escapes; normal strings support escapes which weren't implemented correctly