### PR TITLE
Register `Brewfile`s as Ruby files

### DIFF
--- a/runtime/syntax/ruby.yaml
+++ b/runtime/syntax/ruby.yaml
@@ -1,7 +1,7 @@
 filetype: ruby
 
 detect: 
-    filename: "\\.(rb|rake|gemspec)$|^(Gemfile|config.ru|Rakefile|Capfile|Vagrantfile|Guardfile|Appfile|Fastfile|Pluginfile|Podfile)$"
+    filename: "\\.(rb|rake|gemspec)$|^(Gemfile|config.ru|Rakefile|Capfile|Vagrantfile|Guardfile|Appfile|Fastfile|Pluginfile|Podfile|\\.?[Bb]rewfile)$"
     header: "^#!.*/(env +)?ruby( |$)"
 
 rules:


### PR DESCRIPTION
A `Brewfile` (sometimes named `.Brewfile`) is a bundler for Homebrew packages.
Brewfiles are written in Ruby and are functionally similar to Gemfiles.

This PR counts files matching the regular expression `^\.?[Bb]rewfile$` as Ruby scripts,
which matches files named `Brewfile`, `brewfile`, `.Brewfile`, and `.brewfile`.

Justification: [A search for Ruby files named `Brewfile` on GitHub][Brewfile search] returns 14,153 results.

Other resources:
- [`homebrew-bundle` on GitHub](https://github.com/Homebrew/homebrew-bundle)
- [`brew bundle` Manpage](https://docs.brew.sh/Manpage#bundle-subcommand)

[Brewfile search]: https://github.com/search?q=filename%3ABrewfile+language%3ARuby&type=code
