### PR TITLE
Add "unknown" type in TypeScript.yaml

### DIFF
--- a/runtime/syntax/typescript.yaml
+++ b/runtime/syntax/typescript.yaml
@@ -16,7 +16,7 @@ rules:
     - constant: "\\b(false|true|null|undefined|NaN)\\b"
     - type: "\\b(Array|Boolean|Date|Enumerator|Error|Function|Math)\\b"
     - type: "\\b(Number|Object|RegExp|String|Symbol)\\b"
-    - type: "\\b(any|boolean|never|number|string|symbol)\\b"
+    - type: "\\b(any|unknown|boolean|never|number|string|symbol)\\b"
     - statement: "[-+/*=<>!~%?:&|]"
     - constant: "/[^*]([^/]|(\\\\/))*[^\\\\]/[gim]*"
     - constant: "\\\\[0-7][0-7]?[0-7]?|\\\\x[0-9a-fA-F]+|\\\\[bfnrt'\"\\?\\\\]"


### PR DESCRIPTION
Since TS 3.0, they've added a new type called "unknown" which explicitly allows to pass any kind of parameters, but can't contain any object.