### PR TITLE
scala.yaml: add support for .sc extension

### DIFF
--- a/runtime/syntax/scala.yaml
+++ b/runtime/syntax/scala.yaml
@@ -1,7 +1,7 @@
 filetype: scala
 
 detect:
-    filename: "\\.scala$"
+    filename: "\\.sc(ala)?$"
 
 rules:
     - type: "\\b(boolean|byte|char|double|float|int|long|new|short|this|transient|void)\\b"


### PR DESCRIPTION
It's used for Ammonite scripts and Scala worksheets