### PR TITLE
Adds options for tab bar and tab color reversing

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -335,10 +335,12 @@ var DefaultGlobalOnlySettings = map[string]interface{}{
 	"mouse":          true,
 	"parsecursor":    false,
 	"paste":          false,
-	"savehistory":    true,
-	"sucmd":          "sudo",
 	"pluginchannels": []string{"https://raw.githubusercontent.com/micro-editor/plugin-channel/master/channel.json"},
 	"pluginrepos":    []string{},
+	"savehistory":    true,
+	"sucmd":          "sudo",
+	"tabhighlight":   false,
+	"tabreverse":     true,
 	"xterm":          false,
 }
 

--- a/internal/display/tabwindow.go
+++ b/internal/display/tabwindow.go
@@ -2,6 +2,7 @@ package display
 
 import (
 	runewidth "github.com/mattn/go-runewidth"
+	"github.com/zyedidia/tcell/v2"
 	"github.com/zyedidia/micro/v2/internal/buffer"
 	"github.com/zyedidia/micro/v2/internal/config"
 	"github.com/zyedidia/micro/v2/internal/screen"
@@ -94,16 +95,27 @@ func (w *TabWindow) Display() {
 	x := -w.hscroll
 	done := false
 
-	tabBarStyle := config.DefStyle.Reverse(true)
-	if style, ok := config.Colorscheme["tabbar"]; ok {
-		tabBarStyle = style
-	}
-	tabBarActiveStyle := tabBarStyle
-	if style, ok := config.Colorscheme["tabbar.active"]; ok {
-		tabBarActiveStyle = style
-	}
+	globalTabReverse := config.GetGlobalOption("tabreverse").(bool)
+	globalTabHighlight := config.GetGlobalOption("tabhighlight").(bool)
 
-	draw := func(r rune, n int, active bool) {
+	// xor of reverse and tab highlight to get tab character (as in filename and surrounding characters) reverse state
+	tabCharHighlight := (globalTabReverse || globalTabHighlight) && !(globalTabReverse && globalTabHighlight)
+
+	reverseStyles := func(reverse bool) (tcell.Style, tcell.Style) {
+		tabBarStyle := config.DefStyle.Reverse(reverse)
+		if style, ok := config.Colorscheme["tabbar"]; ok {
+			tabBarStyle = style
+		}
+		tabBarActiveStyle := tabBarStyle
+		if style, ok := config.Colorscheme["tabbar.active"]; ok {
+			tabBarActiveStyle = style
+		}
+		return tabBarStyle, tabBarActiveStyle
+	}
+	
+	draw := func(r rune, n int, active bool, reversed bool) {
+		tabBarStyle, tabBarActiveStyle := reverseStyles(reversed)
+		
 		style := tabBarStyle
 		if active {
 			style = tabBarActiveStyle
@@ -131,28 +143,33 @@ func (w *TabWindow) Display() {
 
 	for i, n := range w.Names {
 		if i == w.active {
-			draw('[', 1, true)
+			draw('[', 1, true, tabCharHighlight)
 		} else {
-			draw(' ', 1, false)
+			draw(' ', 1, false, tabCharHighlight)
 		}
+		
 		for _, c := range n {
-			draw(c, 1, i == w.active)
+			draw(c, 1, i == w.active, tabCharHighlight)
 		}
+		
 		if i == len(w.Names)-1 {
 			done = true
 		}
+		
 		if i == w.active {
-			draw(']', 1, true)
-			draw(' ', 2, true)
+			draw(']', 1, true, tabCharHighlight)
+			draw(' ', 2, true, globalTabReverse)
 		} else {
-			draw(' ', 3, false)
+			draw(' ', 1, false, tabCharHighlight)
+			draw(' ', 2, false, globalTabReverse)
 		}
+		
 		if x >= w.Width {
 			break
 		}
 	}
 
 	if x < w.Width {
-		draw(' ', w.Width-x, false)
+		draw(' ', w.Width-x, false, false)
 	}
 }

--- a/internal/display/tabwindow.go
+++ b/internal/display/tabwindow.go
@@ -170,6 +170,6 @@ func (w *TabWindow) Display() {
 	}
 
 	if x < w.Width {
-		draw(' ', w.Width-x, false, false)
+		draw(' ', w.Width-x, false, globalTabReverse)
 	}
 }

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -365,6 +365,14 @@ Here are the available options:
 
 	default value: `false`
 
+* `tabhighlight`: inverts the tab characters' (filename, save indicator, etc) colors with respect to the tab bar.
+
+	default value: false
+
+* `tabreverse`: reverses the tab bar colors when active.
+
+	default value: true
+
 * `tabsize`: the size in spaces that a tab character should be displayed with.
 
 	default value: `4`
@@ -491,6 +499,8 @@ so that you can see what the formatting should look like.
     "sucmd": "sudo",
     "syntax": true,
     "tabmovement": false,
+    "tabhighlight": true,
+    "tabreverse": false,
     "tabsize": 4,
     "tabstospaces": false,
     "useprimary": true,


### PR DESCRIPTION
This commit adds options to accomodate the setting of the tab bar's colors. The settings.go file was updated to add global variables to store these options, as was the options.md help menu to document their purposes.
	
[tabwindow.go](https://github.com/zyedidia/micro/compare/master...flber:micro:master#diff-4d74b11e63d3a8b9689964aee0db3203c4bad8d506dc9d1d0420c2446454ba30) was slightly modified to implement these options:
- some code to [obtain relevant styles](https://github.com/zyedidia/micro/compare/master...flber:micro:master#diff-4d74b11e63d3a8b9689964aee0db3203c4bad8d506dc9d1d0420c2446454ba30L97-L104) was moved into an inline function (is that the right term? I'm new to Go :P) to clean up the code a bit
- the [inline draw function](https://github.com/zyedidia/micro/compare/master...flber:micro:master#diff-4d74b11e63d3a8b9689964aee0db3203c4bad8d506dc9d1d0420c2446454ba30R116) was modified to specify the character reverse state. This was used by [subsequent calls](https://github.com/zyedidia/micro/compare/master...flber:micro:master#diff-4d74b11e63d3a8b9689964aee0db3203c4bad8d506dc9d1d0420c2446454ba30L134-R173) to highlight tab line characters in a way appropriate to the settings specified.
	
While I think I managed to find and update all relevant material to document this change, I'm new to this codebase and totally could have missed something. If I did, please let me know and I can make a follow-up commit.
	
While I don't think this addition is outside of the feature scope of the project, if you feel it is I'm totally happy keeping this to my fork :)