### PR TITLE
runtime/syntax/nix: Add support for block comments

### DIFF
--- a/runtime/syntax/nix.yaml
+++ b/runtime/syntax/nix.yaml
@@ -25,3 +25,8 @@ rules:
         start: "#"
         end: "$"
         rules: []
+
+    - comment:
+        start: "/\\*"
+        end: "\\*/"
+        rules: []


### PR DESCRIPTION
This PR makes it so code between`/*` and  `*/` is properly highlighted as multi-line comments in `*.nix` files.