### PR TITLE
syntax/git-rebase-todo.yaml: support more commands

### DIFF
--- a/runtime/syntax/git-rebase-todo.yaml
+++ b/runtime/syntax/git-rebase-todo.yaml
@@ -5,7 +5,7 @@ detect:
 
 rules:
     # Rebase commands
-    - statement: "^(p(ick)?|r(eword)?|e(dit)?|s(quash)?|f(ixup)?|x|exec|d(rop)?)\\b"
+    - statement: "^(p(ick)?|r(eword)?|e(dit)?|s(quash)?|f(ixup)?|x|exec|b(reak)?|d(rop)?|l(abel)?|t|reset|m(erge)?)\\b"
     # Commit IDs
     - identifier: "\\b([0-9a-f]{7,40})\\b"
 


### PR DESCRIPTION
The following interactive rebase commands were added: `break`/`b`, `label`/`l`, `reset`/`t` and `merge`/`m`.

For reference, see the list of supported commands in the help text of git's interactive rebase, as of the latest release (v2.37.1):
https://github.com/git/git/blob/v2.37.1/rebase-interactive.c#L43-L59

There's also a similar list (with more items, and in a different order) in the [sequencer.c](https://github.com/git/git/blob/v2.37.1/sequencer.c#L1692-L1705) and [sequencer.h](https://github.com/git/git/blob/v2.37.1/sequencer.h#L86-L103) files of the git project.