### PR TITLE
runtime/syntax/sh: don't start string on escaped quotes

### DIFF
--- a/pkg/highlight/highlighter.go
+++ b/pkg/highlight/highlighter.go
@@ -119,6 +119,17 @@ func findIndex(regex *regexp.Regexp, skip *regexp.Regexp, str []byte, canMatchSt
 		strbytes = str
 	}
 
+	if strings.Contains(regexStr, "(") {
+		match := regex.FindSubmatchIndex(strbytes)
+		if match == nil {
+			return nil
+		}
+		if len(match) < 4 {
+			return []int{runePos(match[0], str), runePos(match[1], str)}
+		}
+		return []int{runePos(match[2], str), runePos(match[3], str)}
+	}
+
 	match := regex.FindIndex(strbytes)
 	if match == nil {
 		return nil

--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -46,14 +46,14 @@ rules:
     - identifier: "\\$\\{?[0-9A-Za-z_!@#$*?-]+\\}?"
 
     - constant.string:
-        start: "\""
+        start: "(?:^|[^\\\\])(\")"
         end: "\""
         skip: "\\\\."
         rules:
             - constant.specialChar: "\\\\."
 
     - constant.string:
-        start: "'"
+        start: "(?:^|[^\\\\])(')"
         end: "'"
         rules: []
 


### PR DESCRIPTION
current (invalid) behaviour:
![image](https://user-images.githubusercontent.com/26630168/180100434-632c541f-4541-4028-b005-c63573d516de.png)

fixed behaviour:
![image](https://user-images.githubusercontent.com/26630168/180100458-efccd345-f5a1-49ba-8d6c-82e4ed33da42.png)
