### PR TITLE
delete minor unreachable code caused by log.Fatal

### DIFF
--- a/cmd/micro/micro_test.go
+++ b/cmd/micro/micro_test.go
@@ -60,7 +60,6 @@ func startup(args []string) (tcell.SimulationScreen, error) {
 			}
 			// Print the stack trace too
 			log.Fatalf(errors.Wrap(err, 2).ErrorStack())
-			os.Exit(1)
 		}
 	}()
 
@@ -171,7 +170,6 @@ func TestMain(m *testing.M) {
 	sim, err = startup([]string{})
 	if err != nil {
 		log.Fatalln(err)
-		os.Exit(1)
 	}
 
 	retval := m.Run()


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

Fatalf is equivalent to Printf() followed by a call to os.Exit(1).