### PR TITLE
Added syntax highlighting for backtick strings in typescript 

### DIFF
--- a/runtime/syntax/typescript.yaml
+++ b/runtime/syntax/typescript.yaml
@@ -41,4 +41,9 @@ rules:
         skip: "\\\\."
         rules:
             - constant.specialChar: "\\\\."
-    
+    - constant.string:
+        start: "`"
+        end: "`"
+        rules:
+            - constant.specialChar: "\\\\."
+            - identifier: "\\x24\\{.*?\\}"    


### PR DESCRIPTION
Took this straight from the javascript syntax file.