### PR TITLE
Restore installation instructions for Debian and Ubuntu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ for other operating systems. These packages are not guaranteed to be up-to-date.
 
 * Linux: Available in distro-specific package managers.
     * `dnf install micro` (Fedora).
+    * `apt install micro` (Ubuntu and Debian).
     * `pacman -S micro` (Arch Linux).
     * `emerge app-editors/micro` (Gentoo).
     * `eopkg install micro` (Solus).


### PR DESCRIPTION
I saw this was deleted a while ago, but since then the version has changed and those reasons aren't actual anymore.