### PR TITLE
Fix git-rebase-todo syntax highlighting

### DIFF
--- a/runtime/syntax/git-commit.yaml
+++ b/runtime/syntax/git-commit.yaml
@@ -1,7 +1,7 @@
 filetype: git-commit
 
 detect:
-    filename: "^(.*[\\/])?(COMMIT_EDITMSG|TAG_EDITMSG|MERGE_MSG|git-rebase-todo)$"
+    filename: "^(.*[\\/])?(COMMIT_EDITMSG|TAG_EDITMSG|MERGE_MSG)$"
 
 rules:
     # File changes


### PR DESCRIPTION
PR #2330 mistakenly added `git-rebase-todo` to the filename pattern to be highlighted with the standard git-commit highlighting. As raised in issue #2519, this prevents the application of the correct syntax highlighting for these files, already defined in `runtime/syntax/git-rebase-todo.yaml`.

By reverting the erroneous change in PR #2330, correct `git-rebase-todo` syntax highlighting is restored.