### PR TITLE
Add slint syntax

### DIFF
--- a/runtime/syntax/slint.yaml
+++ b/runtime/syntax/slint.yaml
@@ -1,0 +1,40 @@
+filetype: slint
+
+detect:
+  filename: "\\.slint"
+
+rules:
+  - type: "\\b(int|float|bool|string|color|brush|physical-length|length|duration|angle|easing|percent|image)\\b"
+  - statement: "\\b(import|export|struct|from|property|callback|animate|states|transitions|if|for|return)\\b"
+  
+  - constant.number: "\\b[0-9]+\\b"
+  - constant.number: "\\b[0-9]+(px|%)\\b"
+  - constant: "\\b(blue|red|green|yellow|red|black|ease|ease_in|ease_out|ease_in_out)\\b"
+  - constant.color: "#[0-9a-fA-F]+"
+  - constant.bool: "\\b(true|false)\\b"
+  - constant.bool.false: "\\b(false)\\b"
+  - constant.bool.true: "\\b(true)\\b"
+
+
+  - symbol.operator.logical: "[!&|]+"
+  - symbol.operator.comparison: "[<=>]+"
+  - symbol.operator.assignment: "[:<=>]+"
+  - symbol.operator: "[-!%&()+,/*<=>?[]|;]+"
+  
+  - identifier.var: "[a-zA-Z_][a-zA-Z_0-9-]*:" 
+  - identifier.var: "[a-zA-Z_][a-zA-Z_0-9-]* *<?=>"
+  
+  - constant.string: "\"(\\\\.|[^\"])*\"|'(\\\\.|[^'])*'"
+  
+  - comment:
+        start: "//"
+        end: "$"
+        rules:
+            - todo: "(TODO|XXX|FIXME)"
+  - comment:
+      start: "/\\*"
+      end: "\\*/"
+      rules:
+          # function documentation
+          - identifier: "\\s\\*\\s.*"
+          - todo: "(TODO|XXX|FIXME)"


### PR DESCRIPTION
Adds [slint](https://slint-ui.com/releases/0.3.0/docs/cpp/markdown/langref.html) syntax highlighting based off of [slints sublime syntax](https://github.com/slint-ui/slint/blob/master/editors/sublime/Slint.sublime-syntax)

Example from [todo.slint](https://github.com/slint-ui/slint/blob/master/examples/todo/ui/todo.slint)
![image](https://user-images.githubusercontent.com/19339842/192087594-0cae7a94-069c-4c2b-a079-34cf462dbb62.png)
