### PR TITLE
Fix relocate at the end of buffer when scrollmargin is 0

### DIFF
--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -219,7 +219,7 @@ func (w *BufWindow) Relocate() bool {
 		w.StartLine = c
 		ret = true
 	}
-	if c.GreaterThan(w.Scroll(w.StartLine, height-1-scrollmargin)) && c.LessThan(w.Scroll(bEnd, -scrollmargin+1)) {
+	if c.GreaterThan(w.Scroll(w.StartLine, height-1-scrollmargin)) && c.LessEqual(w.Scroll(bEnd, -scrollmargin)) {
 		w.StartLine = w.Scroll(c, -height+1+scrollmargin)
 		ret = true
 	} else if c.GreaterThan(w.Scroll(bEnd, -scrollmargin)) && c.GreaterThan(w.Scroll(w.StartLine, height-1)) {

--- a/internal/display/softwrap.go
+++ b/internal/display/softwrap.go
@@ -30,6 +30,28 @@ func (s SLoc) GreaterThan(b SLoc) bool {
 	return s.Line == b.Line && s.Row > b.Row
 }
 
+// LessEqual returns true if s is less than or equal to b
+func (s SLoc) LessEqual(b SLoc) bool {
+	if s.Line < b.Line {
+		return true
+	}
+	if s.Line == b.Line && s.Row < b.Row {
+		return true
+	}
+	return s == b
+}
+
+// GreaterEqual returns true if s is bigger than or equal to b
+func (s SLoc) GreaterEqual(b SLoc) bool {
+	if s.Line > b.Line {
+		return true
+	}
+	if s.Line == b.Line && s.Row > b.Row {
+		return true
+	}
+	return s == b
+}
+
 // VLoc represents a location in the buffer as a visual location in the
 // linewrapped buffer.
 type VLoc struct {


### PR DESCRIPTION
Fix the following issue: when `scrollmargin` is set to 0 and we move the cursor to the end of buffer (e.g. via `Ctrl-End`), the buffer view doesn't move.

The cause is that the condition `c.LessThan(w.Scroll(bEnd, -scrollmargin+1))` doesn't hold, since `Scroll()` takes care not to return a location beyond the end of buffer, so in this case `Scroll()` just returns bEnd.