### PR TITLE
cmd: Fix typo in the plugin line of "micro --help"

### DIFF
--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -62,7 +62,7 @@ func InitFlags() {
 		fmt.Println("-version")
 		fmt.Println("    \tShow the version number and information")
 
-		fmt.Print("\nMicro's plugin's can be managed at the command line with the following commands.\n")
+		fmt.Print("\nMicro's plugins can be managed at the command line with the following commands.\n")
 		fmt.Println("-plugin install [PLUGIN]...")
 		fmt.Println("    \tInstall plugin(s)")
 		fmt.Println("-plugin remove [PLUGIN]...")


### PR DESCRIPTION
In the line, we are referring to all the plugins, instead of talking about a property possessed by a certain plugin. Therefore we must omit the apostrophe.
 
fixes #2582