### PR TITLE
Syntax: Add string interpolation support to nix

### DIFF
--- a/runtime/syntax/_nix_inner.yaml
+++ b/runtime/syntax/_nix_inner.yaml
@@ -1,0 +1,29 @@
+filetype: _nix_inner # to be included by "nix"
+
+rules:
+    - special: "\\b(Ellipsis|null|self|super|true|false|abort)\\b"
+    - statement: "\\b(let|in|with|import|rec|inherit)\\b"
+    - symbol.operator: "([~^.:;,+*|=!\\%@]|<|>|/|-|&)"
+    - symbol.brackets: "([(){}]|\\[|\\])"
+
+    - constant.number: "\\b[0-9](_?[0-9])*(\\.([0-9](_?[0-9])*)?)?(e[0-9](_?[0-9])*)?\\b"
+
+    - constant.string:
+        start: "\""
+        end: "\""
+        rules: []
+
+    - constant.string:
+        start: "''"
+        end: "''"
+        rules: []
+
+    - comment:
+        start: "#"
+        end: "$"
+        rules: []
+
+    - comment:
+        start: "/\\*"
+        end: "\\*/"
+        rules: []

--- a/runtime/syntax/nix.yaml
+++ b/runtime/syntax/nix.yaml
@@ -4,29 +4,26 @@ detect:
     filename: "\\.nix$"
 
 rules:
-    - special: "\\b(Ellipsis|null|self|super|true|false|abort)\\b"
-    - statement: "\\b(let|in|with|import|rec|inherit)\\b"
-    - symbol.operator: "([~^.:;,+*|=!\\%@]|<|>|/|-|&)"
-    - symbol.brackets: "([(){}]|\\[|\\])"
-
-    - constant.number: "\\b[0-9](_?[0-9])*(\\.([0-9](_?[0-9])*)?)?(e[0-9](_?[0-9])*)?\\b"
+    - include: _nix_inner
 
     - constant.string:
         start: "\""
         end: "\""
-        rules: []
+        rules:
+            - symbol.brackets:
+                start: "\\$\\{"
+                end: "\\}"
+                rules:
+                    - default: ".*"
+                    - include: _nix_inner
 
     - constant.string:
         start: "''"
         end: "''"
-        rules: []
-
-    - comment:
-        start: "#"
-        end: "$"
-        rules: []
-
-    - comment:
-        start: "/\\*"
-        end: "\\*/"
-        rules: []
+        rules:
+            - symbol.brackets:
+                start: "\\$\\{"
+                end: "\\}"
+                rules:
+                    - default: ".*"
+                    - include: _nix_inner


### PR DESCRIPTION
It's not perfect, due to the greedy nature of regex, but it's an improvement!

Before:
![image](https://user-images.githubusercontent.com/140964/196002527-7abaad0e-c156-493b-87b6-e517baa577e3.png)

After:
![image](https://user-images.githubusercontent.com/140964/196002532-9f3e3287-e0c0-410a-b2ce-cefe62eae02f.png)


The _trick_ is that i move the `nix` syntax to `_nix_inner`, then make a new `nix`, which includes `_nix_inner` at the top-level, and inside `${...}` regions in strings. This way we support a single level of recursion.