### PR TITLE
Introduce mouse release and mouse drag events

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -51,58 +51,91 @@ func (h *BufPane) ScrollAdjust() {
 func (h *BufPane) MousePress(e *tcell.EventMouse) bool {
 	b := h.Buf
 	mx, my := e.Position()
+	// ignore click on the status line
+	if my >= h.BufView().Y+h.BufView().Height {
+		return false
+	}
 	mouseLoc := h.LocFromVisual(buffer.Loc{mx, my})
 	h.Cursor.Loc = mouseLoc
-	if h.mouseReleased {
-		if b.NumCursors() > 1 {
-			b.ClearCursors()
-			h.Relocate()
-			h.Cursor = h.Buf.GetActiveCursor()
-			h.Cursor.Loc = mouseLoc
-		}
-		if time.Since(h.lastClickTime)/time.Millisecond < config.DoubleClickThreshold && (mouseLoc.X == h.lastLoc.X && mouseLoc.Y == h.lastLoc.Y) {
-			if h.doubleClick {
-				// Triple click
-				h.lastClickTime = time.Now()
 
-				h.tripleClick = true
-				h.doubleClick = false
-
-				h.Cursor.SelectLine()
-				h.Cursor.CopySelection(clipboard.PrimaryReg)
-			} else {
-				// Double click
-				h.lastClickTime = time.Now()
-
-				h.doubleClick = true
-				h.tripleClick = false
-
-				h.Cursor.SelectWord()
-				h.Cursor.CopySelection(clipboard.PrimaryReg)
-			}
-		} else {
-			h.doubleClick = false
-			h.tripleClick = false
+	if b.NumCursors() > 1 {
+		b.ClearCursors()
+		h.Relocate()
+		h.Cursor = h.Buf.GetActiveCursor()
+		h.Cursor.Loc = mouseLoc
+	}
+	if time.Since(h.lastClickTime)/time.Millisecond < config.DoubleClickThreshold && (mouseLoc.X == h.lastLoc.X && mouseLoc.Y == h.lastLoc.Y) {
+		if h.doubleClick {
+			// Triple click
 			h.lastClickTime = time.Now()
 
-			h.Cursor.OrigSelection[0] = h.Cursor.Loc
-			h.Cursor.CurSelection[0] = h.Cursor.Loc
-			h.Cursor.CurSelection[1] = h.Cursor.Loc
-		}
-		h.mouseReleased = false
-	} else if !h.mouseReleased {
-		if h.tripleClick {
-			h.Cursor.AddLineToSelection()
-		} else if h.doubleClick {
-			h.Cursor.AddWordToSelection()
+			h.tripleClick = true
+			h.doubleClick = false
+
+			h.Cursor.SelectLine()
+			h.Cursor.CopySelection(clipboard.PrimaryReg)
 		} else {
-			h.Cursor.SetSelectionEnd(h.Cursor.Loc)
+			// Double click
+			h.lastClickTime = time.Now()
+
+			h.doubleClick = true
+			h.tripleClick = false
+
+			h.Cursor.SelectWord()
+			h.Cursor.CopySelection(clipboard.PrimaryReg)
 		}
+	} else {
+		h.doubleClick = false
+		h.tripleClick = false
+		h.lastClickTime = time.Now()
+
+		h.Cursor.OrigSelection[0] = h.Cursor.Loc
+		h.Cursor.CurSelection[0] = h.Cursor.Loc
+		h.Cursor.CurSelection[1] = h.Cursor.Loc
 	}
 
 	h.Cursor.StoreVisualX()
 	h.lastLoc = mouseLoc
 	h.Relocate()
+	return true
+}
+
+func (h *BufPane) MouseDrag(e *tcell.EventMouse) bool {
+	mx, my := e.Position()
+	// ignore drag on the status line
+	if my >= h.BufView().Y+h.BufView().Height {
+		return false
+	}
+	h.Cursor.Loc = h.LocFromVisual(buffer.Loc{mx, my})
+
+	if h.tripleClick {
+		h.Cursor.AddLineToSelection()
+	} else if h.doubleClick {
+		h.Cursor.AddWordToSelection()
+	} else {
+		h.Cursor.SetSelectionEnd(h.Cursor.Loc)
+	}
+
+	h.Cursor.StoreVisualX()
+	h.Relocate()
+	return true
+}
+
+func (h *BufPane) MouseRelease(e *tcell.EventMouse) bool {
+	// We could finish the selection based on the release location as in the
+	// commented out code below, to allow text selections even in a terminal
+	// that doesn't support mouse motion events. But when the mouse click is
+	// within the scroll margin, that would cause a scroll and selection
+	// even for a simple mouse click, which is not good.
+	// if !h.doubleClick && !h.tripleClick {
+	// 	mx, my := e.Position()
+	// 	h.Cursor.Loc = h.LocFromVisual(buffer.Loc{mx, my})
+	// 	h.Cursor.SetSelectionEnd(h.Cursor.Loc)
+	// }
+
+	if h.Cursor.HasSelection() {
+		h.Cursor.CopySelection(clipboard.PrimaryReg)
+	}
 	return true
 }
 
@@ -1794,6 +1827,10 @@ func (h *BufPane) SpawnMultiCursorSelect() bool {
 func (h *BufPane) MouseMultiCursor(e *tcell.EventMouse) bool {
 	b := h.Buf
 	mx, my := e.Position()
+	// ignore click on the status line
+	if my >= h.BufView().Y+h.BufView().Height {
+		return false
+	}
 	mouseLoc := h.LocFromVisual(buffer.Loc{X: mx, Y: my})
 	c := buffer.NewCursor(b, mouseLoc)
 	b.AddCursor(c)

--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -201,11 +201,20 @@ modSearch:
 		}, true
 	}
 
+	var mstate MouseState = MousePress
+	if strings.HasSuffix(k, "Drag") {
+		k = k[:len(k)-4]
+		mstate = MouseDrag
+	} else if strings.HasSuffix(k, "Release") {
+		k = k[:len(k)-7]
+		mstate = MouseRelease
+	}
 	// See if we can find the key in bindingMouse
 	if code, ok := mouseEvents[k]; ok {
 		return MouseEvent{
-			btn: code,
-			mod: modifiers,
+			btn:   code,
+			mod:   modifiers,
+			state: mstate,
 		}, true
 	}
 

--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -443,14 +443,15 @@ func (h *BufPane) HandleEvent(event tcell.Event) {
 				mod:   metaToAlt(e.Modifiers()),
 				state: MousePress,
 			}
-			if len(h.mousePressed) > 0 {
-				me.state = MouseDrag
-			}
+			isDrag := len(h.mousePressed) > 0
 
 			if e.Buttons() & ^(tcell.WheelUp|tcell.WheelDown|tcell.WheelLeft|tcell.WheelRight) != tcell.ButtonNone {
 				h.mousePressed[me] = true
 			}
 
+			if isDrag {
+				me.state = MouseDrag
+			}
 			h.DoMouseEvent(me, e)
 		} else {
 			// Mouse event with no click - mouse was just released.

--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -325,6 +325,12 @@ func (h *BufPane) PluginCBRune(cb string, r rune) bool {
 	return b
 }
 
+func (h *BufPane) resetMouse() {
+	for me := range h.mousePressed {
+		delete(h.mousePressed, me)
+	}
+}
+
 // OpenBuffer opens the given buffer in this pane.
 func (h *BufPane) OpenBuffer(b *buffer.Buffer) {
 	h.Buf.Close()
@@ -335,9 +341,7 @@ func (h *BufPane) OpenBuffer(b *buffer.Buffer) {
 	h.initialRelocate()
 	// Set mouseReleased to true because we assume the mouse is not being
 	// pressed when the editor is opened
-	for me := range h.mousePressed {
-		delete(h.mousePressed, me)
-	}
+	h.resetMouse()
 	// Set isOverwriteMode to false, because we assume we are in the default
 	// mode when editor is opened
 	h.isOverwriteMode = false

--- a/internal/action/defaults_darwin.go
+++ b/internal/action/defaults_darwin.go
@@ -90,11 +90,13 @@ var bufdefaults = map[string]string{
 	"Esc": "Escape,Deselect,ClearInfo,RemoveAllMultiCursors,UnhighlightSearch",
 
 	// Mouse bindings
-	"MouseWheelUp":   "ScrollUp",
-	"MouseWheelDown": "ScrollDown",
-	"MouseLeft":      "MousePress",
-	"MouseMiddle":    "PastePrimary",
-	"Ctrl-MouseLeft": "MouseMultiCursor",
+	"MouseWheelUp":     "ScrollUp",
+	"MouseWheelDown":   "ScrollDown",
+	"MouseLeft":        "MousePress",
+	"MouseLeftDrag":    "MouseDrag",
+	"MouseLeftRelease": "MouseRelease",
+	"MouseMiddle":      "PastePrimary",
+	"Ctrl-MouseLeft":   "MouseMultiCursor",
 
 	"Alt-n":        "SpawnMultiCursor",
 	"AltShiftUp":   "SpawnMultiCursorUp",
@@ -173,8 +175,10 @@ var infodefaults = map[string]string{
 	"Esc": "AbortCommand",
 
 	// Mouse bindings
-	"MouseWheelUp":   "HistoryUp",
-	"MouseWheelDown": "HistoryDown",
-	"MouseLeft":      "MousePress",
-	"MouseMiddle":    "PastePrimary",
+	"MouseWheelUp":     "HistoryUp",
+	"MouseWheelDown":   "HistoryDown",
+	"MouseLeft":        "MousePress",
+	"MouseLeftDrag":    "MouseDrag",
+	"MouseLeftRelease": "MouseRelease",
+	"MouseMiddle":      "PastePrimary",
 }

--- a/internal/action/defaults_other.go
+++ b/internal/action/defaults_other.go
@@ -92,11 +92,13 @@ var bufdefaults = map[string]string{
 	"Esc": "Escape,Deselect,ClearInfo,RemoveAllMultiCursors,UnhighlightSearch",
 
 	// Mouse bindings
-	"MouseWheelUp":   "ScrollUp",
-	"MouseWheelDown": "ScrollDown",
-	"MouseLeft":      "MousePress",
-	"MouseMiddle":    "PastePrimary",
-	"Ctrl-MouseLeft": "MouseMultiCursor",
+	"MouseWheelUp":     "ScrollUp",
+	"MouseWheelDown":   "ScrollDown",
+	"MouseLeft":        "MousePress",
+	"MouseLeftDrag":    "MouseDrag",
+	"MouseLeftRelease": "MouseRelease",
+	"MouseMiddle":      "PastePrimary",
+	"Ctrl-MouseLeft":   "MouseMultiCursor",
 
 	"Alt-n":        "SpawnMultiCursor",
 	"Alt-m":        "SpawnMultiCursorSelect",
@@ -175,8 +177,10 @@ var infodefaults = map[string]string{
 	"Esc": "AbortCommand",
 
 	// Mouse bindings
-	"MouseWheelUp":   "HistoryUp",
-	"MouseWheelDown": "HistoryDown",
-	"MouseLeft":      "MousePress",
-	"MouseMiddle":    "PastePrimary",
+	"MouseWheelUp":     "HistoryUp",
+	"MouseWheelDown":   "HistoryDown",
+	"MouseLeft":        "MousePress",
+	"MouseLeftDrag":    "MouseDrag",
+	"MouseLeftRelease": "MouseRelease",
+	"MouseMiddle":      "PastePrimary",
 }

--- a/internal/action/events.go
+++ b/internal/action/events.go
@@ -100,11 +100,20 @@ func (k KeySequenceEvent) Name() string {
 	return buf.String()
 }
 
+type MouseState int
+
+const (
+	MousePress = iota
+	MouseDrag
+	MouseRelease
+)
+
 // MouseEvent is a mouse event with a mouse button and
 // any possible key modifiers
 type MouseEvent struct {
-	btn tcell.ButtonMask
-	mod tcell.ModMask
+	btn   tcell.ButtonMask
+	mod   tcell.ModMask
+	state MouseState
 }
 
 func (m MouseEvent) Name() string {
@@ -122,9 +131,17 @@ func (m MouseEvent) Name() string {
 		mod = "Ctrl-"
 	}
 
+	state := ""
+	switch m.state {
+	case MouseDrag:
+		state = "Drag"
+	case MouseRelease:
+		state = "Release"
+	}
+
 	for k, v := range mouseEvents {
 		if v == m.btn {
-			return fmt.Sprintf("%s%s", mod, k)
+			return fmt.Sprintf("%s%s%s", mod, k, state)
 		}
 	}
 	return ""

--- a/internal/action/tab.go
+++ b/internal/action/tab.go
@@ -161,6 +161,21 @@ func InitTabs(bufs []*buffer.Buffer) {
 			}
 		}
 	}
+
+	screen.RestartCallback = func() {
+		// The mouse could be released after the screen was stopped, so that
+		// we couldn't catch the mouse release event and would erroneously think
+		// that it is still pressed. So need to reset the mouse release state
+		// after the screen is restarted.
+		for _, t := range Tabs.List {
+			t.release = true
+			for _, p := range t.Panes {
+				if bp, ok := p.(*BufPane); ok {
+					bp.resetMouse()
+				}
+			}
+		}
+	}
 }
 
 func MainTab() *Tab {

--- a/internal/screen/screen.go
+++ b/internal/screen/screen.go
@@ -22,6 +22,10 @@ var Screen tcell.Screen
 // Events is the channel of tcell events
 var Events chan (tcell.Event)
 
+// RestartCallback is called when the screen is restarted after it was
+// temporarily shut down
+var RestartCallback func()
+
 // The lock is necessary since the screen is polled on a separate thread
 var lock sync.Mutex
 
@@ -134,6 +138,10 @@ func TempStart(screenWasNil bool) {
 	if !screenWasNil {
 		Init()
 		Unlock()
+
+		if RestartCallback != nil {
+			RestartCallback()
+		}
 	}
 }
 

--- a/runtime/help/keybindings.md
+++ b/runtime/help/keybindings.md
@@ -407,8 +407,14 @@ mouse actions)
 
 ```
 MouseLeft
+MouseLeftDrag
+MouseLeftRelease
 MouseMiddle
+MouseMiddleDrag
+MouseMiddleRelease
 MouseRight
+MouseRightDrag
+MouseRightRelease
 MouseWheelUp
 MouseWheelDown
 MouseWheelLeft
@@ -520,11 +526,13 @@ conventions for text editing defaults.
     "Esc": "Escape",
 
     // Mouse bindings
-    "MouseWheelUp":   "ScrollUp",
-    "MouseWheelDown": "ScrollDown",
-    "MouseLeft":      "MousePress",
-    "MouseMiddle":    "PastePrimary",
-    "Ctrl-MouseLeft": "MouseMultiCursor",
+    "MouseWheelUp":     "ScrollUp",
+    "MouseWheelDown":   "ScrollDown",
+    "MouseLeft":        "MousePress",
+    "MouseLeftDrag":    "MouseDrag",
+    "MouseLeftRelease": "MouseRelease",
+    "MouseMiddle":      "PastePrimary",
+    "Ctrl-MouseLeft":   "MouseMultiCursor",
 
     "Alt-n":        "SpawnMultiCursor",
     "AltShiftUp":   "SpawnMultiCursorUp",
@@ -629,10 +637,12 @@ are given below:
         "Esc": "AbortCommand",
 
         // Mouse bindings
-        "MouseWheelUp":   "HistoryUp",
-        "MouseWheelDown": "HistoryDown",
-        "MouseLeft":      "MousePress",
-        "MouseMiddle":    "PastePrimary"
+        "MouseWheelUp":     "HistoryUp",
+        "MouseWheelDown":   "HistoryDown",
+        "MouseLeft":        "MousePress",
+        "MouseLeftDrag":    "MouseDrag",
+        "MouseLeftRelease": "MouseRelease",
+        "MouseMiddle":      "PastePrimary"
     }
 }
 ```


### PR DESCRIPTION
Introduce separate mouse release and mouse drag (move while pressed) events: `MouseLeftRelease`, `MouseLeftDrag`, `MouseRightRelease` etc, to allow binding them to actions independently from mouse press events (MouseLeft, MouseRight etc).

This PR:

- Makes it possible to handle mouse release and drag for arbitrary mouse events and actions (including Lua actions), not just for MouseLeft event and its default MousePress action as in the current code.

- Fixes issue #2599 with PastePrimary and MouseMultiCursor actions: selection is pasted not only when pressing MouseMiddle but also when moving mouse with MouseMiddle pressed; similarly, a new multicursor is added not only when pressing Ctrl-MouseLeft but also when moving mouse with Ctrl-MouseLeft pressed.

My initial approach was not to introduce new events for mouse release and mouse drag but to pass "mouse released" info to action functions in addition to *tcell.EventMouse to let the action functions do the necessary checks (similarly to what MousePress is already doing). But then I realized it was a bad idea, since we still want to be able also to bind mouse events to regular key actions (such as PastePrimary) which don't care about mouse event info.

Fixes #1791 (together with PR #2605)
Fixes #2599 