### PR TITLE
Minor: fix weird error message text when unable to load help

### DIFF
--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -375,7 +375,7 @@ func (h *BufPane) ReopenCmd(args []string) {
 
 func (h *BufPane) openHelp(page string) error {
 	if data, err := config.FindRuntimeFile(config.RTHelp, page).Data(); err != nil {
-		return errors.New(fmt.Sprint("Unable to load help text", page, "\n", err))
+		return errors.New(fmt.Sprintf("Unable to load help text for %s: %v", page, err))
 	} else {
 		helpBuffer := buffer.NewBufferFromString(string(data), page+".md", buffer.BTHelp)
 		helpBuffer.SetName("Help " + page)


### PR DESCRIPTION
If we add something like this to init.lua:

```
   config.AddRuntimeFile("status", config.RTHelp, "help/foo.md")
```

then start micro and run "help foo", the resulting error message looks weird:

```
   Unable to load help textfooopen plugins/status/help/foo.md: file does not exist
```

Change it to:

```
   Unable to load help text for foo: open plugins/status/help/foo.md: file does not exist
```