### PR TITLE
Add reload setting

### DIFF
--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -330,20 +330,39 @@ func (h *BufPane) Name() string {
 	return n
 }
 
+func (h *BufPane) getReloadSetting() string {
+	reloadSetting := h.Buf.Settings["reload"]
+
+	if reloadSetting == nil {
+		return "prompt"
+	}
+
+	return reloadSetting.(string)
+}
+
 // HandleEvent executes the tcell event properly
 func (h *BufPane) HandleEvent(event tcell.Event) {
 	if h.Buf.ExternallyModified() && !h.Buf.ReloadDisabled {
-		InfoBar.YNPrompt("The file on disk has changed. Reload file? (y,n,esc)", func(yes, canceled bool) {
-			if canceled {
-				h.Buf.DisableReload()
-			}
-			if !yes || canceled {
-				h.Buf.UpdateModTime()
-			} else {
-				h.Buf.ReOpen()
-			}
-		})
+		reload := h.getReloadSetting()
 
+		if reload == "prompt" {
+			InfoBar.YNPrompt("The file on disk has changed. Reload file? (y,n,esc)", func(yes, canceled bool) {
+				if canceled {
+					h.Buf.DisableReload()
+				}
+				if !yes || canceled {
+					h.Buf.UpdateModTime()
+				} else {
+					h.Buf.ReOpen()
+				}
+			})
+		} else if (reload == "auto") {
+			h.Buf.ReOpen()
+		} else if (reload == "disabled") {
+			h.Buf.DisableReload()
+		} else {
+			InfoBar.Message("Invalid reload setting")
+		}
 	}
 
 	switch e := event.(type) {


### PR DESCRIPTION
Can be set to:

* auto - Automatically reload files that changed
* disabled - Do not reload files
* prompt - Prompt the user about reloading the file.

I added this because I have to accept the reload prompt frequently. I have tooling that runs behind the scenes outside micro.

With this I can set `reload` to `auto` so that it doesn't prompt me, just does it.
