### PR TITLE
Improve buffer view relocation after jumping to a far-away location

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -879,11 +879,10 @@ func (h *BufPane) Search(str string, useRegex bool, searchDown bool) error {
 		h.Cursor.SetSelectionEnd(match[1])
 		h.Cursor.OrigSelection[0] = h.Cursor.CurSelection[0]
 		h.Cursor.OrigSelection[1] = h.Cursor.CurSelection[1]
-		h.Cursor.GotoLoc(h.Cursor.CurSelection[1])
+		h.GotoLoc(h.Cursor.CurSelection[1])
 		h.Buf.LastSearch = str
 		h.Buf.LastSearchRegex = useRegex
 		h.Buf.HighlightSearch = h.Buf.Settings["hlsearch"].(bool)
-		h.Relocate()
 	} else {
 		h.Cursor.ResetSelection()
 	}
@@ -905,12 +904,11 @@ func (h *BufPane) find(useRegex bool) bool {
 				h.Cursor.SetSelectionEnd(match[1])
 				h.Cursor.OrigSelection[0] = h.Cursor.CurSelection[0]
 				h.Cursor.OrigSelection[1] = h.Cursor.CurSelection[1]
-				h.Cursor.GotoLoc(match[1])
+				h.GotoLoc(match[1])
 			} else {
-				h.Cursor.GotoLoc(h.searchOrig)
+				h.GotoLoc(h.searchOrig)
 				h.Cursor.ResetSelection()
 			}
-			h.Relocate()
 		}
 	}
 	findCallback := func(resp string, canceled bool) {
@@ -925,7 +923,7 @@ func (h *BufPane) find(useRegex bool) bool {
 				h.Cursor.SetSelectionEnd(match[1])
 				h.Cursor.OrigSelection[0] = h.Cursor.CurSelection[0]
 				h.Cursor.OrigSelection[1] = h.Cursor.CurSelection[1]
-				h.Cursor.GotoLoc(h.Cursor.CurSelection[1])
+				h.GotoLoc(h.Cursor.CurSelection[1])
 				h.Buf.LastSearch = resp
 				h.Buf.LastSearchRegex = useRegex
 				h.Buf.HighlightSearch = h.Buf.Settings["hlsearch"].(bool)
@@ -936,7 +934,6 @@ func (h *BufPane) find(useRegex bool) bool {
 		} else {
 			h.Cursor.ResetSelection()
 		}
-		h.Relocate()
 	}
 	pattern := string(h.Cursor.GetSelection())
 	if eventCallback != nil && pattern != "" {
@@ -980,11 +977,10 @@ func (h *BufPane) FindNext() bool {
 		h.Cursor.SetSelectionEnd(match[1])
 		h.Cursor.OrigSelection[0] = h.Cursor.CurSelection[0]
 		h.Cursor.OrigSelection[1] = h.Cursor.CurSelection[1]
-		h.Cursor.Loc = h.Cursor.CurSelection[1]
+		h.GotoLoc(h.Cursor.CurSelection[1])
 	} else {
 		h.Cursor.ResetSelection()
 	}
-	h.Relocate()
 	return true
 }
 
@@ -1007,11 +1003,10 @@ func (h *BufPane) FindPrevious() bool {
 		h.Cursor.SetSelectionEnd(match[1])
 		h.Cursor.OrigSelection[0] = h.Cursor.CurSelection[0]
 		h.Cursor.OrigSelection[1] = h.Cursor.CurSelection[1]
-		h.Cursor.Loc = h.Cursor.CurSelection[1]
+		h.GotoLoc(h.Cursor.CurSelection[1])
 	} else {
 		h.Cursor.ResetSelection()
 	}
-	h.Relocate()
 	return true
 }
 

--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -13,6 +13,7 @@ import (
 	"github.com/zyedidia/micro/v2/internal/display"
 	ulua "github.com/zyedidia/micro/v2/internal/lua"
 	"github.com/zyedidia/micro/v2/internal/screen"
+	"github.com/zyedidia/micro/v2/internal/util"
 	"github.com/zyedidia/tcell/v2"
 )
 
@@ -309,6 +310,26 @@ func (h *BufPane) OpenBuffer(b *buffer.Buffer) {
 	// mode when editor is opened
 	h.isOverwriteMode = false
 	h.lastClickTime = time.Time{}
+}
+
+// GotoLoc moves the cursor to a new location and adjusts the view accordingly.
+// Use GotoLoc when the new location may be far away from the current location.
+func (h *BufPane) GotoLoc(loc buffer.Loc) {
+	sloc := h.SLocFromLoc(loc)
+	d := h.Diff(h.SLocFromLoc(h.Cursor.Loc), sloc)
+
+	h.Cursor.GotoLoc(loc)
+
+	// If the new location is far away from the previous one,
+	// ensure the cursor is at 25% of the window height
+	height := h.BufView().Height
+	if util.Abs(d) >= height {
+		v := h.GetView()
+		v.StartLine = h.Scroll(sloc, -height/4)
+		h.ScrollAdjust()
+		v.StartCol = 0
+	}
+	h.Relocate()
 }
 
 // ID returns this pane's split id.

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -722,7 +722,7 @@ func (h *BufPane) GotoCmd(args []string) {
 			}
 			line = util.Clamp(line-1, 0, h.Buf.LinesNum()-1)
 			col = util.Clamp(col-1, 0, util.CharacterCount(h.Buf.LineBytes(line)))
-			h.Cursor.GotoLoc(buffer.Loc{col, line})
+			h.GotoLoc(buffer.Loc{col, line})
 		} else {
 			line, err := strconv.Atoi(args[0])
 			if err != nil {
@@ -733,9 +733,8 @@ func (h *BufPane) GotoCmd(args []string) {
 				line = h.Buf.LinesNum() + 1 + line
 			}
 			line = util.Clamp(line-1, 0, h.Buf.LinesNum()-1)
-			h.Cursor.GotoLoc(buffer.Loc{0, line})
+			h.GotoLoc(buffer.Loc{0, line})
 		}
-		h.Relocate()
 	}
 }
 
@@ -834,12 +833,10 @@ func (h *BufPane) ReplaceCmd(args []string) {
 
 			h.Cursor.SetSelectionStart(locs[0])
 			h.Cursor.SetSelectionEnd(locs[1])
-			h.Cursor.GotoLoc(locs[0])
+			h.GotoLoc(locs[0])
 			h.Buf.LastSearch = search
 			h.Buf.LastSearchRegex = true
 			h.Buf.HighlightSearch = h.Buf.Settings["hlsearch"].(bool)
-
-			h.Relocate()
 
 			InfoBar.YNPrompt("Perform replacement (y,n,esc)", func(yes, canceled bool) {
 				if !canceled && yes {


### PR DESCRIPTION
When the cursor is moved to a location which is far away (e.g. after a search, a goto line, or when opening a file at a given line), the view is always relocated in such a way that the cursor is at the bottom or at the top (minus scrollmargin), i.e. as if we just scrolled to this location. It's not like in other editors, and IMHO it's annoying. When we jump to a new location far away, we usually want to see more of its context, so the cursor should be placed closer to the center of the view, not near its edges. Certainly not near the bottom.

So this PR implements the behavior similar to other editors:

- If the distance between the new and the old location is less than one frame (i.e. the view either doesn't change or just slightly "shifts") then the current behavior remains unchanged.
- Otherwise the current line is placed at 25% of the window height.

Similarly, when opening a file at a given location, if this location is less than one frame away from the beginning of the file, then keep the current behavior, otherwise this initial location is placed at 25% of the window height.

As a bonus, this PR also fixes issue #1800: `onBufPaneOpen` lua callback called prematurely when the bufpane is not fully initialized yet.

Fixes #1790 
Fixes #1800 
