### PR TITLE
Fix incorrect LastVisualX after changing bufWidth w/o resize

### DIFF
--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -53,8 +53,10 @@ func (w *BufWindow) SetBuffer(b *buffer.Buffer) {
 			} else {
 				w.StartLine.Row = 0
 			}
-			w.Relocate()
+		}
 
+		if option == "softwrap" || option == "wordwrap" {
+			w.Relocate()
 			for _, c := range w.Buf.GetCursors() {
 				c.LastVisualX = c.GetVisualX()
 			}

--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -81,12 +81,6 @@ func (w *BufWindow) Resize(width, height int) {
 	w.updateDisplayInfo()
 
 	w.Relocate()
-
-	if w.Buf.Settings["softwrap"].(bool) {
-		for _, c := range w.Buf.GetCursors() {
-			c.LastVisualX = c.GetVisualX()
-		}
-	}
 }
 
 // SetActive marks the window as active.
@@ -150,9 +144,17 @@ func (w *BufWindow) updateDisplayInfo() {
 		w.gutterOffset += w.maxLineNumLength + 1
 	}
 
+	prevBufWidth := w.bufWidth
+
 	w.bufWidth = w.Width - w.gutterOffset
 	if w.Buf.Settings["scrollbar"].(bool) && w.Buf.LinesNum() > w.Height {
 		w.bufWidth--
+	}
+
+	if w.bufWidth != prevBufWidth && w.Buf.Settings["softwrap"].(bool) {
+		for _, c := range w.Buf.GetCursors() {
+			c.LastVisualX = c.GetVisualX()
+		}
 	}
 }
 


### PR DESCRIPTION
When we resize a buffer pane with `softwrap` enabled, we update the cursors `LastVisualX` values to ensure that moving cursor up or down within a wrapped line will move the cursor to the correct location. The problem is that we need to do it also in cases when the visual buffer width within the buffer window is changing without resizing the window itself, e.g. when toggling the ruler on/off.

So update `LastVisualX` whenever the buffer width changes, not neccesarily as a result of resizing the buffer window.