### PR TITLE
Add `hidecursor` option

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -269,6 +269,7 @@ var defaultCommonSettings = map[string]interface{}{
 	"fastdirty":      false,
 	"fileformat":     "unix",
 	"filetype":       "unknown",
+	"hidecursor":     false,
 	"hlsearch":       false,
 	"incsearch":      true,
 	"ignorecase":     true,
@@ -347,6 +348,7 @@ var DefaultGlobalOnlySettings = map[string]interface{}{
 // a list of settings that should never be globally modified
 var LocalSettings = []string{
 	"filetype",
+	"hidecursor",
 	"readonly",
 }
 

--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -560,7 +560,7 @@ func (w *BufWindow) displayBuffer() {
 
 				screen.SetContent(w.X+vloc.X, w.Y+vloc.Y, r, combc, style)
 
-				if showcursor {
+				if showcursor && !b.Settings["hidecursor"].(bool) {
 					for _, c := range cursors {
 						if c.X == bloc.X && c.Y == bloc.Y && !c.HasSelection() {
 							w.showCursor(w.X+vloc.X, w.Y+vloc.Y, c.Num == 0)

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -159,6 +159,11 @@ Here are the available options:
 	default value: `unknown`. This will be automatically overridden depending
     on the file you open.
 
+* `hidecursor`: don't display the cursor. This option is useful mainly for
+   plugins. This option is local only.
+
+	default value: `false`
+
 * `hlsearch`: highlight all instances of the searched text after a successful
    search. This highlighting can be temporarily turned off via the
    `UnhighlightSearch` action (triggered by the Esc key by default) or toggled


### PR DESCRIPTION
Add `hidecursor` option for disabling displaying the cursor in the current buffer. This option is useful for plugins that may want to disable displaying the cursor for a readonly buffer in various cases.

I'm using this option in my `viewmode` plugin (I'm yet to clean up and upload it) which allows using Micro as a `less`-like pager. The absence of cursor serves as an easy indication for the user that the current buffer is in "viewer" mode and cannot be edited.