### PR TITLE
Improve Julia syntax highlighting

### DIFF
--- a/runtime/syntax/julia.yaml
+++ b/runtime/syntax/julia.yaml
@@ -39,13 +39,12 @@ rules:
         rules:
             - constant.specialChar: "\\\\([\"'abfnrtv\\\\]|[0-3]?[0-7]{1,2}|x[0-9A-Fa-f]{1,2}|u[0-9A-Fa-f]{1,4}|U[0-9A-Fa-f]{1,8})"
 
+    # Lifted from Rust's syntax highlighting
+    - constant.string: "'(\\\\.|.)'"
     - constant.string:
-        start: "'"
+        start: "'\""
         end: "'"
-        skip: "\\\\."
-        rules:
-            - error: "..+"
-            - constant.specialChar: "\\\\([\"'abfnrtv\\\\]|[0-3]?[0-7]{1,2}|x[0-9A-Fa-f]{1,2}|u[0-9A-Fa-f]{1,4}|U[0-9A-Fa-f]{1,8})"
+        rules: []
 
     - comment:
         start: "#="


### PR DESCRIPTION
Specifically, do not allow multiline single-quote strings, which are not a thing in Julia. The existing rule broke when adjoints were used, such as `b = a'`.
The syntax rules have been copied from Rust, which also uses single ticks for character literals, and also uses the ' symbol for things unrelated to chars.