### PR TITLE
util.HttpRequest helper to make requests with headers

### DIFF
--- a/cmd/micro/initlua.go
+++ b/cmd/micro/initlua.go
@@ -150,6 +150,7 @@ func luaImportMicroUtil() *lua.LTable {
 	ulua.L.SetField(pkg, "Unzip", luar.New(ulua.L, util.Unzip))
 	ulua.L.SetField(pkg, "Version", luar.New(ulua.L, util.Version))
 	ulua.L.SetField(pkg, "SemVersion", luar.New(ulua.L, util.SemVersion))
+	ulua.L.SetField(pkg, "HttpRequest", luar.New(ulua.L, util.HttpRequest))
 	ulua.L.SetField(pkg, "CharacterCountInString", luar.New(ulua.L, util.CharacterCountInString))
 	ulua.L.SetField(pkg, "RuneStr", luar.New(ulua.L, func(r rune) string {
 		return string(r)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -492,4 +493,17 @@ func Unzip(src, dest string) error {
 	}
 
 	return nil
+}
+
+// HttpRequest returns a new http.Client for making custom requests (for lua plugins)
+func HttpRequest(method string, url string, headers []string) (resp *http.Response, err error) {
+	client := http.Client{}
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	for i := 0; i < len(headers); i += 2 {
+		req.Header.Add(headers[i], headers[i+1])
+	}
+	return client.Do(req)
 }

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -287,6 +287,7 @@ The packages and functions are listed below (in Go type signatures):
     - `String(b []byte) string`: converts a byte array to a string.
     - `RuneStr(r rune) string`: converts a rune to a string.
     - `Unzip(src, dest string) error`: unzips a file to given folder.
+    - `HttpRequest(method string, url string, headers []string) (http.Response, error)`: makes a http request.
 
 This may seem like a small list of available functions but some of the objects
 returned by the functions have many methods. The Lua plugin may access any


### PR DESCRIPTION
Adding on to #1917, to modify headers when making http requests a helper is necessary. We can already access `http.Client` in Lua plugins, but we can't create the new client because `http.Client{}` is valid Go but not valid Lua.