### PR TITLE
Add -multimode to open multiple files into split.

### DIFF
--- a/internal/action/tab.go
+++ b/internal/action/tab.go
@@ -148,7 +148,19 @@ func (t *TabList) Display() {
 var Tabs *TabList
 
 func InitTabs(bufs []*buffer.Buffer) {
-	Tabs = NewTabList(bufs)
+	multiMode := config.GetGlobalOption("multimode").(string)
+	if multiMode == "tab" {
+		Tabs = NewTabList(bufs)
+	} else {
+		Tabs = NewTabList(bufs[:1])
+		for _, b := range bufs[1:] {
+			if multiMode == "vsplit" {
+				MainTab().CurPane().VSplitBuf(b)
+			} else {  // default hsplit
+				MainTab().CurPane().HSplitBuf(b)
+			}
+		}
+	}
 }
 
 func MainTab() *Tab {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -51,6 +51,7 @@ var optionValidators = map[string]optionValidator{
 	"colorcolumn":  validateNonNegativeValue,
 	"fileformat":   validateLineEnding,
 	"encoding":     validateEncoding,
+	"multimode":    validateMultiMode,
 }
 
 func ReadSettings() error {
@@ -333,6 +334,7 @@ var DefaultGlobalOnlySettings = map[string]interface{}{
 	"infobar":        true,
 	"keymenu":        false,
 	"mouse":          true,
+	"multimode":      "tab",
 	"parsecursor":    false,
 	"paste":          false,
 	"pluginchannels": []string{"https://raw.githubusercontent.com/micro-editor/plugin-channel/master/channel.json"},
@@ -490,4 +492,20 @@ func validateLineEnding(option string, value interface{}) error {
 func validateEncoding(option string, value interface{}) error {
 	_, err := htmlindex.Get(value.(string))
 	return err
+}
+
+func validateMultiMode(option string, value interface{}) error {
+	val, ok := value.(string)
+
+	if !ok {
+		return errors.New("Expected string type for multimode")
+	}
+
+	switch val {
+	case "tab", "hsplit", "vsplit":
+	default:
+		return errors.New(option + " must be 'tab', 'hsplit', or 'vsplit'")
+	}
+
+	return nil
 }

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -223,6 +223,15 @@ Here are the available options:
 
 	default value: `true`
 
+* `multimode`: specifies how to layout multiple files opened at startup.
+   Most useful as a command-line option, like `-multimode vsplit`. Possible
+   values correspond to commands (see `> help commands`) that open files:
+    * `tab`: open each file in a separate tab.
+    * `vsplit`: open files side-by-side.
+    * `hsplit`: open files stacked top to bottom.
+
+	default value: `tab`
+
 * `paste`: treat characters sent from the terminal in a single chunk as a paste
    event rather than a series of manual key presses. If you are pasting using
    the terminal keybinding (not Ctrl-v, which is micro's default paste


### PR DESCRIPTION
Adds config option `multimode`, which takes values `tab`, `vsplit`, or `hsplit` (corresponding to the file-opening commands). I mean to use it with a command line like

    micro -multimode vsplit foo.h foo.c

to open files in a side-by-side split, but if one really wanted to one could set it in the config file to change the default behavior of opening multiple files in tabs.

Closes #2300.

(@nklsfrt mentioned making micro usable as $DIFFPROG, but I haven't thought at all about diff-specific features like synced scrolling. And in particular this feature falls short of being able to open [vimdiff-like git mergetool panes](https://git-scm.com/docs/vimdiff/en) at startup, but it's still useful to me as written.)