### PR TITLE
Add a current line removal plugin

### DIFF
--- a/runtime/plugins/removeline/help/removeline.md
+++ b/runtime/plugins/removeline/help/removeline.md
@@ -1,0 +1,20 @@
+# Remove Line Plugin
+
+The removeline plugin provides current line removal functionality.
+The default binding to remove a line is `Ctrl-Delete`. You can easily modify that in your `bindings.json`
+file:
+
+```json
+{
+    "Ctrl-Delete": "removeline.removeline"
+}
+```
+
+You can also execute a command which will do the same thing as
+the binding:
+
+```
+> removeline
+```
+
+The plugin will override your selection upon execution.

--- a/runtime/plugins/removeline/removeline.lua
+++ b/runtime/plugins/removeline/removeline.lua
@@ -1,0 +1,16 @@
+VERSION = "1.0.0"
+
+local config = import("micro/config")
+
+function removeline(bp, args)
+	bp.Cursor.SelectLine(bp.Cursor)
+	bp.Cursor.DeleteSelection(bp.Cursor)
+end
+
+function init()
+    config.MakeCommand("removeline", removeline, config.NoComplete)
+    config.TryBindKey("Ctrl-Delete", "lua:removeline.removeline", false)
+    config.AddRuntimeFile("removeline", config.RTHelp, "help/removeline.md")
+end
+
+return true


### PR DESCRIPTION
Lack of the Ctrl-Delete shortcut found in VSCode and alike really bugs me. This plugin provides the (in my opinion) missing functionality with minimal potential interference with other plugins and such.