### PR TITLE
Prompt on save/ existing file

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -793,9 +793,12 @@ func (h *BufPane) SaveAsCB(action string, callback func()) bool {
 			filename := strings.Join(args, " ")
 			fileinfo, err := os.Stat(filename)
 			if err != nil {
-				noPrompt := h.saveBufToFile(filename, action, callback)
-				if noPrompt {
-					h.completeAction(action)
+				if os.IsNotExist(err) {
+					noPrompt := h.saveBufToFile(filename, action, callback)
+					if noPrompt {
+						h.completeAction(action)
+						return
+					}
 				}
 			}
 			InfoBar.YNPrompt(
@@ -811,7 +814,6 @@ func (h *BufPane) SaveAsCB(action string, callback func()) bool {
 			)
 		}
 	})
-
 	return false
 }
 

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -791,12 +791,27 @@ func (h *BufPane) SaveAsCB(action string, callback func()) bool {
 				return
 			}
 			filename := strings.Join(args, " ")
-			noPrompt := h.saveBufToFile(filename, action, callback)
-			if noPrompt {
-				h.completeAction(action)
+			fileinfo, err := os.Stat(filename)
+			if err != nil {
+				noPrompt := h.saveBufToFile(filename, action, callback)
+				if noPrompt {
+					h.completeAction(action)
+				}
 			}
+			InfoBar.YNPrompt(
+				fmt.Sprintf("the file %s already exists in the directory, would you like to overwrite? Y/n", fileinfo.Name()),
+				func(yes, canceled bool) {
+					if yes && !canceled {
+						noPrompt := h.saveBufToFile(filename, action, callback)
+						if noPrompt {
+							h.completeAction(action)
+						}
+					}
+				},
+			)
 		}
 	})
+
 	return false
 }
 


### PR DESCRIPTION
Adds YNprompt when user tries save newly created file as existing file name in current directory.
https://github.com/zyedidia/micro/issues/2709

Saves fine if file does exist with prompt as intended and fine if file doesn't exist. Now just testing for other errors os.stat could throw. I am new so please excuse any seemingly obvious mistakes