### PR TITLE
fix some values in `help/options.md`

### DIFF
--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -378,11 +378,11 @@ Here are the available options:
 * `tabhighlight`: inverts the tab characters' (filename, save indicator, etc)
   colors with respect to the tab bar.
 
-	default value: false
+	default value: `false`
 
 * `tabreverse`: reverses the tab bar colors when active.
 
-	default value: true
+	default value: `true`
 
 * `tabsize`: the size in spaces that a tab character should be displayed with.
 


### PR DESCRIPTION
In the `help/options.md` file are some brackets \` missing around values. 