### PR TITLE
fix unsigned int not highlighted in C

### DIFF
--- a/runtime/syntax/c.yaml
+++ b/runtime/syntax/c.yaml
@@ -20,7 +20,7 @@ rules:
     - symbol.operator: "([.:;,+*|=!\\%]|<|>|/|-|&)"
     - symbol.brackets: "[(){}]|\\[|\\]"
       # Integer Constants
-    - constant.number: "(\\b([1-9][0-9]*|0[0-7]*|0[Xx][0-9A-Fa-f]+|0[Bb][01]+)([Uu]?[Ll][Ll]?|[Ll][Ll]?[Uu]?)?\\b)"
+    - constant.number: "(\\b([1-9][0-9]*|0[0-7]*|0[Xx][0-9A-Fa-f]+|0[Bb][01]+)([Uu][Ll]?[Ll]?|[Ll][Ll]?[Uu]?)?\\b)"
       # Decimal Floating Constants
     - constant.number: "(\\b(([0-9]*[.][0-9]+|[0-9]+[.][0-9]*)([Ee][+-]?[0-9]+)?|[0-9]+[Ee][+-]?[0-9]+)[FfLl]?\\b)"
       # Hexadecimal Floating Constants


### PR DESCRIPTION
This fixes that usigned integers in C like `500U` are not highlighted.