### PR TITLE
Update help.md for windows users

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -698,6 +698,20 @@ func (h *BufPane) OutdentSelection() bool {
 	}
 	return false
 }
+func (h *BufPane) SelectToClick(e *tcell.EventMouse) bool {
+	mx, my := e.Position()
+	mouseLoc := h.LocFromVisual(buffer.Loc{mx, my})
+
+	if h.mouseReleased {
+		h.Cursor.Loc = mouseLoc
+		h.Cursor.OrigSelection[0] = h.Cursor.Loc
+		h.Cursor.SetSelectionStart(h.Cursor.Loc)
+		h.mouseReleased = false
+	} else if !h.mouseReleased {
+		h.Cursor.SetSelectionEnd(mouseLoc)
+	}
+	return true
+}
 
 // Autocomplete cycles the suggestions and performs autocompletion if there are suggestions
 func (h *BufPane) Autocomplete() bool {

--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -789,6 +789,7 @@ var BufKeyActions = map[string]BufKeyAction{
 var BufMouseActions = map[string]BufMouseAction{
 	"MousePress":       (*BufPane).MousePress,
 	"MouseMultiCursor": (*BufPane).MouseMultiCursor,
+	"SelectToClick":    (*BufPane).SelectToClick,
 }
 
 // MultiActions is a list of actions that should be executed multiple

--- a/internal/action/defaults_other.go
+++ b/internal/action/defaults_other.go
@@ -179,4 +179,5 @@ var infodefaults = map[string]string{
 	"MouseWheelDown": "HistoryDown",
 	"MouseLeft":      "MousePress",
 	"MouseMiddle":    "PastePrimary",
+	"ShiftMouseLeft": "SelectToClick",
 }

--- a/runtime/help/help.md
+++ b/runtime/help/help.md
@@ -29,6 +29,10 @@ colors`.
 Press Ctrl-w to move between splits, and type `> vsplit filename` or
 `> hsplit filename` to open a new split.
 
+* Windows Users: When entering commands into Micro such as changing directories
+or opening files, make sure not to end the command or file name with an escape
+character (backslash). Please forward slashes in Micro to avoid unusual behavior.
+
 ## Accessing more help
 
 Micro has a built-in help system which can be accessed with the `> help` command.


### PR DESCRIPTION
Not normally one for trivial MD pull requests but Micro does crash every time a command ends with a backslash in Windows. https://github.com/zyedidia/micro/issues/2666
I cannot see an efficient way to alter go-shellquote to fix this so may as well at least just include a warning.