### PR TITLE
add `restrict` to C syntax

### DIFF
--- a/runtime/syntax/c.yaml
+++ b/runtime/syntax/c.yaml
@@ -9,7 +9,7 @@ rules:
     - type: "\\b((s?size)|((u_?)?int(8|16|32|64|ptr)))_t\\b"
     - type: "\\b[a-z_][0-9a-z_]+(_t|_T)\\b"
     - type.extended: "\\b(bool)\\b"
-    - statement: "\\b(volatile|register)\\b"
+    - statement: "\\b(volatile|register|restrict)\\b"
     - statement: "\\b(for|if|while|do|else|case|default|switch)\\b"
     - statement: "\\b(goto|continue|break|return)\\b"
     - preproc: "^[[:space:]]*#[[:space:]]*(define|pragma|include|(un|ifn?)def|endif|el(if|se)|if|warning|error)"


### PR DESCRIPTION
This adds the [`restrict`](https://en.wikipedia.org/wiki/Restrict) keyword in C to the syntax highlighting.