### PR TITLE
Make the commenttype option useful

### DIFF
--- a/runtime/plugins/comment/comment.lua
+++ b/runtime/plugins/comment/comment.lua
@@ -60,11 +60,17 @@ ft["zig"] = "// %s"
 ft["zscript"] = "// %s"
 ft["zsh"] = "# %s"
 
+local last_ft
+
 function updateCommentType(buf)
-    if ft[buf.Settings["filetype"]] ~= nil and ft[buf.Settings["filetype"]] ~= nil then
-        buf.Settings["commenttype"] = ft[buf.Settings["filetype"]]
-    elseif buf.Settings["commenttype"] == nil then
-        buf.Settings["commenttype"] = "# %s"
+    if buf.Settings["commenttype"] == nil or last_ft ~= buf.Settings["filetype"] then
+        if ft[buf.Settings["filetype"]] ~= nil then
+            buf.Settings["commenttype"] = ft[buf.Settings["filetype"]]
+        else
+            buf.Settings["commenttype"] = "# %s"
+        end
+
+        last_ft = buf.Settings["filetype"]
     end
 end
 


### PR DESCRIPTION
There was a bug with the `comment` plugin where the `commenttype` option would be overwritten whenever a line was commented.

However a user should be able to configure their own type of comment as an option. As is explained in the [comment plugin documentation](https://github.com/zyedidia/micro/blob/master/runtime/plugins/comment/help/comment.md?plain=1#L81-L96). Currently this value gets overwritten and is thus useless.

I changed it so that the `commenttype` option only gets updated when it's not set or the filetype has changed.