### PR TITLE
remove `syntax_checker.go` from docs

### DIFF
--- a/runtime/syntax/README.md
+++ b/runtime/syntax/README.md
@@ -5,11 +5,6 @@ Here are micro's syntax files.
 Each yaml file specifies how to detect the filetype based on file extension or headers (first line of the file).
 Then there are patterns and regions linked to highlight groups which tell micro how to highlight that filetype.
 
-Making your own syntax files is very simple. I recommend you check the file after you are finished with the
-[`syntax_checker.go`](./syntax_checker.go) program (located in this directory). Just place your yaml syntax
-file in the current directory and run `go run syntax_checker.go` and it will check every file. If there are no
-errors it will print `No issues!`.
-
 You can read more about how to write syntax files (and colorschemes) in the [colors](../help/colors.md) documentation.
 
 # Legacy '.micro' filetype


### PR DESCRIPTION
Since the `syntax_checker.go` was removed in [this](https://github.com/zyedidia/micro/commit/fe3186ba9dba176fd3f8a5513c16a1895d62bc2b) commit I removed the mention in the docs here.

Somebody should look if this file should really be excluded since it sounds usefull.