### PR TITLE
remove extra space in doc

### DIFF
--- a/runtime/help/keybindings.md
+++ b/runtime/help/keybindings.md
@@ -95,7 +95,7 @@ you could rebind `Ctrl-g` to `> help`:
 
 ```json
 {
-    "Ctrl-g": "command-edit:help "
+    "Ctrl-g": "command-edit:help"
 }
 ```
 


### PR DESCRIPTION
This removes an extra space from the help documents.