### PR TITLE
json doesn't need to start with `{`

### DIFF
--- a/runtime/syntax/json.yaml
+++ b/runtime/syntax/json.yaml
@@ -2,7 +2,6 @@ filetype: json
 
 detect:
     filename: "\\.json$"
-    header: "^\\{$"
 
 rules:
     - constant.number: "\\b[-+]?([1-9][0-9]*|0[0-7]*|0x[0-9a-fA-F]+)([uU][lL]?|[lL][uU]?)?\\b"


### PR DESCRIPTION
JSON doesn't need to have an object at the root level.
This is completely valid JSON.
```json
[1]
```

Besides that I think the restriction doesn't work. It highlights correctly.