### PR TITLE
fix json unicode escape highlighting

### DIFF
--- a/runtime/syntax/json.yaml
+++ b/runtime/syntax/json.yaml
@@ -15,13 +15,10 @@ rules:
         end: "\""
         skip: "\\\\."
         rules:
-            - constant.specialChar: "\\\\."
+            - constant.specialChar: "\\\\(u[0-9a-fA-F]{4}|.)"
     - constant.string:
         start: "'"
         end: "'"
         skip: "\\\\."
         rules:
-            - constant.specialChar: "\\\\."
-
-    - statement: "\\\"(\\\\\"|[^\"])*\\\"[[:space:]]*:\"  \"'(\\'|[^'])*'[[:space:]]*:"
-    - constant: "\\\\u[0-9a-fA-F]{4}|\\\\[bfnrt'\"/\\\\]"
+            - constant.specialChar: "\\\\(u[0-9a-fA-F]{4}|.)"


### PR DESCRIPTION
This fixes the highlighting of unicode escape sequences like `\u0000`.
I havent found a way to show things like `\ug` as an error.

This also removes some unused code.