### PR TITLE
Add support for Jenkinsfile syntax

### DIFF
--- a/runtime/syntax/groovy.yaml
+++ b/runtime/syntax/groovy.yaml
@@ -1,7 +1,7 @@
 filetype: groovy
 
 detect:
-    filename: "\\.(groovy|gy|gvy|gsh|gradle)$"
+    filename: "(\\.(groovy|gy|gvy|gsh|gradle)$|^[Jj]enkinsfile$)"
     header: "^#!.*/(env +)?groovy *$"
 
 rules:


### PR DESCRIPTION
Build pipelines for the Jenkins build [system are configured in Groovy](https://www.jenkins.io/doc/book/pipeline/jenkinsfile/), however since their filename is always `Jenkinsfile`, micro doesn't recognize them as Groovy, and doesn't add syntax highlighting.

This small commit simply adds `Jenkinsfile` and `jenkinsfile` as file names recognized as Groovy.