### PR TITLE
refactor(runtime): simplify AssetDir()

### DIFF
--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -22,7 +22,7 @@ func AssetDir(name string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	names := make([]string, len(entries), len(entries))
+	names := make([]string, len(entries))
 	for i, entry := range entries {
 		names[i] = entry.Name()
 	}

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -1,23 +1,13 @@
 package config
 
 import (
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestAssetDir(t *testing.T) {
 	t.Parallel()
-	// Change working directory to runtime if needed
-	cwd, err := os.Getwd()
-	assert.NoError(t, err)
-	if !strings.Contains(cwd, "runtime") {
-		err := os.Chdir("./runtime")
-		require.NoError(t, err)
-	}
 	// Test AssetDir
 	entries, err := AssetDir("syntax")
 	assert.NoError(t, err)

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAssetDir(t *testing.T) {
+	t.Parallel()
+	// Change working directory to runtime if needed
+	cwd, err := os.Getwd()
+	assert.NoError(t, err)
+	if !strings.Contains(cwd, "runtime") {
+		err := os.Chdir("./runtime")
+		require.NoError(t, err)
+	}
+	// Test AssetDir
+	entries, err := AssetDir("syntax")
+	assert.NoError(t, err)
+	assert.Contains(t, entries, "go.yaml")
+	assert.True(t, len(entries) > 5)
+}


### PR DESCRIPTION
The creation of names map can be simplified by using just one `len(entries)` directive, tests confirm this.