### PR TITLE
fixed tex comment detection at start of line

### DIFF
--- a/runtime/syntax/tex.yaml
+++ b/runtime/syntax/tex.yaml
@@ -23,7 +23,7 @@ rules:
     - statement: "\\\\%"
     # comments
     - comment:
-        start: "[^\\\\]%"
+        start: "[^\\\\]%|^%"
         end: "$"
         rules: []
     - comment:


### PR DESCRIPTION
The previous highlighting regex didn't detect comments that started a line, since they didn't start with something that's not a backslash, followed by a %. This fixes the start of line detection, but it's still not perfect.
This still matches whatever the "not a backslash" character is, and colours it. I tried for about 2 hours trying fix it, using both more advanced regex, skip, and rules. I don't think it can be done without negative lookbehind. 