### PR TITLE
[add] function identifier for C/C++ and Python

### DIFF
--- a/runtime/syntax/c.yaml
+++ b/runtime/syntax/c.yaml
@@ -5,6 +5,8 @@ detect:
 
 rules:
     - identifier: "\\b[A-Z_][0-9A-Z_]+\\b"
+    - identifier.function: "\\b([A-Z][A-Za-z0-9_]+\\()"
+
     - type: "\\b(auto|float|double|char|int|short|long|sizeof|enum|void|static|const|struct|union|typedef|extern|(un)?signed|inline)\\b"
     - type: "\\b((s?size)|((u_?)?int(8|16|32|64|ptr)))_t\\b"
     - type: "\\b[a-z_][0-9a-z_]+(_t|_T)\\b"

--- a/runtime/syntax/cpp.yaml
+++ b/runtime/syntax/cpp.yaml
@@ -5,6 +5,8 @@ detect:
 
 rules:
     - identifier: "\\b[A-Z_][0-9A-Z_]*\\b"
+    - identifier.function: "\\b([A-Z][A-Za-z0-9_]+\\()"
+
     - type: "\\b(float|double|bool|char|int|short|long|enum|void|struct|union|typedef|(un)?signed|inline)\\b"
     - type: "\\b(((s?size)|((u_?)?int(8|16|32|64|ptr))|char(8|16|32))_t|wchar_t)\\b"
     - type: "\\b[a-z_][0-9a-z_]+(_t|_T)\\b"

--- a/runtime/syntax/python3.yaml
+++ b/runtime/syntax/python3.yaml
@@ -17,6 +17,8 @@ rules:
     - type: "\\b(bool|bytearray|bytes|classmethod|complex|dict|enumerate|filter|float|frozenset|int|list|map|memoryview|object|property|range|reversed|set|slice|staticmethod|str|super|tuple|type|zip)\\b"
       # definitions
     - identifier: "def [a-zA-Z_0-9]+"
+    - identifier.function: "\\b([A-Z][A-Za-z0-9_]+\\()"
+
       # keywords
     - statement: "\\b(and|as|assert|async|await|break|case|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|match|nonlocal|not|or|pass|raise|return|try|while|with|yield)\\b"
       # decorators


### PR DESCRIPTION
Adds the `identifier.function` subgroup for C/C++ and Python. I like to have different highlight color for function calls. 