### PR TITLE
Allow circular syntax highlighting rules

### DIFF
--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -51,6 +51,11 @@ rules:
         skip: "\\\\."
         rules:
             - constant.specialChar: "\\\\."
+            - default:
+                start: "\\$\\("
+                end: "\\)"
+                rules:
+                    - include: "shell"
 
     - constant.string:
         start: "'"


### PR DESCRIPTION
Adapt the syntax highlighting code to allow circular rule inclusions and add shell command substitution in strings as an example.

Without the changes in the first commit, the command substitution `"string $(cmd "quoted") more string"` is parsed as two strings instead of one string containing a substitution containing a string.

Without the changes in the second commit, micro eats all available memory trying to resolve the recursive include.

I've used this for the past few weeks and didn't notice problems (opening mainly shell, Go and Python files), but if you have a set of test files somewhere, I can check if any highlighting changes.