### PR TITLE
Document OSC 52 support for wezterm

### DIFF
--- a/runtime/help/copypaste.md
+++ b/runtime/help/copypaste.md
@@ -35,6 +35,9 @@ Here is a list of terminal emulators and their status:
 
 * `foot`: supported.
 
+* `wezterm`: only copying (writing to clipboard) is supported.
+
+
 **Summary:** If you want copy and paste to work over SSH, then you
 should set `clipboard` to `terminal`, and make sure your terminal
 supports OSC 52.


### PR DESCRIPTION
Status page: https://wezfurlong.org/wezterm/escape-sequences.html#operating-system-command-sequences

Status as of 20230521:

> Requests to query the clipboard are ignored. Allows setting or clearing the clipboard

Issue to support querying: https://github.com/wez/wezterm/issues/2050