### PR TITLE
Fix python decorator syntax.

### DIFF
--- a/runtime/syntax/python2.yaml
+++ b/runtime/syntax/python2.yaml
@@ -21,7 +21,7 @@ rules:
       # keywords
     - statement: "\\b(and|as|assert|break|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|not|or|pass|print|raise|return|try|while|with|yield)\\b"
       # decorators
-    - brightgreen: "@.*[(]"
+    - preproc: "^\\s*@[^(]*"
       # operators
     - symbol.operator: "([.:;,+*|=!\\%@]|<|>|/|-|&)"
       # parentheses

--- a/runtime/syntax/python3.yaml
+++ b/runtime/syntax/python3.yaml
@@ -20,7 +20,7 @@ rules:
       # keywords
     - statement: "\\b(and|as|assert|async|await|break|case|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|match|nonlocal|not|or|pass|raise|return|try|while|with|yield)\\b"
       # decorators
-    - brightgreen: "@.*[(]"
+    - preproc: "^\\s*@[^(]*"
       # operators
     - symbol.operator: "([~^.:;,+*|=!\\%@]|<|>|/|-|&)"
       # parentheses


### PR DESCRIPTION
1. Python decorators begin a compound statement, so they only appear at the start of a line. So match at the line start to avoid giving decorator colors to matrix multiplication (`@`) expressions. Source: https://docs.python.org/3/reference/compound_stmts.html#function-definitions

2. Python decorators go to the end of the line and might not include parentheses (for example `@functools.cache`). So instead of matching everything until an `(`, just match as many non-`(` characters as possible—which both catches the `@functools.cache` example and allows decorator parameters to fall back to the default color.

3. Instead of hardcoding `brightgreen` (which railscast.micro also complains about), color decorators as `preproc` (otherwise unused by the python syntax files, and arguably the right colorscheme group to be using for syntactic sugars anyway). Note this will change decorator colors—for example from bright green to kinda brown on monokai, and from yellow to more of a light orange on railscast.