### PR TITLE
plugins: Add capability to dis-/enable them per buffer

### DIFF
--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -306,7 +306,7 @@ func (h *BufPane) ResizePane(size int) {
 // PluginCB calls all plugin callbacks with a certain name and displays an
 // error if there is one and returns the aggregrate boolean response
 func (h *BufPane) PluginCB(cb string) bool {
-	b, err := config.RunPluginFnBool(cb, luar.New(ulua.L, h))
+	b, err := config.RunPluginFnBool(h.Buf.Settings, cb, luar.New(ulua.L, h))
 	if err != nil {
 		screen.TermMessage(err)
 	}
@@ -315,7 +315,7 @@ func (h *BufPane) PluginCB(cb string) bool {
 
 // PluginCBRune is the same as PluginCB but also passes a rune to the plugins
 func (h *BufPane) PluginCBRune(cb string, r rune) bool {
-	b, err := config.RunPluginFnBool(cb, luar.New(ulua.L, h), luar.New(ulua.L, string(r)))
+	b, err := config.RunPluginFnBool(h.Buf.Settings, cb, luar.New(ulua.L, h), luar.New(ulua.L, string(r)))
 	if err != nil {
 		screen.TermMessage(err)
 	}

--- a/internal/buffer/eventhandler.go
+++ b/internal/buffer/eventhandler.go
@@ -237,7 +237,7 @@ func (eh *EventHandler) Execute(t *TextEvent) {
 	}
 	eh.UndoStack.Push(t)
 
-	b, err := config.RunPluginFnBool("onBeforeTextEvent", luar.New(ulua.L, eh.buf), luar.New(ulua.L, t))
+	b, err := config.RunPluginFnBool(nil, "onBeforeTextEvent", luar.New(ulua.L, eh.buf), luar.New(ulua.L, t))
 	if err != nil {
 		screen.TermMessage(err)
 	}

--- a/internal/buffer/settings.go
+++ b/internal/buffer/settings.go
@@ -55,7 +55,26 @@ func (b *Buffer) SetOptionNative(option string, nativeValue interface{}) error {
 				buf.HighlightSearch = nativeValue.(bool)
 			}
 		}
-	}
+	} else {
+		for _, pl := range config.Plugins {
+			if option == pl.Name {
+				if nativeValue.(bool) {
+					if !pl.Loaded {
+						pl.Load()
+					}
+					_, err := pl.Call("init")
+					if err != nil && err != config.ErrNoSuchFunction {
+						screen.TermMessage(err)
+					}
+				} else if !nativeValue.(bool) && pl.Loaded {
+					_, err := pl.Call("deinit")
+					if err != nil && err != config.ErrNoSuchFunction {
+						screen.TermMessage(err)
+					}
+				}
+			}
+		}
+ 	}
 
 	if b.OptionCallback != nil {
 		b.OptionCallback(option, nativeValue)

--- a/internal/config/plugin_installer.go
+++ b/internal/config/plugin_installer.go
@@ -363,7 +363,7 @@ func GetInstalledVersions(withCore bool) PluginVersions {
 	}
 
 	for _, p := range Plugins {
-		if !p.IsEnabled() {
+		if !p.IsLoaded() {
 			continue
 		}
 		version := GetInstalledPluginVersion(p.Name)
@@ -572,7 +572,7 @@ func (pv PluginVersions) install(out io.Writer) {
 // UninstallPlugin deletes the plugin folder of the given plugin
 func UninstallPlugin(out io.Writer, name string) {
 	for _, p := range Plugins {
-		if !p.IsEnabled() {
+		if !p.IsLoaded() {
 			continue
 		}
 		if p.Name == name {
@@ -605,7 +605,7 @@ func UpdatePlugins(out io.Writer, plugins []string) {
 	// if no plugins are specified, update all installed plugins.
 	if len(plugins) == 0 {
 		for _, p := range Plugins {
-			if !p.IsEnabled() || p.Default {
+			if !p.IsLoaded() || p.Default {
 				continue
 			}
 			plugins = append(plugins, p.Name)

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -236,6 +236,21 @@ func RegisterGlobalOptionPlug(pl string, name string, defaultvalue interface{}) 
 	return RegisterGlobalOption(pl+"."+name, defaultvalue)
 }
 
+// RegisterCommonOption creates a new option
+func RegisterCommonOption(name string, defaultvalue interface{}) error {
+	if v, ok := GlobalSettings[name]; !ok {
+		defaultCommonSettings[name] = defaultvalue
+		GlobalSettings[name] = defaultvalue
+		err := WriteSettings(filepath.Join(ConfigDir, "settings.json"))
+		if err != nil {
+			return errors.New("Error writing settings.json file: " + err.Error())
+		}
+	} else {
+		defaultCommonSettings[name] = v
+	}
+	return nil
+}
+
 // RegisterGlobalOption creates a new global-only option
 func RegisterGlobalOption(name string, defaultvalue interface{}) error {
 	if v, ok := GlobalSettings[name]; !ok {

--- a/internal/display/statusline.go
+++ b/internal/display/statusline.go
@@ -66,7 +66,7 @@ func SetStatusInfoFnLua(fn string) {
 		return
 	}
 	statusInfo[fn] = func(b *buffer.Buffer) string {
-		if pl == nil || !pl.IsEnabled() {
+		if pl == nil || !pl.IsLoaded() {
 			return ""
 		}
 		val, err := pl.Call(plFn, luar.New(ulua.L, b))


### PR DESCRIPTION
From current end user perspective it's not really clear why plugins can't be disabled for local buffers and receiving an invalid option doesn't tell that much. So I tried to block at least the callbacks triggering actions in the plugins.

Close #2835