### PR TITLE
highlighter: Fix regions and patterns inside regions

### DIFF
--- a/pkg/highlight/highlighter.go
+++ b/pkg/highlight/highlighter.go
@@ -170,10 +170,12 @@ func (h *Highlighter) highlightRegion(highlights LineMatch, start int, canMatchE
 		}
 
 		for _, p := range curRegion.rules.patterns {
-			matches := findAllIndex(p.regex, line)
-			for _, m := range matches {
-				for i := m[0]; i < m[1]; i++ {
-					fullHighlights[i] = p.group
+			if curRegion.group == curRegion.limitGroup || p.group == curRegion.limitGroup {
+				matches := findAllIndex(p.regex, line)
+				for _, m := range matches {
+					for i := m[0]; i < m[1]; i++ {
+						fullHighlights[i] = p.group
+					}
 				}
 			}
 		}
@@ -198,7 +200,6 @@ func (h *Highlighter) highlightRegion(highlights LineMatch, start int, canMatchE
 		}
 		if !statesOnly {
 			highlights[start+loc[1]] = curRegion.parent.group
-			h.highlightRegion(highlights, start, false, lineNum, sliceEnd(line, loc[0]), curRegion, statesOnly)
 		}
 		h.highlightRegion(highlights, start+loc[1], canMatchEnd, lineNum, sliceStart(line, loc[1]), curRegion.parent, statesOnly)
 		return highlights

--- a/pkg/highlight/highlighter.go
+++ b/pkg/highlight/highlighter.go
@@ -134,16 +134,7 @@ func (h *Highlighter) highlightRegion(highlights LineMatch, start int, canMatchE
 		}
 	}
 
-	if lineLen == 0 {
-		if canMatchEnd {
-			h.lastRegion = curRegion
-		}
-
-		return highlights
-	}
-
 	firstLoc := []int{lineLen, 0}
-
 	var firstRegion *region
 	for _, r := range curRegion.rules.regions {
 		loc := findIndex(r.start, r.skip, line)

--- a/pkg/highlight/highlighter.go
+++ b/pkg/highlight/highlighter.go
@@ -134,8 +134,12 @@ func (h *Highlighter) highlightRegion(highlights LineMatch, start int, canMatchE
 		}
 	}
 
-	firstLoc := []int{lineLen, 0}
 	var firstRegion *region
+	firstLoc := []int{lineLen, 0}
+	endLoc := findIndex(curRegion.end, curRegion.skip, line)
+	if endLoc != nil {
+		firstLoc = endLoc
+	}
 	for _, r := range curRegion.rules.regions {
 		loc := findIndex(r.start, r.skip, line)
 		if loc != nil {
@@ -145,7 +149,7 @@ func (h *Highlighter) highlightRegion(highlights LineMatch, start int, canMatchE
 			}
 		}
 	}
-	if firstLoc[0] != lineLen {
+	if firstRegion != nil && firstLoc[0] != lineLen {
 		if !statesOnly {
 			highlights[start+firstLoc[0]] = firstRegion.limitGroup
 		}
@@ -177,7 +181,7 @@ func (h *Highlighter) highlightRegion(highlights LineMatch, start int, canMatchE
 		}
 	}
 
-	loc := findIndex(curRegion.end, curRegion.skip, line)
+	loc := endLoc
 	if loc != nil {
 		if !statesOnly {
 			highlights[start+loc[0]] = curRegion.limitGroup
@@ -212,8 +216,8 @@ func (h *Highlighter) highlightEmptyRegion(highlights LineMatch, start int, canM
 		return highlights
 	}
 
-	firstLoc := []int{lineLen, 0}
 	var firstRegion *region
+	firstLoc := []int{lineLen, 0}
 	for _, r := range h.Def.rules.regions {
 		loc := findIndex(r.start, r.skip, line)
 		if loc != nil {
@@ -223,7 +227,7 @@ func (h *Highlighter) highlightEmptyRegion(highlights LineMatch, start int, canM
 			}
 		}
 	}
-	if firstLoc[0] != lineLen {
+	if firstRegion != nil && firstLoc[0] != lineLen {
 		if !statesOnly {
 			highlights[start+firstLoc[0]] = firstRegion.limitGroup
 		}

--- a/pkg/highlight/highlighter.go
+++ b/pkg/highlight/highlighter.go
@@ -168,8 +168,10 @@ func (h *Highlighter) highlightRegion(highlights LineMatch, start int, canMatchE
 			if curRegion.group == curRegion.limitGroup || p.group == curRegion.limitGroup {
 				matches := findAllIndex(p.regex, line)
 				for _, m := range matches {
-					for i := m[0]; i < m[1]; i++ {
-						fullHighlights[i] = p.group
+					if ((endLoc == nil) || (m[0] < endLoc[0])) {
+						for i := m[0]; i < m[1]; i++ {
+							fullHighlights[i] = p.group
+						}
 					}
 				}
 			}

--- a/pkg/highlight/highlighter.go
+++ b/pkg/highlight/highlighter.go
@@ -134,26 +134,6 @@ func (h *Highlighter) highlightRegion(highlights LineMatch, start int, canMatchE
 		}
 	}
 
-	loc := findIndex(curRegion.end, curRegion.skip, line)
-	if loc != nil {
-		if !statesOnly {
-			highlights[start+loc[0]] = curRegion.limitGroup
-		}
-		if curRegion.parent == nil {
-			if !statesOnly {
-				highlights[start+loc[1]] = 0
-			}
-			h.highlightEmptyRegion(highlights, start+loc[1], canMatchEnd, lineNum, sliceStart(line, loc[1]), statesOnly)
-			return highlights
-		}
-		if !statesOnly {
-			highlights[start+loc[1]] = curRegion.parent.group
-			h.highlightRegion(highlights, start, false, lineNum, sliceEnd(line, loc[0]), curRegion, statesOnly)
-		}
-		h.highlightRegion(highlights, start+loc[1], canMatchEnd, lineNum, sliceStart(line, loc[1]), curRegion.parent, statesOnly)
-		return highlights
-	}
-
 	if lineLen == 0 {
 		if canMatchEnd {
 			h.lastRegion = curRegion
@@ -178,7 +158,7 @@ func (h *Highlighter) highlightRegion(highlights LineMatch, start int, canMatchE
 		if !statesOnly {
 			highlights[start+firstLoc[0]] = firstRegion.limitGroup
 		}
-		h.highlightRegion(highlights, start, false, lineNum, sliceEnd(line, firstLoc[0]), curRegion, statesOnly)
+		h.highlightEmptyRegion(highlights, start+firstLoc[1], canMatchEnd, lineNum, sliceStart(line, firstLoc[1]), statesOnly)
 		h.highlightRegion(highlights, start+firstLoc[1], canMatchEnd, lineNum, sliceStart(line, firstLoc[1]), firstRegion, statesOnly)
 		return highlights
 	}
@@ -202,6 +182,26 @@ func (h *Highlighter) highlightRegion(highlights LineMatch, start int, canMatchE
 				highlights[start+i] = h
 			}
 		}
+	}
+
+	loc := findIndex(curRegion.end, curRegion.skip, line)
+	if loc != nil {
+		if !statesOnly {
+			highlights[start+loc[0]] = curRegion.limitGroup
+		}
+		if curRegion.parent == nil {
+			if !statesOnly {
+				highlights[start+loc[1]] = 0
+			}
+			h.highlightEmptyRegion(highlights, start+loc[1], canMatchEnd, lineNum, sliceStart(line, loc[1]), statesOnly)
+			return highlights
+		}
+		if !statesOnly {
+			highlights[start+loc[1]] = curRegion.parent.group
+			h.highlightRegion(highlights, start, false, lineNum, sliceEnd(line, loc[0]), curRegion, statesOnly)
+		}
+		h.highlightRegion(highlights, start+loc[1], canMatchEnd, lineNum, sliceStart(line, loc[1]), curRegion.parent, statesOnly)
+		return highlights
 	}
 
 	if canMatchEnd {

--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -48,12 +48,12 @@ rules:
         start: "\""
         end: "\""
         skip: "\\\\."
-        rules:
-            - constant.specialChar: "\\\\."
+        rules: []
 
     - constant.string:
         start: "'"
         end: "'"
+        skip: "\\\\."
         rules: []
 
     - comment:

--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -42,7 +42,7 @@ rules:
     - statement: " (-[A-Za-z]+|--[a-z]+)"
 
     - identifier: "\\$\\{[0-9A-Za-z_:!%&=+#~@*^$?, .\\-\\/\\[\\]]+\\}"
-    - identifier: "\\$[0-9A-Za-z_:!%&=+#~@*^$?,\\-\\/\\[\\]]+"
+    - identifier: "\\$[0-9A-Za-z_:!%&=+#~@*^$?,\\-\\[\\]]+"
 
     - constant.string:
         start: "\""

--- a/runtime/syntax/yaml.yaml
+++ b/runtime/syntax/yaml.yaml
@@ -30,6 +30,5 @@ rules:
     - comment:
         start: "#"
         end: "$"
-        rules: []
-
-
+        rules:
+            - todo: "(TODO|XXX|FIXME):?"


### PR DESCRIPTION
Somehow this feature was broken too like the `- include:` addressed with #2787. This PR addresses the whole child-region/pattern topic inside regions in case they are needed (e.g. the default TODO/FIXME/XXX-pattern inside the `shell` syntax definition/yaml).
With the `- include:` feature still a bit more work is needed, but so far #2787 will be improved already by this and the previous improvements.

Before:
![grafik](https://github.com/zyedidia/micro/assets/3951388/41427dc8-58c8-4fa3-885e-921527d9f9f6)

After:
![grafik](https://github.com/zyedidia/micro/assets/3951388/c8258e79-9dce-4a34-b2aa-37935ada731d)

For the string and identifier highlighting inside the comment temporary sub-rules have been introduced inside the sh.yaml.