### PR TITLE
option: Don't apply rmtrailingws in case of timed autosave

### DIFF
--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -420,7 +420,7 @@ func DoEvent() {
 	case <-config.Autosave:
 		ulua.Lock.Lock()
 		for _, b := range buffer.OpenBuffers {
-			b.Save()
+			b.AutoSave()
 		}
 		ulua.Lock.Unlock()
 	case <-shell.CloseTerms:

--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -93,9 +93,14 @@ func (b *Buffer) Save() error {
 	return b.SaveAs(b.Path)
 }
 
+// AutoSave saves the buffer to its default path
+func (b *Buffer) AutoSave() error {
+	return b.saveToFile(b.Path, false, true)
+}
+
 // SaveAs saves the buffer to a specified path (filename), creating the file if it does not exist
 func (b *Buffer) SaveAs(filename string) error {
-	return b.saveToFile(filename, false)
+	return b.saveToFile(filename, false, false)
 }
 
 func (b *Buffer) SaveWithSudo() error {
@@ -103,10 +108,10 @@ func (b *Buffer) SaveWithSudo() error {
 }
 
 func (b *Buffer) SaveAsWithSudo(filename string) error {
-	return b.saveToFile(filename, true)
+	return b.saveToFile(filename, true, false)
 }
 
-func (b *Buffer) saveToFile(filename string, withSudo bool) error {
+func (b *Buffer) saveToFile(filename string, withSudo bool, autoSave bool) error {
 	var err error
 	if b.Type.Readonly {
 		return errors.New("Cannot save readonly buffer")
@@ -118,7 +123,7 @@ func (b *Buffer) saveToFile(filename string, withSudo bool) error {
 		return errors.New("Save with sudo not supported on Windows")
 	}
 
-	if b.Settings["rmtrailingws"].(bool) {
+	if !autoSave && b.Settings["rmtrailingws"].(bool) {
 		for i, l := range b.lines {
 			leftover := util.CharacterCount(bytes.TrimRightFunc(l.data, unicode.IsSpace))
 

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -282,7 +282,10 @@ Here are the available options:
     default value: `false`
 
 * `rmtrailingws`: micro will automatically trim trailing whitespaces at ends of
-   lines. Note: This setting overrides `keepautoindent`
+   lines.
+   Note: This setting overrides `keepautoindent` and isn't used at timed `autosave`
+   or forced `autosave` in case the buffer didn't change. A manual save will
+   involve the action regardless if the buffer has been changed or not.
 
 	default value: `false`
 


### PR DESCRIPTION
This can get handy in case someone uses `rmtrailingws` including `autosave` > 0 and has some longer AFK sessions after the space at the EOL was already inserted.

The options are adapted accordingly.

Close #2848