### PR TITLE
Wrap default values in back ticks for tabhighlight and tabreverse

### DIFF
--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -382,7 +382,7 @@ Here are the available options:
 * `tabhighlight`: inverts the tab characters' (filename, save indicator, etc)
   colors with respect to the tab bar.
 
-	default value: false
+	default value: `false`
 
 * `tabreverse`: reverses the tab bar colors when active.
 

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -386,7 +386,7 @@ Here are the available options:
 
 * `tabreverse`: reverses the tab bar colors when active.
 
-	default value: true
+	default value: `true`
 
 * `tabsize`: the size in spaces that a tab character should be displayed with.
 


### PR DESCRIPTION
Default value false in option "tabhighlight" documentation, options.md Line: 385 was missing back ticks.

Wrap false in back ticks for document formatting.

```markdown
* `tabhighlight`: inverts the tab characters' (filename, save indicator, etc)
  colors with respect to the tab bar.

-   default value: false
+   default value: `false`

* `tabreverse`: reverses the tab bar colors when active.
```

---

Default value true in option "tabrevers" documentation, options.md Line: 389 was missing back ticks.

Wrap true in back ticks for document formatting.

```markdown
* `tabreverse`: reverses the tab bar colors when active.

-   default value: true
+   default value: `true`

* `tabsize`: the size in spaces that a tab character should be displayed with.
```

Please let me know if there was any problems with this pull request. Thanks for the opportunity to contribute, and for the micro text editor.

Cheers
itsf4llofstars