### PR TITLE
Fixed newline format detection for files not ending with a newline

### DIFF
--- a/internal/buffer/line_array.go
+++ b/internal/buffer/line_array.go
@@ -121,7 +121,7 @@ func NewLineArray(size uint64, endings FileFormat, reader io.Reader) *LineArray 
 			}
 			dlen = len(data)
 		} else if dlen > 0 {
-			if endings == FFAuto {
+			if la.Endings == FFAuto {
 				la.Endings = FFUnix
 			}
 		}

--- a/internal/buffer/line_array.go
+++ b/internal/buffer/line_array.go
@@ -116,7 +116,7 @@ func NewLineArray(size uint64, endings FileFormat, reader io.Reader) *LineArray 
 		dlen := len(data)
 		if dlen > 1 && data[dlen-2] == '\r' {
 			data = append(data[:dlen-2], '\n')
-			if endings == FFAuto {
+			if la.Endings == FFAuto {
 				la.Endings = FFDos
 			}
 			dlen = len(data)


### PR DESCRIPTION
Files with Windows-style line endings were being converted to Unix-style if the file did not end with a newline