### PR TITLE
Add onSetActive callback

### DIFF
--- a/internal/action/tab.go
+++ b/internal/action/tab.go
@@ -1,9 +1,12 @@
 package action
 
 import (
+	luar "layeh.com/gopher-luar"
+
 	"github.com/zyedidia/micro/v2/internal/buffer"
 	"github.com/zyedidia/micro/v2/internal/config"
 	"github.com/zyedidia/micro/v2/internal/display"
+	ulua "github.com/zyedidia/micro/v2/internal/lua"
 	"github.com/zyedidia/micro/v2/internal/screen"
 	"github.com/zyedidia/micro/v2/internal/views"
 	"github.com/zyedidia/tcell/v2"
@@ -275,6 +278,11 @@ func (t *Tab) SetActive(i int) {
 		} else {
 			p.SetActive(false)
 		}
+	}
+
+	err := config.RunPluginFn("onSetActive", luar.New(ulua.L, MainTab().CurPane()))
+	if err != nil {
+		screen.TermMessage(err)
 	}
 }
 

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -50,6 +50,8 @@ which micro defines:
 
 * `postinit()`: initialization function called after `init()`.
 
+* `onSetActive(bufpane)`: runs when changing the currently active panel.
+
 * `onBufferOpen(buf)`: runs when a buffer is opened. The input contains
    the buffer object.
 


### PR DESCRIPTION
Adds the `onSetActive` callcack to be used by plugins in lua. The function will be executed whenever the buffer in focus is changed.

Example:
```lua
local micro = import('micro')
function onSetActive(bufpane)
  micro.Log('Active: '..bufpane.Buf.Path)
end
```