### PR TITLE
actions: Fix the iteration over a slice under modification in QuitAll()

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1582,9 +1582,7 @@ func (h *BufPane) QuitAll() bool {
 	}
 
 	quit := func() {
-		for _, b := range buffer.OpenBuffers {
-			b.Close()
-		}
+		buffer.CloseOpenBuffers()
 		screen.Screen.Fini()
 		InfoBar.Close()
 		runtime.Goexit()

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -430,6 +430,15 @@ func NewBuffer(r io.Reader, size int64, path string, startcursor Loc, btype BufT
 	return b
 }
 
+// CloseOpenBuffers removes all open buffers
+func CloseOpenBuffers() {
+	for i, buf := range OpenBuffers {
+		buf.Fini()
+		OpenBuffers[i] = nil
+	}
+	OpenBuffers = OpenBuffers[:0]
+}
+
 // Close removes this buffer from the list of open buffers
 func (b *Buffer) Close() {
 	for i, buf := range OpenBuffers {


### PR DESCRIPTION
Currently `QuitAll()` iterates over `buffer.OpenBuffers`, which is modified directly in case `Close()` is called for the related buffer.
Since the `buffer` is the owner of `OpenBuffers` it can directly take care of the full clean-up and we don't need to do a nested iteration or local copy.

Fixes #2892