### PR TITLE
Fix issues with handling invalid regex in syntax files

### DIFF
--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -699,6 +699,7 @@ func (b *Buffer) UpdateRules() {
 		header, err = highlight.MakeHeaderYaml(data)
 		if err != nil {
 			screen.TermMessage("Error parsing header for syntax file " + f.Name() + ": " + err.Error())
+			continue
 		}
 		file, err := highlight.ParseFile(data)
 		if err != nil {

--- a/pkg/highlight/parser.go
+++ b/pkg/highlight/parser.go
@@ -109,7 +109,7 @@ func MakeHeader(data []byte) (*Header, error) {
 	if fnameRgx != "" {
 		header.FtDetect[0], err = regexp.Compile(fnameRgx)
 	}
-	if headerRgx != "" {
+	if err == nil && headerRgx != "" {
 		header.FtDetect[1], err = regexp.Compile(headerRgx)
 	}
 
@@ -135,7 +135,7 @@ func MakeHeaderYaml(data []byte) (*Header, error) {
 	if hdrYaml.Detect.FNameRgx != "" {
 		header.FtDetect[0], err = regexp.Compile(hdrYaml.Detect.FNameRgx)
 	}
-	if hdrYaml.Detect.HeaderRgx != "" {
+	if err == nil && hdrYaml.Detect.HeaderRgx != "" {
 		header.FtDetect[1], err = regexp.Compile(hdrYaml.Detect.HeaderRgx)
 	}
 


### PR DESCRIPTION
- Fix panic when a user's custom syntax file has an invalid regex for `filename` or `header`
- Fix ignoring error when the `filename` regex is invalid but the `header` regex is correct