### PR TITLE
syntax: Fix include of patch in git-commit

### DIFF
--- a/runtime/syntax/git-commit.yaml
+++ b/runtime/syntax/git-commit.yaml
@@ -31,6 +31,5 @@ rules:
         # should never match valid diff output and extend highlighting to the
         # end of the file
         end: "^ENDOFFILE"
-        limit-group: "magenta"
         rules:
             - include: "patch"


### PR DESCRIPTION
Due to introduced limit-group checks in [ceaa143](https://github.com/zyedidia/micro/commit/ceaa143c621630b72401f2afd80ba80befc6f7d4#diff-16d0164b7fcc4350a9a7a5827b930e8de29487a35a3afa8d9e165b8e2af0f13aR176) it was revealed, that the previously defined `magenta` was the only rule applied. Now the patch highlighting within a commit message works again.

fixes #2916