### PR TITLE
fix: recognize .cmd as batch files

### DIFF
--- a/runtime/syntax/bat.yaml
+++ b/runtime/syntax/bat.yaml
@@ -1,7 +1,7 @@
 filetype: batch
 
 detect:
-  filename: "(\\.bat$)"
+  filename: "(\\.bat$|\\.cmd$)"
   # header: ""
 
 rules:


### PR DESCRIPTION
In Windows batch files can have the extension .bat or .cmd, both are recognized by default.
This pull request updates the batch file recognition in Micro to properly detect files with the .cmd extension and apply syntax highlighting.
