### PR TITLE
syntax: Provide default.yaml as fallback definition

### DIFF
--- a/cmd/micro/micro_test.go
+++ b/cmd/micro/micro_test.go
@@ -109,7 +109,10 @@ func handleEvent() {
 	if e != nil {
 		screen.Events <- e
 	}
-	DoEvent()
+
+	for len(screen.DrawChan()) > 0 || len(screen.Events) > 0 {
+		DoEvent()
+	}
 }
 
 func injectKey(key tcell.Key, r rune, mod tcell.ModMask) {
@@ -151,6 +154,16 @@ func openFile(file string) {
 	injectKey(tcell.KeyEnter, rune(tcell.KeyEnter), tcell.ModNone)
 }
 
+func findBuffer(file string) *buffer.Buffer {
+	var buf *buffer.Buffer
+	for _, b := range buffer.OpenBuffers {
+		if b.Path == file {
+			buf = b
+		}
+	}
+	return buf
+}
+
 func createTestFile(name string, content string) (string, error) {
 	testf, err := ioutil.TempFile("", name)
 	if err != nil {
@@ -190,14 +203,7 @@ func TestSimpleEdit(t *testing.T) {
 
 	openFile(file)
 
-	var buf *buffer.Buffer
-	for _, b := range buffer.OpenBuffers {
-		if b.Path == file {
-			buf = b
-		}
-	}
-
-	if buf == nil {
+	if findBuffer(file) == nil {
 		t.Errorf("Could not find buffer %s", file)
 		return
 	}
@@ -235,6 +241,11 @@ func TestMouse(t *testing.T) {
 	defer os.Remove(file)
 
 	openFile(file)
+
+	if findBuffer(file) == nil {
+		t.Errorf("Could not find buffer %s", file)
+		return
+	}
 
 	// buffer:
 	// base content
@@ -298,6 +309,11 @@ func TestSearchAndReplace(t *testing.T) {
 	defer os.Remove(file)
 
 	openFile(file)
+
+	if findBuffer(file) == nil {
+		t.Errorf("Could not find buffer %s", file)
+		return
+	}
 
 	injectKey(tcell.KeyCtrlE, rune(tcell.KeyCtrlE), tcell.ModCtrl)
 	injectString(fmt.Sprintf("replaceall %s %s", "foo", "test_string"))

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -907,6 +907,30 @@ func (b *Buffer) UpdateRules() {
 	if b.Highlighter == nil || syntaxFile != "" {
 		if b.SyntaxDef != nil {
 			b.Settings["filetype"] = b.SyntaxDef.FileType
+		} else {
+			for _, f := range config.ListRuntimeFiles(config.RTSyntax) {
+				if f.Name() == "default" {
+					data, err := f.Data()
+					if err != nil {
+						screen.TermMessage("Error loading syntax file " + f.Name() + ": " + err.Error())
+						continue
+					}
+
+					file, err := highlight.ParseFile(data)
+					if err != nil {
+						screen.TermMessage("Error parsing syntax file " + f.Name() + ": " + err.Error())
+						continue
+					}
+
+					syndef, err := highlight.ParseDef(file, header)
+					if err != nil {
+						screen.TermMessage("Error parsing syntax file " + f.Name() + ": " + err.Error())
+						continue
+					}
+					b.SyntaxDef = syndef
+					break
+				}
+			}
 		}
 	}
 

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -710,6 +710,10 @@ func (b *Buffer) UpdateRules() {
 	var header *highlight.Header
 	// search for the syntax file in the user's custom syntax files
 	for _, f := range config.ListRealRuntimeFiles(config.RTSyntax) {
+		if f.Name() == "default" {
+			continue
+		}
+
 		data, err := f.Data()
 		if err != nil {
 			screen.TermMessage("Error loading syntax file " + f.Name() + ": " + err.Error())

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -876,7 +876,7 @@ func (b *Buffer) UpdateRules() {
 		for _, f := range config.ListRuntimeFiles(config.RTSyntax) {
 			data, err := f.Data()
 			if err != nil {
-				screen.TermMessage("Error parsing syntax file " + f.Name() + ": " + err.Error())
+				screen.TermMessage("Error loading syntax file " + f.Name() + ": " + err.Error())
 				continue
 			}
 			header, err := highlight.MakeHeaderYaml(data)

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -770,7 +770,7 @@ func (b *Buffer) UpdateRules() {
 	}
 
 	if !foundDef {
-		// search in the default syntax files
+		// search for the syntax file in the runtime files
 		for _, f := range config.ListRuntimeFiles(config.RTSyntaxHeader) {
 			data, err := f.Data()
 			if err != nil {
@@ -883,6 +883,7 @@ func (b *Buffer) UpdateRules() {
 				screen.TermMessage("Error loading syntax file " + f.Name() + ": " + err.Error())
 				continue
 			}
+
 			header, err := highlight.MakeHeaderYaml(data)
 			if err != nil {
 				screen.TermMessage("Error parsing syntax file " + f.Name() + ": " + err.Error())

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -712,6 +712,34 @@ func parseDefFromFile(f config.RuntimeFile, header *highlight.Header) *highlight
 	return syndef
 }
 
+// findRealRuntimeSyntaxDef finds a specific syntax definition
+// in the user's custom syntax files
+func findRealRuntimeSyntaxDef(name string, header *highlight.Header) *highlight.Def {
+	for _, f := range config.ListRealRuntimeFiles(config.RTSyntax) {
+		if f.Name() == name {
+			syndef := parseDefFromFile(f, header)
+			if syndef != nil {
+				return syndef
+			}
+		}
+	}
+	return nil
+}
+
+// findRuntimeSyntaxDef finds a specific syntax definition
+// in the runtime files
+func findRuntimeSyntaxDef(name string, header *highlight.Header) *highlight.Def {
+	for _, f := range config.ListRuntimeFiles(config.RTSyntax) {
+		if f.Name() == name {
+			syndef := parseDefFromFile(f, header)
+			if syndef != nil {
+				return syndef
+			}
+		}
+	}
+	return nil
+}
+
 // UpdateRules updates the syntax rules and filetype for this buffer
 // This is called when the colorscheme changes
 func (b *Buffer) UpdateRules() {
@@ -878,17 +906,7 @@ func (b *Buffer) UpdateRules() {
 
 	if syntaxFile != "" && !foundDef {
 		// we found a syntax file using a syntax header file
-		for _, f := range config.ListRuntimeFiles(config.RTSyntax) {
-			if f.Name() == syntaxFile {
-				syndef := parseDefFromFile(f, header)
-				if syndef == nil {
-					continue
-				}
-
-				b.SyntaxDef = syndef
-				break
-			}
-		}
+		b.SyntaxDef = findRuntimeSyntaxDef(syntaxFile, header)
 	}
 
 	if b.SyntaxDef != nil && highlight.HasIncludes(b.SyntaxDef) {
@@ -932,31 +950,10 @@ func (b *Buffer) UpdateRules() {
 			b.Settings["filetype"] = b.SyntaxDef.FileType
 		} else {
 			// search for the default file in the user's custom syntax files
-			for _, f := range config.ListRealRuntimeFiles(config.RTSyntax) {
-				if f.Name() == "default" {
-					syndef := parseDefFromFile(f, nil)
-					if syndef == nil {
-						continue
-					}
-
-					b.SyntaxDef = syndef
-					break
-				}
-			}
-
+			b.SyntaxDef = findRealRuntimeSyntaxDef("default", nil)
 			if b.SyntaxDef == nil {
 				// search for the default file in the runtime files
-				for _, f := range config.ListRuntimeFiles(config.RTSyntax) {
-					if f.Name() == "default" {
-						syndef := parseDefFromFile(f, nil)
-						if syndef == nil {
-							continue
-						}
-
-						b.SyntaxDef = syndef
-						break
-					}
-				}
+				b.SyntaxDef = findRuntimeSyntaxDef("default", nil)
 			}
 		}
 	}

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -908,8 +908,6 @@ func (b *Buffer) UpdateRules() {
 		if b.SyntaxDef != nil {
 			b.Settings["filetype"] = b.SyntaxDef.FileType
 		}
-	} else {
-		b.SyntaxDef = &highlight.EmptyDef
 	}
 
 	if b.SyntaxDef != nil {

--- a/pkg/highlight/highlighter.go
+++ b/pkg/highlight/highlighter.go
@@ -67,9 +67,6 @@ func combineLineMatch(src, dst LineMatch) LineMatch {
 // A State represents the region at the end of a line
 type State *region
 
-// EmptyDef is an empty definition.
-var EmptyDef = Def{nil, &rules{}}
-
 // LineStates is an interface for a buffer-like object which can also store the states and matches for every line
 type LineStates interface {
 	LineBytes(n int) []byte

--- a/runtime/syntax/default.yaml
+++ b/runtime/syntax/default.yaml
@@ -5,12 +5,6 @@ detect:
 
 rules:
     # Mails
-    - special: "[[:alnum:].%_+-]+@[[:alnum:].-]+\\.[[:alpha:]]{2,}"
+    - special: "[[:alnum:].%_+-]+@[[:alnum:].-]+"
     # URLs
-    - identifier: "(https?|ftp|ssh)://\\S+\\.\\S+[^])>\\s,.]"
-
-    - comment:
-        start: "(^|\\s)#"
-        end: "$"
-        rules:
-            - todo: "(TODO|XXX|FIXME):?"
+    - identifier: "(https?|ftp|ssh)://\\S*[^])>\\s,.]"

--- a/runtime/syntax/default.yaml
+++ b/runtime/syntax/default.yaml
@@ -1,0 +1,16 @@
+filetype: unknown
+
+detect:
+    filename: ""
+
+rules:
+    # Mails
+    - special: "[[:alnum:].%_+-]+@[[:alnum:].-]+\\.[[:alpha:]]{2,}"
+    # URLs
+    - identifier: "(https?|ftp|ssh)://\\S+\\.\\S+[^])>\\s,.]"
+
+    - comment:
+        start: "(^|\\s)#"
+        end: "$"
+        rules:
+            - todo: "(TODO|XXX|FIXME):?"


### PR DESCRIPTION
This will provide a basic rule set which is applied in the moment no known file type can be found or identified. The approach is heavily inspired by `nano` and his [default.nanorc](https://git.savannah.gnu.org/cgit/nano.git/tree/syntax/default.nanorc). Now it's possible that files without any extension will be highlighted even they aren't explicitly added to a dedicated syntax definition (e.g. `/etc/fstab` or config files present under `/etc/default/`).

Closes #2926