### PR TITLE
Add screen.Redraw binding for Lua's plugins

### DIFF
--- a/cmd/micro/initlua.go
+++ b/cmd/micro/initlua.go
@@ -55,6 +55,7 @@ func luaImportMicro() *lua.LTable {
 		return action.Tabs
 	}))
 	ulua.L.SetField(pkg, "Lock", luar.New(ulua.L, ulua.Lock))
+	ulua.L.SetField(pkg, "Redraw", luar.New(ulua.L, screen.Redraw))
 
 	return pkg
 }

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -121,6 +121,18 @@ The packages and functions are listed below (in Go type signatures):
        current pane is not a BufPane.
 
     - `CurTab() *Tab`: returns the current tab.
+
+    - `Tabs() *TabList`: returns the list of all tabs (in `Tabs().List`)
+
+    - `Redraw()`: update the screen contents. In most cases micro itself
+       redraws the screen when needed, but in cases when it doesn't (e.g.
+       if a lua code is running asynchronously, e.g. in a timer callback)
+       this function can be used to explicitly request screen update.
+
+    - `Lock`: Access the Lua's lock mutex. This is useful to prevent 
+       simultaneous access to a shared resource from different threads.
+
+    
 * `micro/config`
 	- `MakeCommand(name string, action func(bp *BufPane, args[]string),
                    completer buffer.Completer)`:


### PR DESCRIPTION
This adds a binding for `screen.Redraw` function in Lua as discussed in the linked issue. 
This is required for using asynchronous functions in Lua that have visible impact on the UI.

This fixes #2923 

I've tested it in my filemanager's plugin branch and it's working perfectly.
