### PR TITLE
Expose screen.Redraw() to lua

### DIFF
--- a/cmd/micro/initlua.go
+++ b/cmd/micro/initlua.go
@@ -55,6 +55,7 @@ func luaImportMicro() *lua.LTable {
 		return action.Tabs
 	}))
 	ulua.L.SetField(pkg, "Lock", luar.New(ulua.L, ulua.Lock))
+	ulua.L.SetField(pkg, "Redraw", luar.New(ulua.L, screen.Redraw))
 
 	return pkg
 }

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -121,6 +121,11 @@ The packages and functions are listed below (in Go type signatures):
        current pane is not a BufPane.
 
     - `CurTab() *Tab`: returns the current tab.
+
+    - `Redraw()`: update the screen contents. In most cases micro itself
+       redraws the screen when needed, but in cases when it doesn't (e.g.
+       if a lua code is running asynchronously, e.g. in a timer callback)
+       this function can be used to explicitly request screen update.
 * `micro/config`
 	- `MakeCommand(name string, action func(bp *BufPane, args[]string),
                    completer buffer.Completer)`:


### PR DESCRIPTION
If lua code is running asynchronously, e.g. in a timer callback passed to `time.AfterFunc()`, micro does not automatically update the screen contents after the actions performed by this async lua code. For such cases, expose `screen.Redraw()` to lua (as `micro.Redraw()`) to let lua code explicitly request screen update when needed.

Fixes #2923