### PR TITLE
Fix non-working lua Lock

### DIFF
--- a/cmd/micro/initlua.go
+++ b/cmd/micro/initlua.go
@@ -54,7 +54,7 @@ func luaImportMicro() *lua.LTable {
 	ulua.L.SetField(pkg, "Tabs", luar.New(ulua.L, func() *action.TabList {
 		return action.Tabs
 	}))
-	ulua.L.SetField(pkg, "Lock", luar.New(ulua.L, ulua.Lock))
+	ulua.L.SetField(pkg, "Lock", luar.New(ulua.L, &ulua.Lock))
 
 	return pkg
 }


### PR DESCRIPTION
The lock provided to lua as `micro.Lock` does not really work: an attempt to use it via `micro.Lock:Lock()` results in an error:

```
Plugin initlua: init:260: attempt to call a non-function object stack traceback:
	init:260: in main chunk
	[G]: ?
```

The reason is that the value that is provided to lua is a copy of the mutex, not the mutex itself.

Ref #1539

This PR makes it work, but generally I'm not sure if directly exposing the Go `sync.Mutex` object to lua is the nicest way to provide this functionality.