### PR TITLE
syntax: sh: Add here document as string region

### DIFF
--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -56,6 +56,12 @@ rules:
         skip: "\\\\."
         rules: []
 
+    - constant.string:
+        start: "<<[^\\s]+[-~.]*[A-Za-z0-9]+$"
+        end: "^[^\\s]+[A-Za-z0-9]+$"
+        skip: "\\\\."
+        rules: []
+
     - comment:
         start: "(^|\\s)#"
         end: "$"


### PR DESCRIPTION
This will treat a here document block with the limit string `EOF` as a string region.

Fixes #2949