### PR TITLE
command: Fix replace to be able to insert '$'

### DIFF
--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -794,6 +794,7 @@ func (h *BufPane) ReplaceCmd(args []string) {
 
 	if noRegex {
 		search = regexp.QuoteMeta(search)
+		replaceStr = strings.ReplaceAll(replaceStr, "$", "$$")
 	}
 
 	replace := []byte(replaceStr)

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -794,7 +794,6 @@ func (h *BufPane) ReplaceCmd(args []string) {
 
 	if noRegex {
 		search = regexp.QuoteMeta(search)
-		replaceStr = strings.ReplaceAll(replaceStr, "$", "$$")
 	}
 
 	replace := []byte(replaceStr)
@@ -821,7 +820,7 @@ func (h *BufPane) ReplaceCmd(args []string) {
 		end = h.Cursor.CurSelection[1]
 	}
 	if all {
-		nreplaced, _ = h.Buf.ReplaceRegex(start, end, regex, replace)
+		nreplaced, _ = h.Buf.ReplaceRegex(start, end, regex, replace, !noRegex)
 	} else {
 		inRange := func(l buffer.Loc) bool {
 			return l.GreaterEqual(start) && l.LessEqual(end)
@@ -851,7 +850,7 @@ func (h *BufPane) ReplaceCmd(args []string) {
 
 			InfoBar.YNPrompt("Perform replacement (y,n,esc)", func(yes, canceled bool) {
 				if !canceled && yes {
-					_, nrunes := h.Buf.ReplaceRegex(locs[0], locs[1], regex, replace)
+					_, nrunes := h.Buf.ReplaceRegex(locs[0], locs[1], regex, replace, !noRegex)
 
 					searchLoc = locs[0]
 					searchLoc.X += nrunes + locs[0].Diff(locs[1], h.Buf)

--- a/internal/buffer/search.go
+++ b/internal/buffer/search.go
@@ -148,7 +148,7 @@ func (b *Buffer) FindNext(s string, start, end, from Loc, down bool, useRegex bo
 // ReplaceRegex replaces all occurrences of 'search' with 'replace' in the given area
 // and returns the number of replacements made and the number of runes
 // added or removed on the last line of the range
-func (b *Buffer) ReplaceRegex(start, end Loc, search *regexp.Regexp, replace []byte) (int, int) {
+func (b *Buffer) ReplaceRegex(start, end Loc, search *regexp.Regexp, replace []byte, captureGroups bool) (int, int) {
 	if start.GreaterThan(end) {
 		start, end = end, start
 	}
@@ -172,9 +172,13 @@ func (b *Buffer) ReplaceRegex(start, end Loc, search *regexp.Regexp, replace []b
 			l = util.SliceStart(l, end.X)
 		}
 		newText := search.ReplaceAllFunc(l, func(in []byte) []byte {
-			result := []byte{}
-			for _, submatches := range search.FindAllSubmatchIndex(in, -1) {
-				result = search.Expand(result, replace, in, submatches)
+			var result []byte
+			if captureGroups {
+				for _, submatches := range search.FindAllSubmatchIndex(in, -1) {
+					result = search.Expand(result, replace, in, submatches)
+				}
+			} else {
+				result = replace
 			}
 			found++
 			if i == end.Y {

--- a/runtime/help/commands.md
+++ b/runtime/help/commands.md
@@ -42,6 +42,10 @@ quotes here but these are not necessary when entering the command in micro.
 
    Note that `search` must be a valid regex (unless `-l` is passed). If one 
    of the arguments does not have any spaces in it, you may omit the quotes.
+   In case the search is done non-literal (without `-l`) the character `$` can't
+   be simply added, since `Regexp.Expand()` is used in the background to add
+   more complex template replacement functionality. To add a `$` a double `$$`
+   must be used.
 
 * `replaceall 'search' 'value'`: this will replace all occurrences of `search`
    with `value` without user confirmation.

--- a/runtime/help/commands.md
+++ b/runtime/help/commands.md
@@ -42,10 +42,12 @@ quotes here but these are not necessary when entering the command in micro.
 
    Note that `search` must be a valid regex (unless `-l` is passed). If one 
    of the arguments does not have any spaces in it, you may omit the quotes.
-   In case the search is done non-literal (without `-l`) the character `$` can't
-   be simply added, since `Regexp.Expand()` is used in the background to add
-   more complex template replacement functionality. To add a `$` a double `$$`
-   must be used.
+
+   In case the search is done non-literal (without `-l`), the 'value'
+   is interpreted as a template:
+   * `$3` or `${3}` substitutes the submatch of the 3rd (capturing group)
+   * `$foo` or `${foo}` substitutes the submatch of the (?P<foo>named group)
+   * You have to write `$$` to substitute a literal dollar.
 
 * `replaceall 'search' 'value'`: this will replace all occurrences of `search`
    with `value` without user confirmation.


### PR DESCRIPTION
This will introduce at least the capability to insert `$`s, but I'm unsure, if every possible scenario can be fulfilled with that, because the user input can be complex, the expectation for the two different replace modes could be different and not everybody reads the documentation.

Fixes #2951