### PR TITLE
bindings: Allow raw escape sequence to be bound with `bind`

### DIFF
--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -88,6 +88,10 @@ func BindKey(k, v string, bind func(e Event, a string)) {
 		return
 	}
 
+	if strings.HasPrefix(k, "\x1b") {
+		screen.Screen.RegisterRawSeq(k)
+	}
+
 	bind(event, v)
 
 	// switch e := event.(type) {
@@ -153,7 +157,6 @@ modSearch:
 			k = k[5:]
 			modifiers |= tcell.ModShift
 		case strings.HasPrefix(k, "\x1b"):
-			screen.Screen.RegisterRawSeq(k)
 			return RawEvent{
 				esc: k,
 			}, true
@@ -320,6 +323,10 @@ func UnbindKey(k string) error {
 					break
 				}
 			}
+		}
+
+		if strings.HasPrefix(k, "\x1b") {
+			screen.Screen.UnregisterRawSeq(k)
 		}
 
 		defaults := DefaultBindings("buffer")

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -634,6 +634,11 @@ func (h *BufPane) ShowCmd(args []string) {
 	InfoBar.Message(option)
 }
 
+func parseKeyArg(arg string) string {
+	// If this is a raw escape sequence, convert it to its raw byte form
+	return strings.ReplaceAll(arg, "\\x1b", "\x1b")
+}
+
 // ShowKeyCmd displays the action that a key is bound to
 func (h *BufPane) ShowKeyCmd(args []string) {
 	if len(args) < 1 {
@@ -641,7 +646,7 @@ func (h *BufPane) ShowKeyCmd(args []string) {
 		return
 	}
 
-	event, err := findEvent(args[0])
+	event, err := findEvent(parseKeyArg(args[0]))
 	if err != nil {
 		InfoBar.Error(err)
 		return
@@ -660,7 +665,7 @@ func (h *BufPane) BindCmd(args []string) {
 		return
 	}
 
-	_, err := TryBindKey(args[0], args[1], true)
+	_, err := TryBindKey(parseKeyArg(args[0]), args[1], true)
 	if err != nil {
 		InfoBar.Error(err)
 	}
@@ -673,7 +678,7 @@ func (h *BufPane) UnbindCmd(args []string) {
 		return
 	}
 
-	err := UnbindKey(args[0])
+	err := UnbindKey(parseKeyArg(args[0]))
 	if err != nil {
 		InfoBar.Error(err)
 	}


### PR DESCRIPTION
This will allow to use e.g. `bind "\x1b[D" "lua:comment.comment"` from within `micro` directly. The respective sequence will then be implicitly converted into `\u` notation when it's stored to the `bindings.json`.

#2950