### PR TITLE
plugin: Add new `onBufferOptionChanged` callback

### DIFF
--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -62,6 +62,10 @@ that micro defines:
 * `onBufferOpen(buf)`: runs when a buffer is opened. The input contains
    the buffer object.
 
+* `onBufferOptionChanged(buf, option, old, new)`: runs when an option of the
+   buffer has changed. The input contains the buffer object, the option name,
+   the old and the new value.
+
 * `onBufPaneOpen(bufpane)`: runs when a bufpane is opened. The input
    contains the bufpane object.
 

--- a/runtime/plugins/linter/linter.lua
+++ b/runtime/plugins/linter/linter.lua
@@ -141,6 +141,32 @@ function onSave(bp)
     return true
 end
 
+function onBufferOptionChanged(buf, option, old, new)
+    if option == "filetype" then
+        if old ~= new then
+            for k, v in pairs(linters) do
+                local ftmatch = old == v.filetype
+                if v.domatch then
+                    ftmatch = string.match(old, v.filetype)
+                end
+
+                local hasOS = contains(v.os, runtime.GOOS)
+                if not hasOS and v.whitelist then
+                    ftmatch = false
+                end
+                if hasOS and not v.whitelist then
+                    ftmatch = false
+                end
+
+                if ftmatch then
+                    buf:ClearMessages(k)
+                end
+            end
+        end
+    end
+    return true
+end
+
 function lint(buf, linter, cmd, args, errorformat, loff, coff, callback)
     buf:ClearMessages(linter)
 

--- a/runtime/plugins/linter/linter.lua
+++ b/runtime/plugins/linter/linter.lua
@@ -66,7 +66,7 @@ function preinit()
     end
 
     makeLinter("gcc", "c", "gcc", {"-fsyntax-only", "-Wall", "-Wextra", "%f"}, "%f:%l:%c:.+: %m")
-    makeLinter("g++", "c++", "gcc", {"-fsyntax-only","-std=c++14", "-Wall", "-Wextra", "%f"}, "%f:%l:%c:.+: %m")
+    makeLinter("g++", "c++", "g++", {"-fsyntax-only","-std=c++14", "-Wall", "-Wextra", "%f"}, "%f:%l:%c:.+: %m")
     makeLinter("dmd", "d", "dmd", {"-color=off", "-o-", "-w", "-wi", "-c", "%f"}, "%f%(%l%):.+: %m")
     makeLinter("eslint", "javascript", "eslint", {"-f","compact","%f"}, "%f: line %l, col %c, %m")
     makeLinter("gobuild", "go", "go", {"build", "-o", devnull, "%d"}, "%f:%l:%c:? %m")

--- a/runtime/plugins/linter/linter.lua
+++ b/runtime/plugins/linter/linter.lua
@@ -66,7 +66,7 @@ function preinit()
     end
 
     makeLinter("gcc", "c", "gcc", {"-fsyntax-only", "-Wall", "-Wextra", "%f"}, "%f:%l:%c:.+: %m")
-    makeLinter("g++", "c++", "g++", {"-fsyntax-only","-std=c++14", "-Wall", "-Wextra", "%f"}, "%f:%l:%c:.+: %m")
+    makeLinter("g++", "c++", "g++", {"-fsyntax-only","-Wall", "-Wextra", "%f"}, "%f:%l:%c:.+: %m")
     makeLinter("dmd", "d", "dmd", {"-color=off", "-o-", "-w", "-wi", "-c", "%f"}, "%f%(%l%):.+: %m")
     makeLinter("eslint", "javascript", "eslint", {"-f","compact","%f"}, "%f: line %l, col %c, %m")
     makeLinter("gobuild", "go", "go", {"build", "-o", devnull, "%d"}, "%f:%l:%c:? %m")


### PR DESCRIPTION
With the introduction of the new callback it's possible for plugins to react upon changed buffer settings.
Especially the `linter` plugin will benefit by this change, since it can the properly unregister messages created with a different linter type.

Fixes #2961
Fixes #3587