### PR TITLE
save: Restore the screen before overwriteFile() is left

### DIFF
--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -78,10 +78,10 @@ func overwriteFile(name string, enc encoding.Encoding, fn func(io.Writer) error,
 	if withSudo {
 		// wait for dd to finish and restart the screen if we used sudo
 		err := cmd.Wait()
+		screen.TempStart(screenb)
 		if err != nil {
 			return err
 		}
-		screen.TempStart(screenb)
 	}
 
 	return


### PR DESCRIPTION
This will solve the crash which was 100% reproducible in the moment the privilege escalation failed due to endless temporary shutdown of the screen.

Fixes #2823
Fixes #2960