### PR TITLE
save: Restore the screen if failed to start sudo

### DIFF
--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -51,6 +51,7 @@ func overwriteFile(name string, enc encoding.Encoding, fn func(io.Writer) error,
 		// contents to its stdin it might hang because the kernel's pipe size
 		// is too small to handle the full file contents all at once
 		if e := cmd.Start(); e != nil && err == nil {
+			screen.TempStart(screenb)
 			return err
 		}
 	} else if writeCloser, err = os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644); err != nil {


### PR DESCRIPTION
Similarly to the crash fixed by #2967, which happens if sudo failed, a crash also happens when sudo even fails to start. The reason for the crash is also similar: nil dereference of screen.Screen caused by the fact that we do not restore temporarily disabled screen.

To reproduce this crash, set the `sucmd` option to some non-existing command, e.g. `aaa`, and try to save a file with root privileges.