### PR TITLE
Add a Dependabot config to auto-update GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This PR introduces the following change:

* Introduce a Dependabot config that will cause Dependabot to submit monthly PRs to update GitHub action versions (if applicable that month).

For example, this repo currently uses the `actions/checkout@v3` action in CI. If this merges, Dependabot will submit a PR to update that to `@v4`.