### PR TITLE
Fix unneeded rewriting of settings.json

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -239,7 +239,7 @@ func RegisterGlobalOptionPlug(pl string, name string, defaultvalue interface{}) 
 
 // RegisterCommonOption creates a new option
 func RegisterCommonOption(name string, defaultvalue interface{}) error {
-	if v, ok := GlobalSettings[name]; !ok {
+	if _, ok := GlobalSettings[name]; !ok {
 		defaultCommonSettings[name] = defaultvalue
 		GlobalSettings[name] = defaultvalue
 		err := WriteSettings(filepath.Join(ConfigDir, "settings.json"))
@@ -247,14 +247,14 @@ func RegisterCommonOption(name string, defaultvalue interface{}) error {
 			return errors.New("Error writing settings.json file: " + err.Error())
 		}
 	} else {
-		defaultCommonSettings[name] = v
+		defaultCommonSettings[name] = defaultvalue
 	}
 	return nil
 }
 
 // RegisterGlobalOption creates a new global-only option
 func RegisterGlobalOption(name string, defaultvalue interface{}) error {
-	if v, ok := GlobalSettings[name]; !ok {
+	if _, ok := GlobalSettings[name]; !ok {
 		DefaultGlobalOnlySettings[name] = defaultvalue
 		GlobalSettings[name] = defaultvalue
 		err := WriteSettings(filepath.Join(ConfigDir, "settings.json"))
@@ -262,7 +262,7 @@ func RegisterGlobalOption(name string, defaultvalue interface{}) error {
 			return errors.New("Error writing settings.json file: " + err.Error())
 		}
 	} else {
-		DefaultGlobalOnlySettings[name] = v
+		DefaultGlobalOnlySettings[name] = defaultvalue
 	}
 	return nil
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -230,10 +230,6 @@ func RegisterGlobalOptionPlug(pl string, name string, defaultvalue interface{}) 
 func RegisterCommonOption(name string, defaultvalue interface{}) error {
 	if _, ok := GlobalSettings[name]; !ok {
 		GlobalSettings[name] = defaultvalue
-		err := WriteSettings(filepath.Join(ConfigDir, "settings.json"))
-		if err != nil {
-			return errors.New("Error writing settings.json file: " + err.Error())
-		}
 	}
 	defaultCommonSettings[name] = defaultvalue
 	return nil
@@ -243,10 +239,6 @@ func RegisterCommonOption(name string, defaultvalue interface{}) error {
 func RegisterGlobalOption(name string, defaultvalue interface{}) error {
 	if _, ok := GlobalSettings[name]; !ok {
 		GlobalSettings[name] = defaultvalue
-		err := WriteSettings(filepath.Join(ConfigDir, "settings.json"))
-		if err != nil {
-			return errors.New("Error writing settings.json file: " + err.Error())
-		}
 	}
 	DefaultGlobalOnlySettings[name] = defaultvalue
 	return nil

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -229,30 +229,26 @@ func RegisterGlobalOptionPlug(pl string, name string, defaultvalue interface{}) 
 // RegisterCommonOption creates a new option
 func RegisterCommonOption(name string, defaultvalue interface{}) error {
 	if _, ok := GlobalSettings[name]; !ok {
-		defaultCommonSettings[name] = defaultvalue
 		GlobalSettings[name] = defaultvalue
 		err := WriteSettings(filepath.Join(ConfigDir, "settings.json"))
 		if err != nil {
 			return errors.New("Error writing settings.json file: " + err.Error())
 		}
-	} else {
-		defaultCommonSettings[name] = defaultvalue
 	}
+	defaultCommonSettings[name] = defaultvalue
 	return nil
 }
 
 // RegisterGlobalOption creates a new global-only option
 func RegisterGlobalOption(name string, defaultvalue interface{}) error {
 	if _, ok := GlobalSettings[name]; !ok {
-		DefaultGlobalOnlySettings[name] = defaultvalue
 		GlobalSettings[name] = defaultvalue
 		err := WriteSettings(filepath.Join(ConfigDir, "settings.json"))
 		if err != nil {
 			return errors.New("Error writing settings.json file: " + err.Error())
 		}
-	} else {
-		DefaultGlobalOnlySettings[name] = defaultvalue
 	}
+	DefaultGlobalOnlySettings[name] = defaultvalue
 	return nil
 }
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -218,18 +218,7 @@ func OverwriteSettings(filename string) error {
 
 // RegisterCommonOptionPlug creates a new option (called pl.name). This is meant to be called by plugins to add options.
 func RegisterCommonOptionPlug(pl string, name string, defaultvalue interface{}) error {
-	name = pl + "." + name
-	if _, ok := GlobalSettings[name]; !ok {
-		defaultCommonSettings[name] = defaultvalue
-		GlobalSettings[name] = defaultvalue
-		err := WriteSettings(filepath.Join(ConfigDir, "settings.json"))
-		if err != nil {
-			return errors.New("Error writing settings.json file: " + err.Error())
-		}
-	} else {
-		defaultCommonSettings[name] = defaultvalue
-	}
-	return nil
+	return RegisterCommonOption(pl+"."+name, defaultvalue)
 }
 
 // RegisterGlobalOptionPlug creates a new global-only option (named pl.name)


### PR DESCRIPTION
It doesn't seem necessary to write settings to settings.json when registering a new option. The option is set to its default value, which means that it will not be written to settings.json (precisely because it's the default value), so the contents of settings.json don't change and thus don't need to be written again.

This unneeded writing, in particular, causes unexpected "The file on disk has changed. Reload file? (y,n,esc)" each time when we open settings.json via micro.

Fixes https://github.com/zyedidia/micro/issues/2647

As a bonus, a few other small fixes and code improvements.

