### PR TITLE
Fix overwriting persistent non-default settings in `settings.json` with temporary default settings

### DIFF
--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -275,6 +275,7 @@ func main() {
 				continue
 			}
 			config.GlobalSettings[k] = nativeValue
+			config.VolatileSettings[k] = true
 		}
 	}
 

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -482,6 +482,7 @@ func SetGlobalOptionNative(option string, nativeValue interface{}) error {
 	if !local {
 		config.GlobalSettings[option] = nativeValue
 		config.ModifiedSettings[option] = true
+		delete(config.VolatileSettings, option)
 
 		if option == "colorscheme" {
 			// LoadSyntaxFiles()

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -33,10 +33,15 @@ var (
 	// ModifiedSettings is a map of settings which should be written to disk
 	// because they have been modified by the user in this session
 	ModifiedSettings map[string]bool
+
+	// VolatileSettings is a map of settings which should not be written to disk
+	// because they have been temporarily set for this session only
+	VolatileSettings map[string]bool
 )
 
 func init() {
 	ModifiedSettings = make(map[string]bool)
+	VolatileSettings = make(map[string]bool)
 	parsedSettings = make(map[string]interface{})
 }
 
@@ -173,7 +178,8 @@ func WriteSettings(filename string) error {
 		for k, v := range parsedSettings {
 			if !strings.HasPrefix(reflect.TypeOf(v).String(), "map") {
 				cur, okcur := GlobalSettings[k]
-				if def, ok := defaults[k]; ok && okcur && reflect.DeepEqual(cur, def) {
+				_, vol := VolatileSettings[k]
+				if def, ok := defaults[k]; ok && okcur && !vol && reflect.DeepEqual(cur, def) {
 					delete(parsedSettings, k)
 				}
 			}


### PR DESCRIPTION
Passing options via `micro -option=value` in the command line should only temporarily override the option value for the current micro session, not change it permanently in settings.json. But currently it wrongly writes it to settings.json in the case when the value passed via command line is the default value of this option, while the current permanent setting in settings.json is a non-default value.

Fixes #3005