### PR TITLE
Add support for highlighting matching braces with colors

### DIFF
--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -558,6 +558,9 @@ func (w *BufWindow) displayBuffer() {
 					for _, mb := range matchingBraces {
 						if mb.X == bloc.X && mb.Y == bloc.Y {
 							style = style.Underline(true)
+							if s, ok := config.Colorscheme["match-brace"]; ok {
+								style = s
+							}
 						}
 					}
 				}

--- a/runtime/help/colors.md
+++ b/runtime/help/colors.md
@@ -180,6 +180,8 @@ Here is a list of the colorscheme groups that you can use:
 * tabbar (Color of the tabbar that lists open files)
 * indent-char (Color of the character which indicates tabs if the option is
   enabled)
+* match-brace (Color of the matching braces when the cursor is on a brace
+  character)
 * line-number
 * gutter-error
 * gutter-warning


### PR DESCRIPTION
By default, matching braces are only underlined, without any color highlighting. Allow overriding this default behavior by specifying colors for matching braces in a colorscheme file, e.g.:

```
color-link match-brace "#F8F8F2,#707070"
```

Ref #3013