### PR TITLE
Make plugins in `~/.config/micro/plug` dir override built-in plugins

### DIFF
--- a/internal/config/rtfiles.go
+++ b/internal/config/rtfiles.go
@@ -218,7 +218,15 @@ func InitRuntimeFiles() {
 
 	plugdir = filepath.Join("runtime", "plugins")
 	if files, err := rt.AssetDir(plugdir); err == nil {
+	outer:
 		for _, d := range files {
+			for _, p := range Plugins {
+				if p.Name == d {
+					log.Println(p.Name, "built-in plugin overridden by user-defined one")
+					continue outer
+				}
+			}
+
 			if srcs, err := rt.AssetDir(filepath.Join(plugdir, d)); err == nil {
 				p := new(Plugin)
 				p.Name = d


### PR DESCRIPTION
If `~/.config/micro/plug` directory contains a plugin with the same name as a built-in plugin, the expected behavior is that the user-defined plugin in `~/.config/micro/plug` is loaded instead of the built-in one.

Whereas the existing behavior is that the built-in plugin is used instead of the user-defined one. Even worse, it is buggy: in this case the plugin is registered twice, so its callbacks are executed twice (e.g. with the `autoclose` plugin, a bracket is autoclosed with two closing brackets instead of one).

Fix this by ensuring that if a plugin with the same name exists in the `~/.config/micro/plug` directory, the built-in one is ignored.

Fixes #3029