### PR TITLE
micro: DoEvent: Don't forward the resize event into the InfoBar

### DIFF
--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -473,7 +473,8 @@ func DoEvent() {
 	}
 
 	ulua.Lock.Lock()
-	if action.InfoBar.HasPrompt {
+	_, resize := event.(*tcell.EventResize)
+	if action.InfoBar.HasPrompt && !resize {
 		action.InfoBar.HandleEvent(event)
 	} else {
 		action.Tabs.HandleEvent(event)


### PR DESCRIPTION
In case the `InfoBar` has an active prompt (e.g. Find, etc.) it shouldn't generally receive any event, because it isn't responsible for each. In case a resize event has been fired it needs to be processed by the tab handler instead.

Fixes #3033