### PR TITLE
termwindow: Show cursor only when his X and Y axis is smaller than the window size

### DIFF
--- a/internal/display/termwindow.go
+++ b/internal/display/termwindow.go
@@ -110,6 +110,8 @@ func (w *TermWindow) Display() {
 	}
 	if w.State.CursorVisible() && w.active {
 		curx, cury := w.State.Cursor()
-		screen.ShowCursor(curx+w.X, cury+w.Y)
+		if curx < w.Width && cury < w.Height {
+			screen.ShowCursor(curx+w.X, cury+w.Y)
+		}
 	}
 }


### PR DESCRIPTION
This will prevent showing the cursor over the terminal windows own status bar.

Fixes #3034