### PR TITLE
command: Fix set local-only options for the current buffer only

### DIFF
--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -532,8 +532,12 @@ func SetGlobalOptionNative(option string, nativeValue interface{}) error {
 		}
 	}
 
-	for _, b := range buffer.OpenBuffers {
-		b.SetOptionNative(option, nativeValue)
+	if local {
+		MainTab().CurPane().Buf.SetOptionNative(option, nativeValue)
+	} else {
+		for _, b := range buffer.OpenBuffers {
+			b.SetOptionNative(option, nativeValue)
+		}
 	}
 
 	return config.WriteSettings(filepath.Join(config.ConfigDir, "settings.json"))


### PR DESCRIPTION
Otherwise we will set local-only options for all open buffers, which isn't intended, working as expected and either as documented.

Fixes #3041