### PR TITLE
bufwindow: Fix slice creation with wordwrap active in case of zero size split

### DIFF
--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -601,7 +601,7 @@ func (w *BufWindow) displayBuffer() {
 		}
 
 		var word []glyph
-		if wordwrap {
+		if wordwrap && w.bufWidth > 0 {
 			word = make([]glyph, 0, w.bufWidth)
 		} else {
 			word = make([]glyph, 0, 1)


### PR DESCRIPTION
The caption of the slice needs to have a minimum of 1 and thus 0 isn't possible.

Fixes #3052