### PR TITLE
command: Fix `reload` command to correctly initialize and reload all runtime files

### DIFF
--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -254,7 +254,7 @@ func main() {
 		screen.TermMessage(err)
 	}
 
-	config.InitRuntimeFiles()
+	config.InitRuntimeFiles(true)
 	err = config.ReadSettings()
 	if err != nil {
 		screen.TermMessage(err)

--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -254,7 +254,9 @@ func main() {
 		screen.TermMessage(err)
 	}
 
-	config.InitRuntimeFiles(true)
+	config.InitRuntimeFiles()
+	config.InitPlugins()
+
 	err = config.ReadSettings()
 	if err != nil {
 		screen.TermMessage(err)

--- a/cmd/micro/micro_test.go
+++ b/cmd/micro/micro_test.go
@@ -35,7 +35,7 @@ func startup(args []string) (tcell.SimulationScreen, error) {
 		return nil, err
 	}
 
-	config.InitRuntimeFiles()
+	config.InitRuntimeFiles(true)
 	err = config.ReadSettings()
 	if err != nil {
 		return nil, err

--- a/cmd/micro/micro_test.go
+++ b/cmd/micro/micro_test.go
@@ -35,7 +35,9 @@ func startup(args []string) (tcell.SimulationScreen, error) {
 		return nil, err
 	}
 
-	config.InitRuntimeFiles(true)
+	config.InitRuntimeFiles()
+	config.InitPlugins()
+
 	err = config.ReadSettings()
 	if err != nil {
 		return nil, err

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -340,7 +340,15 @@ func ReloadConfig() {
 }
 
 func reloadRuntime(reloadAll bool) {
-	config.InitRuntimeFiles()
+	if reloadAll {
+		err := config.RunPluginFn("deinit")
+		if err != nil {
+			screen.TermMessage(err)
+		}
+	}
+
+	config.InitRuntimeFiles(reloadAll)
+
 	err := config.ReadSettings()
 	if err != nil {
 		screen.TermMessage(err)
@@ -351,10 +359,6 @@ func reloadRuntime(reloadAll bool) {
 	}
 
 	if reloadAll {
-		err = config.RunPluginFn("deinit")
-		if err != nil {
-			screen.TermMessage(err)
-		}
 		err = config.LoadAllPlugins()
 		if err != nil {
 			screen.TermMessage(err)

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -339,15 +339,19 @@ func ReloadConfig() {
 	reloadRuntime(false)
 }
 
-func reloadRuntime(reloadAll bool) {
-	if reloadAll {
+func reloadRuntime(reloadPlugins bool) {
+	if reloadPlugins {
 		err := config.RunPluginFn("deinit")
 		if err != nil {
 			screen.TermMessage(err)
 		}
 	}
 
-	config.InitRuntimeFiles(reloadAll)
+	config.InitRuntimeFiles()
+
+	if reloadPlugins {
+		config.InitPlugins()
+	}
 
 	err := config.ReadSettings()
 	if err != nil {
@@ -358,7 +362,7 @@ func reloadRuntime(reloadAll bool) {
 		screen.TermMessage(err)
 	}
 
-	if reloadAll {
+	if reloadPlugins {
 		err = config.LoadAllPlugins()
 		if err != nil {
 			screen.TermMessage(err)
@@ -368,7 +372,7 @@ func reloadRuntime(reloadAll bool) {
 	InitBindings()
 	InitCommands()
 
-	if reloadAll {
+	if reloadPlugins {
 		err = config.RunPluginFn("preinit")
 		if err != nil {
 			screen.TermMessage(err)

--- a/internal/buffer/buffer_test.go
+++ b/internal/buffer/buffer_test.go
@@ -20,6 +20,8 @@ type operation struct {
 
 func init() {
 	ulua.L = lua.NewState()
+	config.InitRuntimeFiles()
+	config.InitPlugins()
 	config.InitGlobalSettings()
 	config.GlobalSettings["backup"] = false
 	config.GlobalSettings["fastdirty"] = true

--- a/internal/buffer/settings.go
+++ b/internal/buffer/settings.go
@@ -20,7 +20,7 @@ func (b *Buffer) SetOptionNative(option string, nativeValue interface{}) error {
 	} else if option == "statusline" {
 		screen.Redraw()
 	} else if option == "filetype" {
-		config.InitRuntimeFiles(false)
+		config.InitRuntimeFiles()
 		err := config.ReadSettings()
 		if err != nil {
 			screen.TermMessage(err)

--- a/internal/buffer/settings.go
+++ b/internal/buffer/settings.go
@@ -20,7 +20,7 @@ func (b *Buffer) SetOptionNative(option string, nativeValue interface{}) error {
 	} else if option == "statusline" {
 		screen.Redraw()
 	} else if option == "filetype" {
-		config.InitRuntimeFiles()
+		config.InitRuntimeFiles(false)
 		err := config.ReadSettings()
 		if err != nil {
 			screen.TermMessage(err)
@@ -74,7 +74,7 @@ func (b *Buffer) SetOptionNative(option string, nativeValue interface{}) error {
 				}
 			}
 		}
- 	}
+	}
 
 	if b.OptionCallback != nil {
 		b.OptionCallback(option, nativeValue)

--- a/internal/config/rtfiles.go
+++ b/internal/config/rtfiles.go
@@ -39,10 +39,6 @@ type RuntimeFile interface {
 var allFiles [][]RuntimeFile
 var realFiles [][]RuntimeFile
 
-func init() {
-	initRuntimeVars()
-}
-
 func initRuntimeVars() {
 	allFiles = make([][]RuntimeFile, NumTypes)
 	realFiles = make([][]RuntimeFile, NumTypes)

--- a/internal/config/rtfiles.go
+++ b/internal/config/rtfiles.go
@@ -40,8 +40,13 @@ var allFiles [][]RuntimeFile
 var realFiles [][]RuntimeFile
 
 func init() {
+	initRuntimeVars()
+}
+
+func initRuntimeVars() {
 	allFiles = make([][]RuntimeFile, NumTypes)
 	realFiles = make([][]RuntimeFile, NumTypes)
+	Plugins = Plugins[:0]
 }
 
 // NewRTFiletype creates a new RTFiletype
@@ -172,6 +177,8 @@ func InitRuntimeFiles() {
 		AddRuntimeFilesFromDirectory(fileType, filepath.Join(ConfigDir, dir), pattern)
 		AddRuntimeFilesFromAssets(fileType, path.Join("runtime", dir), pattern)
 	}
+
+	initRuntimeVars()
 
 	add(RTColorscheme, "colorschemes", "*.micro")
 	add(RTSyntax, "syntax", "*.yaml")

--- a/internal/config/rtfiles.go
+++ b/internal/config/rtfiles.go
@@ -40,13 +40,15 @@ var allFiles [][]RuntimeFile
 var realFiles [][]RuntimeFile
 
 func init() {
-	initRuntimeVars()
+	initRuntimeVars(true)
 }
 
-func initRuntimeVars() {
+func initRuntimeVars(reloadAll bool) {
 	allFiles = make([][]RuntimeFile, NumTypes)
 	realFiles = make([][]RuntimeFile, NumTypes)
-	Plugins = Plugins[:0]
+	if reloadAll {
+		Plugins = Plugins[:0]
+	}
 }
 
 // NewRTFiletype creates a new RTFiletype
@@ -172,86 +174,47 @@ func ListRealRuntimeFiles(fileType RTFiletype) []RuntimeFile {
 }
 
 // InitRuntimeFiles initializes all assets file and the config directory
-func InitRuntimeFiles() {
+func InitRuntimeFiles(reloadAll bool) {
 	add := func(fileType RTFiletype, dir, pattern string) {
 		AddRuntimeFilesFromDirectory(fileType, filepath.Join(ConfigDir, dir), pattern)
 		AddRuntimeFilesFromAssets(fileType, path.Join("runtime", dir), pattern)
 	}
 
-	initRuntimeVars()
+	initRuntimeVars(reloadAll)
 
 	add(RTColorscheme, "colorschemes", "*.micro")
 	add(RTSyntax, "syntax", "*.yaml")
 	add(RTSyntaxHeader, "syntax", "*.hdr")
 	add(RTHelp, "help", "*.md")
 
-	initlua := filepath.Join(ConfigDir, "init.lua")
-	if _, err := os.Stat(initlua); !os.IsNotExist(err) {
-		p := new(Plugin)
-		p.Name = "initlua"
-		p.DirName = "initlua"
-		p.Srcs = append(p.Srcs, realFile(initlua))
-		Plugins = append(Plugins, p)
-	}
-
-	// Search ConfigDir for plugin-scripts
-	plugdir := filepath.Join(ConfigDir, "plug")
-	files, _ := ioutil.ReadDir(plugdir)
-
-	isID := regexp.MustCompile(`^[_A-Za-z0-9]+$`).MatchString
-
-	for _, d := range files {
-		plugpath := filepath.Join(plugdir, d.Name())
-		if stat, err := os.Stat(plugpath); err == nil && stat.IsDir() {
-			srcs, _ := ioutil.ReadDir(plugpath)
+	if reloadAll {
+		initlua := filepath.Join(ConfigDir, "init.lua")
+		if _, err := os.Stat(initlua); !os.IsNotExist(err) {
 			p := new(Plugin)
-			p.Name = d.Name()
-			p.DirName = d.Name()
-			for _, f := range srcs {
-				if strings.HasSuffix(f.Name(), ".lua") {
-					p.Srcs = append(p.Srcs, realFile(filepath.Join(plugdir, d.Name(), f.Name())))
-				} else if strings.HasSuffix(f.Name(), ".json") {
-					data, err := ioutil.ReadFile(filepath.Join(plugdir, d.Name(), f.Name()))
-					if err != nil {
-						continue
-					}
-					p.Info, err = NewPluginInfo(data)
-					if err != nil {
-						continue
-					}
-					p.Name = p.Info.Name
-				}
-			}
-
-			if !isID(p.Name) || len(p.Srcs) <= 0 {
-				log.Println(p.Name, "is not a plugin")
-				continue
-			}
+			p.Name = "initlua"
+			p.DirName = "initlua"
+			p.Srcs = append(p.Srcs, realFile(initlua))
 			Plugins = append(Plugins, p)
 		}
-	}
 
-	plugdir = filepath.Join("runtime", "plugins")
-	if files, err := rt.AssetDir(plugdir); err == nil {
-	outer:
+		// Search ConfigDir for plugin-scripts
+		plugdir := filepath.Join(ConfigDir, "plug")
+		files, _ := ioutil.ReadDir(plugdir)
+
+		isID := regexp.MustCompile(`^[_A-Za-z0-9]+$`).MatchString
+
 		for _, d := range files {
-			for _, p := range Plugins {
-				if p.Name == d {
-					log.Println(p.Name, "built-in plugin overridden by user-defined one")
-					continue outer
-				}
-			}
-
-			if srcs, err := rt.AssetDir(filepath.Join(plugdir, d)); err == nil {
+			plugpath := filepath.Join(plugdir, d.Name())
+			if stat, err := os.Stat(plugpath); err == nil && stat.IsDir() {
+				srcs, _ := ioutil.ReadDir(plugpath)
 				p := new(Plugin)
-				p.Name = d
-				p.DirName = d
-				p.Default = true
+				p.Name = d.Name()
+				p.DirName = d.Name()
 				for _, f := range srcs {
-					if strings.HasSuffix(f, ".lua") {
-						p.Srcs = append(p.Srcs, assetFile(filepath.Join(plugdir, d, f)))
-					} else if strings.HasSuffix(f, ".json") {
-						data, err := rt.Asset(filepath.Join(plugdir, d, f))
+					if strings.HasSuffix(f.Name(), ".lua") {
+						p.Srcs = append(p.Srcs, realFile(filepath.Join(plugdir, d.Name(), f.Name())))
+					} else if strings.HasSuffix(f.Name(), ".json") {
+						data, err := ioutil.ReadFile(filepath.Join(plugdir, d.Name(), f.Name()))
 						if err != nil {
 							continue
 						}
@@ -262,11 +225,52 @@ func InitRuntimeFiles() {
 						p.Name = p.Info.Name
 					}
 				}
+
 				if !isID(p.Name) || len(p.Srcs) <= 0 {
 					log.Println(p.Name, "is not a plugin")
 					continue
 				}
 				Plugins = append(Plugins, p)
+			}
+		}
+
+		plugdir = filepath.Join("runtime", "plugins")
+		if files, err := rt.AssetDir(plugdir); err == nil {
+		outer:
+			for _, d := range files {
+				for _, p := range Plugins {
+					if p.Name == d {
+						log.Println(p.Name, "built-in plugin overridden by user-defined one")
+						continue outer
+					}
+				}
+
+				if srcs, err := rt.AssetDir(filepath.Join(plugdir, d)); err == nil {
+					p := new(Plugin)
+					p.Name = d
+					p.DirName = d
+					p.Default = true
+					for _, f := range srcs {
+						if strings.HasSuffix(f, ".lua") {
+							p.Srcs = append(p.Srcs, assetFile(filepath.Join(plugdir, d, f)))
+						} else if strings.HasSuffix(f, ".json") {
+							data, err := rt.Asset(filepath.Join(plugdir, d, f))
+							if err != nil {
+								continue
+							}
+							p.Info, err = NewPluginInfo(data)
+							if err != nil {
+								continue
+							}
+							p.Name = p.Info.Name
+						}
+					}
+					if !isID(p.Name) || len(p.Srcs) <= 0 {
+						log.Println(p.Name, "is not a plugin")
+						continue
+					}
+					Plugins = append(Plugins, p)
+				}
 			}
 		}
 	}

--- a/internal/config/rtfiles_test.go
+++ b/internal/config/rtfiles_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	InitRuntimeFiles()
+	InitRuntimeFiles(true)
 }
 
 func TestAddFile(t *testing.T) {

--- a/internal/config/rtfiles_test.go
+++ b/internal/config/rtfiles_test.go
@@ -7,7 +7,8 @@ import (
 )
 
 func init() {
-	InitRuntimeFiles(true)
+	InitRuntimeFiles()
+	InitPlugins()
 }
 
 func TestAddFile(t *testing.T) {


### PR DESCRIPTION
This fix will prevent duplicating runtime files in the moment `reload` and it will now reload the plugins as well.
Now it needs to be discussed if it's really a good idea to export `reload` to the Lua plugins, because this could lead to unexpected behavior within the plugins.

Fixes #2795
Fixes #3044
Fixes #3059