### PR TITLE
Tell user that option can't be set locally when user tries to set global only option

### DIFF
--- a/internal/buffer/settings.go
+++ b/internal/buffer/settings.go
@@ -86,6 +86,9 @@ func (b *Buffer) SetOptionNative(option string, nativeValue interface{}) error {
 // SetOption sets a given option to a value just for this buffer
 func (b *Buffer) SetOption(option, value string) error {
 	if _, ok := b.Settings[option]; !ok {
+		if _, ok := config.DefaultGlobalOnlySettings[option]; ok {
+			return config.ErrGlobalOnlyOption
+		}
 		return config.ErrInvalidOption
 	}
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -23,6 +23,8 @@ var (
 	ErrInvalidOption = errors.New("Invalid option")
 	ErrInvalidValue  = errors.New("Invalid value")
 
+	ErrGlobalOnlyOption = errors.New("This option can't be set locally")
+
 	// The options that the user can set
 	GlobalSettings map[string]interface{}
 


### PR DESCRIPTION
Tell user that option can't be set locally when user tries to set global only option option instead of just telling that option is invalid