### PR TITLE
rtfiles: Give user defined runtime files precedence over asset files

### DIFF
--- a/internal/config/rtfiles.go
+++ b/internal/config/rtfiles.go
@@ -129,9 +129,17 @@ func AddRuntimeFilesFromAssets(fileType RTFiletype, directory, pattern string) {
 	if err != nil {
 		return
 	}
+
+assetLoop:
 	for _, f := range files {
 		if ok, _ := path.Match(pattern, f); ok {
-			AddRuntimeFile(fileType, assetFile(path.Join(directory, f)))
+			af := assetFile(path.Join(directory, f))
+			for _, rf := range realFiles[fileType] {
+				if af.Name() == rf.Name() {
+					continue assetLoop
+				}
+			}
+			AddRuntimeFile(fileType, af)
 		}
 	}
 }


### PR DESCRIPTION
In case the user creates runtime files (e.g. color schemes, syntax, etc.) with the same name as the built in asset files then the user defined ones will receive precedence over the built in ones. There is no duplication any longer.

Fixes #3058