### PR TITLE
Fix ruler overwriting neighboring split pane + fix crash #3052

### DIFF
--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -620,7 +620,7 @@ func (w *BufWindow) displayBuffer() {
 		wordwidth := 0
 
 		totalwidth := w.StartCol - nColsBeforeStart
-		for len(line) > 0 {
+		for len(line) > 0 && vloc.X < maxWidth {
 			r, combc, size := util.DecodeCharacter(line)
 			line = line[size:]
 


### PR DESCRIPTION
When we resize a split pane to a very small width, so that the ruler does not fit in the pane, it overwrites the sibling split pane.

To fix it, clean up the calculation of gutter width, buffer width and scrollbar width, so that they add up exactly to the window width, and ensure that we don't draw the gutter beyond this calculated gutter
width (gutterOffset).

As a bonus, this also fixes the crash #3052 (observed when resizing a split pane to a very small width, if wordwrap is enabled), by ensuring that bufWidth is never negative.

Fixes #3052 