### PR TITLE
Fix split pane divider hovering over neighboring split pane

### DIFF
--- a/internal/views/splits.go
+++ b/internal/views/splits.go
@@ -185,6 +185,9 @@ func (n *Node) hResizeSplit(i int, size int) bool {
 
 // ResizeSplit resizes a certain split to a given size
 func (n *Node) ResizeSplit(size int) bool {
+	if size <= 0 {
+		return false
+	}
 	if len(n.parent.children) <= 1 {
 		// cannot resize a lone node
 		return false


### PR DESCRIPTION
Fix the following funny issue: if we open 3 vertical split panes (i.e. with 2 vertical dividers between them) and drag the rightmost divider to the left (for resizing the middle and the rightmost split panes), it does not stop at the leftmost divider but jumps over it and then hovers over the leftmost split pane. And likewise with horizontal split panes.