### PR TITLE
actions: saveas: Fix crash at access without permission

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -793,25 +793,26 @@ func (h *BufPane) SaveAsCB(action string, callback func()) bool {
 			filename := strings.Join(args, " ")
 			fileinfo, err := os.Stat(filename)
 			if err != nil {
-				if os.IsNotExist(err) {
+				if errors.Is(err, fs.ErrNotExist) || errors.Is(err, fs.ErrPermission) {
 					noPrompt := h.saveBufToFile(filename, action, callback)
 					if noPrompt {
 						h.completeAction(action)
 						return
 					}
 				}
-			}
-			InfoBar.YNPrompt(
-				fmt.Sprintf("the file %s already exists in the directory, would you like to overwrite? Y/n", fileinfo.Name()),
-				func(yes, canceled bool) {
-					if yes && !canceled {
-						noPrompt := h.saveBufToFile(filename, action, callback)
-						if noPrompt {
-							h.completeAction(action)
+			} else {
+				InfoBar.YNPrompt(
+					fmt.Sprintf("The file %s already exists in the directory, would you like to overwrite? Y/n", fileinfo.Name()),
+					func(yes, canceled bool) {
+						if yes && !canceled {
+							noPrompt := h.saveBufToFile(filename, action, callback)
+							if noPrompt {
+								h.completeAction(action)
+							}
 						}
-					}
-				},
-			)
+					},
+				)
+			}
 		}
 	})
 	return false


### PR DESCRIPTION
In the moment `os.Stat()` fails due to not existing permission `fileinfo.Name()` will be access, which we need to prevent. In that case we can't be sure, if the file exists or not anyway. Missing privileges should lead to a call of `saveBufToFile` since this will take care of extending privileges (e.g. by invoking `sudo`).

Currently the behavior ignores existing files which can't be accessed due to missing permissions. They will be overwritten in the moment `sudo` is invoked without any further check if the user wants to overwrite possible existing ones.
On `micro` start with such a files as parameter we will receive the complaint:
```
stat [FILENAME]: permission denied

Press enter to continue
```

So maybe we need a more plausible but more complex solution to 1. stat with more privileges and 2. ask to load/read the file with more privileges.

Fixes #3080