### PR TITLE
Fix cursor moving down when selection exist. Solves (#3087)

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -176,7 +176,7 @@ func (h *BufPane) CursorUp() bool {
 
 // CursorDown moves the cursor down
 func (h *BufPane) CursorDown() bool {
-	h.Cursor.Deselect(true)
+	h.Cursor.Deselect(false)
 	h.MoveCursorDown(1)
 	h.Relocate()
 	return true


### PR DESCRIPTION
Previously `CursorDown` function called `Deselect` with a wrong argument which lead to the situation when cursor was moved to the start instead of the end of the selection. Solves (#3087)