### PR TITLE
Set bits in mode used when creating files

### DIFF
--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -54,7 +54,7 @@ func overwriteFile(name string, enc encoding.Encoding, fn func(io.Writer) error,
 			screen.TempStart(screenb)
 			return err
 		}
-	} else if writeCloser, err = os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644); err != nil {
+	} else if writeCloser, err = os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666); err != nil {
 		return
 	}
 


### PR DESCRIPTION
The bits set in the mode of files that are created are usually bits not set in the umask except execution bits, so files are usually opened with 0666 mode in other programs. The write permission bit of group and other users in the mode is usually cleared because they are set in the umask.

The bits are not set even if they are cleared in the umask when using micro, so the argument is changed in this pull request. I have not tested if it would work when changing the argument. I have also not made a pull request before, so it would be nice if I am told if there is something I did that is strange.
