### PR TITLE
Add onRune parameter, utf8 package in plugins.md

### DIFF
--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -67,9 +67,9 @@ which micro defines:
    by the user. Returns a boolean which defines whether the action should
    be canceled.
 
-* `onRune(rune)`: runs when the composed rune has been inserted
+* `onRune(bufpane, rune)`: runs when the composed rune has been inserted
 
-* `preRune(rune)`: runs before the composed rune will be inserted
+* `preRune(bufpane, rune)`: runs before the composed rune will be inserted
 
 For example a function which is run every time the user saves the buffer
 would be:
@@ -367,6 +367,7 @@ strings
 regexp
 errors
 time
+unicode/utf8
 archive/zip
 net/http
 ```


### PR DESCRIPTION
The bufpane where a rune is entered is passed when `onRune`, `preRune` are called and `unicode/utf8` can be used in plugins, but the parameter and package were not written in `plugins.md` so they have been added in the file in this pull request.