### PR TITLE
Do correct cursor right with storing visual X in `CursorRight` action

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -211,7 +211,7 @@ func (h *BufPane) CursorLeft() bool {
 func (h *BufPane) CursorRight() bool {
 	if h.Cursor.HasSelection() {
 		h.Cursor.Deselect(false)
-		h.Cursor.Loc = h.Cursor.Loc.Move(1, h.Buf)
+		h.Cursor.Right()
 	} else {
 		tabstospaces := h.Buf.Settings["tabstospaces"].(bool)
 		tabmovement := h.Buf.Settings["tabmovement"].(bool)


### PR DESCRIPTION
***The description was provided by  @vicencb:***

Here is a concrete example to reproduce the issue i am referring to:

Given this text file:
```
1234
ABCD
EFGH
IJKL
```
Move the cursor to `1` if not already there, then `SelectDown`, then `CursorRight` and finally `CursorDown`.
After this, the cursor is expected to be at `E` but instead it is after the `H`.