### PR TITLE
Add syntax highlight code for ignore files

### DIFF
--- a/runtime/syntax/ignore.yaml
+++ b/runtime/syntax/ignore.yaml
@@ -1,0 +1,14 @@
+filetype: "ignore"
+
+detect:
+  filename: ".*ignore$"
+
+rules:
+  - statement: ".*$"           # files
+  - constant.string: ".*/$"    # directories
+  - diff-deleted: "^!.*"       # negated
+
+  - special: "/"
+  - identifier: "^!|\\?|\\*|\\[.*?]|\\."
+
+  - comment: "#.*$"


### PR DESCRIPTION
Adding ignore file support by default so you don't need to install the [language-ignore plugin](https://codeberg.org/micro-plugins/language-ignore).

![image](https://github.com/zyedidia/micro/assets/44283700/52989622-d9c6-4d8d-855c-eb5a1eb6428d)
