### PR TITLE
Add wrapindent option to allow wrapping and hanging indents

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -317,6 +317,7 @@ var defaultCommonSettings = map[string]interface{}{
 	"tabstospaces":   false,
 	"useprimary":     true,
 	"wordwrap":       false,
+	"wrapindent":     float64(-1),
 }
 
 func GetInfoBarOffset() int {

--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -432,6 +432,7 @@ func (w *BufWindow) displayBuffer() {
 
 	softwrap := b.Settings["softwrap"].(bool)
 	wordwrap := softwrap && b.Settings["wordwrap"].(bool)
+	wrapindent := util.IntOpt(w.Buf.Settings["wrapindent"])
 
 	tabsize := util.IntOpt(b.Settings["tabsize"])
 	colorcolumn := util.IntOpt(b.Settings["colorcolumn"])
@@ -649,11 +650,19 @@ func (w *BufWindow) displayBuffer() {
 				if !softwrap {
 					break
 				} else {
+					// Get leading whitespaces before we wrap the line
+					ws := util.GetLeadingWhitespace(b.LineBytes(bloc.Y))
+
 					vloc.Y++
 					if vloc.Y >= w.bufHeight {
 						break
 					}
 					wrap()
+
+					// After we wrapped the line, add the visual width of the leading whitespaces to the visual X column
+					if wrapindent > -1 {
+						vloc.X += util.StringWidth(ws, len(ws), tabsize) + wrapindent
+					}
 				}
 			}
 
@@ -682,11 +691,19 @@ func (w *BufWindow) displayBuffer() {
 				if !softwrap {
 					break
 				} else {
+					// Get leading whitespaces before we wrap the line
+					ws := util.GetLeadingWhitespace(b.LineBytes(bloc.Y))
+
 					vloc.Y++
 					if vloc.Y >= w.bufHeight {
 						break
 					}
 					wrap()
+
+					// After we wrapped the line, add the visual width of the leading whitespaces to the visual X column
+					if wrapindent > -1 {
+						vloc.X += util.StringWidth(ws, len(ws), tabsize) + wrapindent
+					}
 				}
 			}
 		}

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -422,6 +422,13 @@ Here are the available options:
 
 	default value: `false`
 
+* `wrapindent`: maintain indentation of wrapped lines
+    * `-1`: disabled, wrapped lines begin in the first column
+    * `0`: wrapped lines inherit indentation from parent
+    * `4`: creates additional hanging indent by this width
+
+	default value: `-1`
+
 * `xterm`: micro will assume that the terminal it is running in conforms to
   `xterm-256color` regardless of what the `$TERM` variable actually contains.
    Enabling this option may cause unwanted effects if your terminal in fact


### PR DESCRIPTION
Possible implementation of feature request described in #2935 to allow configurable wrapping indents / hanging indents. Hope it corresponds with the project's coding styles and contribution guidelines.

Pull request adds the option `wrapindent`, which is -1 by default, where there is no change from the current default behaviour of no wrapping indents. Once `wrapindent` is set to 0 or greater, the new wrapped line respectively inherits or adds to the indent level of the parent line.

This seems to work fine for wordwrap: true / false, and softwrap: true. However, with wordwrap: false, it might occasionally add an additional empty space, if the line wrap is on a whitespace character, which might only be a minor quibble.