### PR TITLE
feat: adds GetArg and GetWord methods to Buffer

### DIFF
--- a/internal/action/infocomplete.go
+++ b/internal/action/infocomplete.go
@@ -17,7 +17,7 @@ import (
 // CommandComplete autocompletes commands
 func CommandComplete(b *buffer.Buffer) ([]string, []string) {
 	c := b.GetActiveCursor()
-	input, argstart := buffer.GetArg(b)
+	input, argstart := b.GetArg()
 
 	var suggestions []string
 	for cmd := range commands {
@@ -38,7 +38,7 @@ func CommandComplete(b *buffer.Buffer) ([]string, []string) {
 // HelpComplete autocompletes help topics
 func HelpComplete(b *buffer.Buffer) ([]string, []string) {
 	c := b.GetActiveCursor()
-	input, argstart := buffer.GetArg(b)
+	input, argstart := b.GetArg()
 
 	var suggestions []string
 
@@ -89,7 +89,7 @@ func contains(s []string, e string) bool {
 // OptionComplete autocompletes options
 func OptionComplete(b *buffer.Buffer) ([]string, []string) {
 	c := b.GetActiveCursor()
-	input, argstart := buffer.GetArg(b)
+	input, argstart := b.GetArg()
 
 	var suggestions []string
 	for option := range config.GlobalSettings {
@@ -116,7 +116,7 @@ func OptionValueComplete(b *buffer.Buffer) ([]string, []string) {
 	c := b.GetActiveCursor()
 	l := b.LineBytes(c.Y)
 	l = util.SliceStart(l, c.X)
-	input, argstart := buffer.GetArg(b)
+	input, argstart := b.GetArg()
 
 	completeValue := false
 	args := bytes.Split(l, []byte{' '})
@@ -210,7 +210,7 @@ func OptionValueComplete(b *buffer.Buffer) ([]string, []string) {
 // PluginCmdComplete autocompletes the plugin command
 func PluginCmdComplete(b *buffer.Buffer) ([]string, []string) {
 	c := b.GetActiveCursor()
-	input, argstart := buffer.GetArg(b)
+	input, argstart := b.GetArg()
 
 	var suggestions []string
 	for _, cmd := range PluginCmds {
@@ -232,7 +232,7 @@ func PluginComplete(b *buffer.Buffer) ([]string, []string) {
 	c := b.GetActiveCursor()
 	l := b.LineBytes(c.Y)
 	l = util.SliceStart(l, c.X)
-	input, argstart := buffer.GetArg(b)
+	input, argstart := b.GetArg()
 
 	completeValue := false
 	args := bytes.Split(l, []byte{' '})

--- a/internal/buffer/autocomplete.go
+++ b/internal/buffer/autocomplete.go
@@ -64,7 +64,7 @@ func (b *Buffer) CycleAutocomplete(forward bool) {
 
 // GetWord gets the most recent word separated by any separator
 // (whitespace, punctuation, any non alphanumeric character)
-func GetWord(b *Buffer) ([]byte, int) {
+func (b *Buffer) GetWord() ([]byte, int) {
 	c := b.GetActiveCursor()
 	l := b.LineBytes(c.Y)
 	l = util.SliceStart(l, c.X)
@@ -83,7 +83,7 @@ func GetWord(b *Buffer) ([]byte, int) {
 }
 
 // GetArg gets the most recent word (separated by ' ' only)
-func GetArg(b *Buffer) (string, int) {
+func (b *Buffer) GetArg() (string, int) {
 	c := b.GetActiveCursor()
 	l := b.LineBytes(c.Y)
 	l = util.SliceStart(l, c.X)
@@ -104,7 +104,7 @@ func GetArg(b *Buffer) (string, int) {
 // FileComplete autocompletes filenames
 func FileComplete(b *Buffer) ([]string, []string) {
 	c := b.GetActiveCursor()
-	input, argstart := GetArg(b)
+	input, argstart := b.GetArg()
 
 	sep := string(os.PathSeparator)
 	dirs := strings.Split(input, sep)
@@ -153,7 +153,7 @@ func FileComplete(b *Buffer) ([]string, []string) {
 // BufferComplete autocompletes based on previous words in the buffer
 func BufferComplete(b *Buffer) ([]string, []string) {
 	c := b.GetActiveCursor()
-	input, argstart := GetWord(b)
+	input, argstart := b.GetWord()
 
 	if argstart == -1 {
 		return []string{}, []string{}


### PR DESCRIPTION
Turns the GetArg function into a buffer object method to be used by lua plugins.

Example:
```lua
function init()
  local config = import('micro/config')

  config.MakeCommand('ex', function(bp, args) end, function(buf)
    local cmds = { '-h', '--help' }

    local input, argstart = buf:GetArg()

    local completions = {}
    local suggestions = {}

    for _, a in pairs(cmds) do
      local i, j = a:find(input, 1, true)
      if i == 1 then
        table.insert(suggestions, a)
        table.insert(completions, a:sub(j + 1))
      end
    end

    table.sort(completions)
    table.sort(suggestions)

    return completions, suggestions
  end)
end
```

Closes #3111