### PR TITLE
Fix Makefile syntax matching := and : as targets

### DIFF
--- a/runtime/syntax/makefile.yaml
+++ b/runtime/syntax/makefile.yaml
@@ -14,7 +14,8 @@ rules:
     - statement: "\\$\\((flavor|foreach|if|info|join|lastword|notdir|or)[[:space:]]"
     - statement: "\\$\\((origin|patsubst|realpath|shell|sort|strip|suffix)[[:space:]]"
     - statement: "\\$\\((value|warning|wildcard|word|wordlist|words)[[:space:]]"
-    - identifier: "^.+:"
+    - identifier: "^.+:[^=]"
+    - identifier: "^.+:$"
     - identifier: "[()$]"
     - constant.string:
         start: "\""


### PR DESCRIPTION
Before and after:
![Screenshot at 2024-01-13 01-15-53](https://github.com/zyedidia/micro/assets/32369330/0ac45cd1-f272-4480-a07c-7829628847ad)
![Screenshot at 2024-01-13 01-16-06](https://github.com/zyedidia/micro/assets/32369330/284adc0d-d053-4ab3-987e-3182be858999)
