### PR TITLE
Some syntax highlighting updates for C and C#.

### DIFF
--- a/runtime/syntax/c.yaml
+++ b/runtime/syntax/c.yaml
@@ -5,18 +5,20 @@ detect:
 
 rules:
     - identifier: "\\b[A-Z_][0-9A-Z_]+\\b"
-    - type: "\\b(float|double|bool|char|int|short|long|enum|void|struct|union|typedef|(un)?signed|inline)\\b"
-    - type: "\\b((s?size)|((u_?)?int(8|16|32|64|ptr)))_t\\b"
+    - type: "\\b(_Atomic|_BitInt|float|double|_Decimal32|_Decimal64|_Decimal128|_Complex|complex|_Imaginary|imaginary|_Bool|bool|char|int|short|long|enum|void|struct|union|typedef|typeof|typeof_unqual|(un)?signed|inline|_Noreturn)\\b"
+    - type: "\\b((s?size)|((u_?)?int(8|16|32|64|ptr))|char(8|16|32)|wchar)_t\\b"
     - type: "\\b[a-z_][0-9a-z_]+(_t|_T)\\b"
-    - statement: "\\b(auto|volatile|register|restrict|static|const|extern)\\b"
-    - statement: "\\b(for|if|while|do|else|case|default|switch)\\b"
+    - statement: "\\b(auto|volatile|register|restrict|_Alignas|alignas|_Alignof|alignof|static|const|constexpr|extern|_Thread_local|thread_local)\\b"
+    - statement: "\\b(for|if|while|do|else|case|default|switch|_Generic|_Static_assert|static_assert)\\b"
     - statement: "\\b(goto|continue|break|return)\\b"
-    - preproc: "^[[:space:]]*#[[:space:]]*(define|pragma|include|(un|ifn?)def|endif|el(if|se)|if|warning|error)"
+    - statement: "\\b(asm|fortran)\\b"
+    - preproc: "^[[:space:]]*#[[:space:]]*(define|embed|pragma|include|(un|ifn?)def|endif|el(if|ifdef|ifndef|se)|if|line|warning|error|__has_include|__has_embed|__has_c_attribute)"
+    - preproc: "^[[:space:]]*_Pragma\\b"
       # GCC builtins
     - statement: "__attribute__[[:space:]]*\\(\\([^)]*\\)\\)"
     - statement: "__(aligned|asm|builtin|hidden|inline|packed|restrict|section|typeof|weak)__"
       # Operator Color
-    - symbol.operator: "[-+*/%=<>.:;,~&|^!?]|\\b(sizeof)\\b"
+    - symbol.operator: "[-+*/%=<>.:;,~&|^!?]|\\b(offsetof|sizeof)\\b"
     - symbol.brackets: "[(){}]|\\[|\\]"
       # Integer Constants
     - constant.number: "(\\b([1-9][0-9]*|0[0-7]*|0[Xx][0-9A-Fa-f]+|0[Bb][01]+)([Uu][Ll]?[Ll]?|[Ll][Ll]?[Uu]?)?\\b)"

--- a/runtime/syntax/c.yaml
+++ b/runtime/syntax/c.yaml
@@ -7,6 +7,8 @@ rules:
     - identifier: "\\b[A-Z_][0-9A-Z_]+\\b"
     - type: "\\b(_Atomic|_BitInt|float|double|_Decimal32|_Decimal64|_Decimal128|_Complex|complex|_Imaginary|imaginary|_Bool|bool|char|int|short|long|enum|void|struct|union|typedef|typeof|typeof_unqual|(un)?signed|inline|_Noreturn)\\b"
     - type: "\\b((s?size)|((u_?)?int(8|16|32|64|ptr))|char(8|16|32)|wchar)_t\\b"
+      # GCC float/decimal/fixed types
+    - type: "\\b(_Float16|__fp16|_Float32|_Float32x|_Float64|_Float64x|__float80|_Float128|_Float128x|__float128|__ibm128|__int128|_Fract|_Sat|_Accum)\\b"
     - type: "\\b[a-z_][0-9a-z_]+(_t|_T)\\b"
     - statement: "\\b(auto|volatile|register|restrict|_Alignas|alignas|_Alignof|alignof|static|const|constexpr|extern|_Thread_local|thread_local)\\b"
     - statement: "\\b(for|if|while|do|else|case|default|switch|_Generic|_Static_assert|static_assert)\\b"
@@ -16,7 +18,7 @@ rules:
     - preproc: "^[[:space:]]*_Pragma\\b"
       # GCC builtins
     - statement: "__attribute__[[:space:]]*\\(\\([^)]*\\)\\)"
-    - statement: "__(aligned|asm|builtin|hidden|inline|packed|restrict|section|typeof|weak)__"
+    - statement: "__(aligned|asm|builtin|extension|hidden|inline|packed|restrict|section|typeof|weak)__"
       # Operator Color
     - symbol.operator: "[-+*/%=<>.:;,~&|^!?]|\\b(offsetof|sizeof)\\b"
     - symbol.brackets: "[(){}]|\\[|\\]"

--- a/runtime/syntax/cake.yaml
+++ b/runtime/syntax/cake.yaml
@@ -1,0 +1,7 @@
+filetype: cake
+detect:
+    filename: "\\.cake$"
+
+rules:
+    - include: "csharp"
+    - preproc: "^[[:space:]]*#(addin|break|l|load|module|r|reference|tool)"

--- a/runtime/syntax/csharp.yaml
+++ b/runtime/syntax/csharp.yaml
@@ -10,6 +10,7 @@ rules:
       # Annotation
     - identifier.var: "@[A-Za-z]+"
 
+    - preproc: "^[[:space:]]*#[[:space:]]*(define|elif|else|endif|endregion|error|if|line|nullable|pragma|region|undef|warning)"
     - identifier: "([A-Za-z0-9_]*[[:space:]]*[()])"
     - type: "\\b(bool|byte|sbyte|char|decimal|double|float|IntPtr|int|uint|long|ulong|managed|unmanaged|nint|nuint|object|short|ushort|string|base|this|var|void)\\b"
     - statement: "\\b(alias|as|case|catch|checked|default|do|dynamic|else|finally|fixed|for|foreach|goto|if|is|lock|new|null|return|switch|throw|try|unchecked|when|while|with)\\b"

--- a/runtime/syntax/csharp.yaml
+++ b/runtime/syntax/csharp.yaml
@@ -11,9 +11,9 @@ rules:
     - identifier.var: "@[A-Za-z]+"
 
     - identifier: "([A-Za-z0-9_]*[[:space:]]*[()])"
-    - type: "\\b(bool|byte|sbyte|char|decimal|double|float|IntPtr|int|uint|long|ulong|object|short|ushort|string|base|this|var|void)\\b"
-    - statement: "\\b(alias|as|case|catch|checked|default|do|dynamic|else|finally|fixed|for|foreach|goto|if|is|lock|new|null|return|switch|throw|try|unchecked|while)\\b"
-    - statement: "\\b(abstract|async|class|const|delegate|enum|event|explicit|extern|get|implicit|in|internal|interface|namespace|operator|out|override|params|partial|private|protected|public|readonly|ref|sealed|set|sizeof|stackalloc|static|struct|typeof|unsafe|using|value|virtual|volatile|yield)\\b"
+    - type: "\\b(bool|byte|sbyte|char|decimal|double|float|IntPtr|int|uint|long|ulong|managed|unmanaged|nint|nuint|object|short|ushort|string|base|this|var|void)\\b"
+    - statement: "\\b(alias|as|case|catch|checked|default|do|dynamic|else|finally|fixed|for|foreach|goto|if|is|lock|new|null|return|switch|throw|try|unchecked|when|while|with)\\b"
+    - statement: "\\b(abstract|add|and|args|async|await|class|const|delegate|enum|event|explicit|extern|file|get|global|implicit|in|init|internal|interface|nameof|namespace|not|notnull|operator|or|out|override|params|partial|private|protected|public|readonly|record|ref|remove|required|scoped|sealed|set|sizeof|stackalloc|static|struct|typeof|unsafe|using|value|virtual|volatile|yield)\\b"
       # LINQ-only keywords (ones that cannot be used outside of a LINQ query - lots others can)
     - statement: "\\b(from|where|select|group|info|orderby|join|let|in|on|equals|by|ascending|descending)\\b"
     - special: "\\b(break|continue)\\b"

--- a/runtime/syntax/msbuild.yaml
+++ b/runtime/syntax/msbuild.yaml
@@ -1,0 +1,6 @@
+filetype: msbuild
+detect:
+    filename: "\\.(.*proj|props|targets|tasks)$"
+
+rules:
+    - include: "xml"


### PR DESCRIPTION
* Update keywords for C23 and add some extension keywords.
* Update keywords for C# 12 and add preprocessor directives.
* Add syntax for [Cake](https://github.com/cake-build/cake) build scripts (based on C#).
* Add syntax for various [MSBuild](https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild) files (just plain old XML).