### PR TITLE
syntax: sh: Fix command parameter highlighting

### DIFF
--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -39,7 +39,7 @@ rules:
       # Coreutils commands
     - type: "\\b(base64|basename|cat|chcon|chgrp|chmod|chown|chroot|cksum|comm|cp|csplit|cut|date|dd|df|dir|dircolors|dirname|du|env|expand|expr|factor|false|fmt|fold|head|hostid|id|install|join|link|ln|logname|ls|md5sum|mkdir|mkfifo|mknod|mktemp|mv|nice|nl|nohup|nproc|numfmt|od|paste|pathchk|pinky|pr|printenv|printf|ptx|pwd|readlink|realpath|rm|rmdir|runcon|seq|(sha1|sha224|sha256|sha384|sha512)sum|shred|shuf|sleep|sort|split|stat|stdbuf|stty|sum|sync|tac|tail|tee|test|time|timeout|touch|tr|true|truncate|tsort|tty|uname|unexpand|uniq|unlink|users|vdir|wc|who|whoami|yes)\\b"
       # Conditional flags
-    - statement: " (-[A-Za-z]+|--[a-z]+)"
+    - statement: "\\s+(-[A-Za-z]+|--[a-z]+)"
 
     - identifier: "\\$\\{[0-9A-Za-z_:!%&=+#~@*^$?, .\\-\\/\\[\\]]+\\}"
     - identifier: "\\$[0-9A-Za-z_:!%&=+#~@*^$?,\\-\\[\\]]+"


### PR DESCRIPTION
This will fix the following use case:
```shell
#!/bin/sh

command \
    -a \
    -A \
    --abc
``` 

| before | after |
|--------|--------|
| ![grafik](https://github.com/zyedidia/micro/assets/3951388/8c7bf19a-109b-4eb0-86ad-fc45c428062b) | ![grafik](https://github.com/zyedidia/micro/assets/3951388/5d2aa358-7a4d-4767-ab1e-c381cbdabe58) |
