### PR TITLE
plugins: autoclose: Do autoclose in case the next char is a whitespace

### DIFF
--- a/cmd/micro/initlua.go
+++ b/cmd/micro/initlua.go
@@ -146,6 +146,7 @@ func luaImportMicroUtil() *lua.LTable {
 	ulua.L.SetField(pkg, "RuneAt", luar.New(ulua.L, util.LuaRuneAt))
 	ulua.L.SetField(pkg, "GetLeadingWhitespace", luar.New(ulua.L, util.LuaGetLeadingWhitespace))
 	ulua.L.SetField(pkg, "IsWordChar", luar.New(ulua.L, util.LuaIsWordChar))
+	ulua.L.SetField(pkg, "IsWhitespace", luar.New(ulua.L, util.LuaIsWhitespace))
 	ulua.L.SetField(pkg, "String", luar.New(ulua.L, util.String))
 	ulua.L.SetField(pkg, "Unzip", luar.New(ulua.L, util.Unzip))
 	ulua.L.SetField(pkg, "Version", luar.New(ulua.L, util.Version))

--- a/internal/util/lua.go
+++ b/internal/util/lua.go
@@ -39,3 +39,9 @@ func LuaIsWordChar(s string) bool {
 	r, _, _ := DecodeCharacterInString(s)
 	return IsWordChar(r)
 }
+
+// LuaIsWhitespace returns true if the first rune in a whitespace character
+func LuaIsWhitespace(s string) bool {
+	r, _, _ := DecodeCharacterInString(s)
+	return IsWhitespace(r)
+}

--- a/runtime/plugins/autoclose/autoclose.lua
+++ b/runtime/plugins/autoclose/autoclose.lua
@@ -28,7 +28,7 @@ function onRune(bp, r)
         if r == charAt(autoclosePairs[i], 1) then
             local curLine = bp.Buf:Line(bp.Cursor.Y)
 
-            if bp.Cursor.X == uutil.CharacterCountInString(curLine) or not uutil.IsWordChar(charAt(curLine, bp.Cursor.X+1)) then
+            if bp.Cursor.X == uutil.CharacterCountInString(curLine) or uutil.IsWhitespace(charAt(curLine, bp.Cursor.X+1)) then
                 -- the '-' here is to derefence the pointer to bp.Cursor.Loc which is automatically made
                 -- when converting go structs to lua
                 -- It needs to be dereferenced because the function expects a non pointer struct


### PR DESCRIPTION
For me the current behavior is a bit unexpected too in case the brace is opened before an non white space character and automatically closed.
So I'd like to suggest this as the new behavior.
Yes, a new option could be introduced instead to control that, but then we end up in too much options.

closes #3133