### PR TITLE
Make default `fileformat` value suited to the OS

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 
@@ -284,7 +285,7 @@ var defaultCommonSettings = map[string]interface{}{
 	"encoding":       "utf-8",
 	"eofnewline":     true,
 	"fastdirty":      false,
-	"fileformat":     "unix",
+	"fileformat":     defaultFileFormat(),
 	"filetype":       "unknown",
 	"hlsearch":       false,
 	"incsearch":      true,
@@ -317,6 +318,13 @@ var defaultCommonSettings = map[string]interface{}{
 	"tabstospaces":   false,
 	"useprimary":     true,
 	"wordwrap":       false,
+}
+
+func defaultFileFormat() string {
+	if runtime.GOOS == "windows" {
+		return "dos"
+	}
+	return "unix"
 }
 
 func GetInfoBarOffset() int {

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -157,7 +157,7 @@ Here are the available options:
    an effect if the file is empty/newly created, because otherwise the fileformat
    will be automatically detected from the existing line endings.
 
-	default value: `unix`
+	default value: `unix` on Unix systems, `dos` on Windows
 
 * `filetype`: sets the filetype for the current buffer. Set this option to
   `off` to completely disable filetype detection.


### PR DESCRIPTION
Set the `fileformat` option by default to `dos` on Windows.
See this discussion: https://github.com/zyedidia/micro/issues/2066#issuecomment-1914794075

Note that I haven't tested this on Windows, as I'm not using Windows. UPDATE: @sergeevabc has [confirmed](https://github.com/zyedidia/micro/issues/2066#issuecomment-1943049166) that it works as expected on Windows.