### PR TITLE
Fix various issues with `SpawnMultiCursor{Up,Down}`

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1772,6 +1772,9 @@ func (h *BufPane) SpawnMultiCursorUpN(n int) bool {
 		if n < 0 && lastC.Y+1 == h.Buf.LinesNum() {
 			return false
 		}
+
+		h.Buf.DeselectCursors()
+
 		c = buffer.NewCursor(h.Buf, buffer.Loc{lastC.X, lastC.Y - n})
 		c.LastVisualX = lastC.LastVisualX
 		c.X = c.GetCharPosInLine(h.Buf.LineBytes(c.Y), c.LastVisualX)
@@ -1782,6 +1785,9 @@ func (h *BufPane) SpawnMultiCursorUpN(n int) bool {
 		if sloc == vloc.SLoc {
 			return false
 		}
+
+		h.Buf.DeselectCursors()
+
 		vloc.SLoc = sloc
 		vloc.VisualX = lastC.LastVisualX
 		c = buffer.NewCursor(h.Buf, h.LocFromVLoc(vloc))

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1763,13 +1763,13 @@ func (h *BufPane) SpawnMultiCursor() bool {
 
 // SpawnMultiCursorUp creates additional cursor, at the same X (if possible), one Y less.
 func (h *BufPane) SpawnMultiCursorUp() bool {
-	if h.Cursor.Y == 0 {
+	lastC := h.Buf.GetCursor(h.Buf.NumCursors() - 1)
+	if lastC.Y == 0 {
 		return false
 	}
-	h.Cursor.GotoLoc(buffer.Loc{h.Cursor.X, h.Cursor.Y - 1})
-	h.Cursor.Relocate()
+	c := buffer.NewCursor(h.Buf, buffer.Loc{lastC.X, lastC.Y - 1})
+	c.Relocate()
 
-	c := buffer.NewCursor(h.Buf, buffer.Loc{h.Cursor.X, h.Cursor.Y + 1})
 	h.Buf.AddCursor(c)
 	h.Buf.SetCurCursor(h.Buf.NumCursors() - 1)
 	h.Buf.MergeCursors()
@@ -1780,13 +1780,13 @@ func (h *BufPane) SpawnMultiCursorUp() bool {
 
 // SpawnMultiCursorDown creates additional cursor, at the same X (if possible), one Y more.
 func (h *BufPane) SpawnMultiCursorDown() bool {
-	if h.Cursor.Y+1 == h.Buf.LinesNum() {
+	lastC := h.Buf.GetCursor(h.Buf.NumCursors() - 1)
+	if lastC.Y+1 == h.Buf.LinesNum() {
 		return false
 	}
-	h.Cursor.GotoLoc(buffer.Loc{h.Cursor.X, h.Cursor.Y + 1})
-	h.Cursor.Relocate()
+	c := buffer.NewCursor(h.Buf, buffer.Loc{lastC.X, lastC.Y + 1})
+	c.Relocate()
 
-	c := buffer.NewCursor(h.Buf, buffer.Loc{h.Cursor.X, h.Cursor.Y - 1})
 	h.Buf.AddCursor(c)
 	h.Buf.SetCurCursor(h.Buf.NumCursors() - 1)
 	h.Buf.MergeCursors()

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1771,6 +1771,8 @@ func (h *BufPane) SpawnMultiCursorUpN(n int) bool {
 		return false
 	}
 	c := buffer.NewCursor(h.Buf, buffer.Loc{lastC.X, lastC.Y - n})
+	c.LastVisualX = lastC.LastVisualX
+	c.X = c.GetCharPosInLine(h.Buf.LineBytes(c.Y), c.LastVisualX)
 	c.Relocate()
 
 	h.Buf.AddCursor(c)

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1761,13 +1761,16 @@ func (h *BufPane) SpawnMultiCursor() bool {
 	return true
 }
 
-// SpawnMultiCursorUp creates additional cursor, at the same X (if possible), one Y less.
-func (h *BufPane) SpawnMultiCursorUp() bool {
+// SpawnMultiCursorUpN is not an action
+func (h *BufPane) SpawnMultiCursorUpN(n int) bool {
 	lastC := h.Buf.GetCursor(h.Buf.NumCursors() - 1)
-	if lastC.Y == 0 {
+	if n > 0 && lastC.Y == 0 {
 		return false
 	}
-	c := buffer.NewCursor(h.Buf, buffer.Loc{lastC.X, lastC.Y - 1})
+	if n < 0 && lastC.Y+1 == h.Buf.LinesNum() {
+		return false
+	}
+	c := buffer.NewCursor(h.Buf, buffer.Loc{lastC.X, lastC.Y - n})
 	c.Relocate()
 
 	h.Buf.AddCursor(c)
@@ -1778,20 +1781,14 @@ func (h *BufPane) SpawnMultiCursorUp() bool {
 	return true
 }
 
+// SpawnMultiCursorUp creates additional cursor, at the same X (if possible), one Y less.
+func (h *BufPane) SpawnMultiCursorUp() bool {
+	return h.SpawnMultiCursorUpN(1)
+}
+
 // SpawnMultiCursorDown creates additional cursor, at the same X (if possible), one Y more.
 func (h *BufPane) SpawnMultiCursorDown() bool {
-	lastC := h.Buf.GetCursor(h.Buf.NumCursors() - 1)
-	if lastC.Y+1 == h.Buf.LinesNum() {
-		return false
-	}
-	c := buffer.NewCursor(h.Buf, buffer.Loc{lastC.X, lastC.Y + 1})
-	c.Relocate()
-
-	h.Buf.AddCursor(c)
-	h.Buf.SetCurCursor(h.Buf.NumCursors() - 1)
-	h.Buf.MergeCursors()
-	h.Relocate()
-	return true
+	return h.SpawnMultiCursorUpN(-1)
 }
 
 // SpawnMultiCursorSelect adds a cursor at the beginning of each line of a selection

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -568,6 +568,13 @@ func (b *Buffer) RelocateCursors() {
 	}
 }
 
+// DeselectCursors removes selection from all cursors
+func (b *Buffer) DeselectCursors() {
+	for _, c := range b.cursors {
+		c.Deselect(true)
+	}
+}
+
 // RuneAt returns the rune at a given location in the buffer
 func (b *Buffer) RuneAt(loc Loc) rune {
 	line := b.LineBytes(loc.Y)


### PR DESCRIPTION
Fix various issues with spawning multicursors via `SpawnMultiCursorUp` and `SpawnMultiCursorDown` actions (`Alt-Shift-Up` and `Alt-Shift-Down`):

- Visual text width (e.g. tabs width) not respected:

Current behavior:
![image](https://github.com/zyedidia/micro/assets/147101/f9d73b82-d508-4eea-91b7-8ebf917485ef)
Expected behavior:
![image](https://github.com/zyedidia/micro/assets/147101/5e73cb37-3767-404d-9611-9994f0c0ac6f)

- When spawning new cursor, current cursor unexpectedly moved too:

Current behavior:
![image](https://github.com/zyedidia/micro/assets/147101/6af0bdec-c9b3-47d0-99bb-eafd7fd358ca)
Expected behavior:
![image](https://github.com/zyedidia/micro/assets/147101/31f809a2-da19-48d7-b99e-16209b792b72)

- `LastVisualX` not respected:

Current behavior:
![image](https://github.com/zyedidia/micro/assets/147101/c97e0a6c-fe41-4de3-aa4b-4693c6a7fd4f)
Expected behavior:
![image](https://github.com/zyedidia/micro/assets/147101/b338c9fa-4f60-49a9-8f3e-27af0b948e6f)

- Softwrapping not respected.
- `RemoveMultiCursor` action (`Alt-p` key) removes not the last spawned cursor but the last one before it.
- Cursor selections are not unset when spawning new cursors, which causes weird user experience.