### PR TITLE
Add bash zsh and nu shell completions

### DIFF
--- a/completions/bash/micro.bash
+++ b/completions/bash/micro.bash
@@ -1,0 +1,52 @@
+#compdef micro                -*- shell-script -*-
+
+# Shell completion for micro command
+# To be installed in "/usr/share/bash-completion/completions/micro"
+# and "/usr/share/zsh/site-functions/"
+
+_micro() {
+	local prev cur plugin_opts all_opts
+	COMPREPLY=()
+
+	prev="${COMP_WORDS[COMP_CWORD-1]}"
+	cur="${COMP_WORDS[COMP_CWORD]}"
+	plugin_opts='remove update search list available'
+    all_opts='-clean -config-dir -options -debug -version -plugin'
+
+	case "${prev}" in
+		-plugin)
+			COMPREPLY=( $(compgen -W "${plugin_opts}" -- "${cur}") )
+			return 0
+			;;
+		-config-dir)
+			_filedir -d
+			return 0
+			;;
+		*)
+            _filedir -d
+		;;
+	esac
+
+	# Options
+	case "${cur}" in
+		-*)
+			COMPREPLY=( $( compgen -W "${all_opts}" -- "${cur}") )
+			return 0
+			;;
+		--*)
+			COMPREPLY=( $( compgen -W "--version --help" -- "${cur}") )
+			return 0
+			;;
+		*)
+			COMPREPLY=( $( compgen -W "${all_opts}" -- "${cur}") )
+			return 0
+			;;
+	esac
+}
+
+if [[ -n ${ZSH_VERSION} ]]; then
+	autoload -U bashcompinit
+	bashcompinit
+fi
+
+complete -F _micro micro

--- a/completions/nush/micro.nu
+++ b/completions/nush/micro.nu
@@ -1,0 +1,9 @@
+export extern "micro" [
+    -version(-v)              # Show version of eza
+    -help                     # Show list of command-line options
+    -clean                    # Cleans the configuration directory
+    -config-dir               # Specify a custom location for the configuration directory
+    -option                   # Show all option help
+    -debug                    # Enable debug mode (enables logging to ./log.txt)
+    -plugin                   # Manage micro plugins. Use either of "remove", "update", "search", "list", or "available" subcommands
+]

--- a/completions/zsh/micro.zsh
+++ b/completions/zsh/micro.zsh
@@ -1,0 +1,24 @@
+#compdef micro                -*- shell-script -*-
+
+# Save this file as _micro in /usr/local/share/zsh/site-functions or in any
+# other folder in $fpath.  E.g. save it in a folder called ~/.zfunc and add a
+# line containing `fpath=(~/.zfunc $fpath)` somewhere before `compinit` in your
+# ~/.zshrc.
+
+__micro() {
+    # Give completions using the `_arguments` utility function with
+    # `-s` for option stacking like `micro -ab` for `micro -a -b` and
+    # `-S` for delimiting options with `--` like in `micro -- -a`.
+    _arguments -s -S \
+        "(- *)"{-v,-version}"[Show the version number and information]" \
+        "(- *)"-help"[Show list of command-line options]" \
+        -clean"[Cleans the configuration directory]" \
+        -config-dir"[Specify a custom location for the configuration directory]" \
+        -option"[Show all option help]" \
+        -debug"[Enable debug mode (enables logging to ./log.txt)]" \
+        -plugin"[Manage micro plugins]:(action):(remove update search list available)" \
+        '*:filename:_files'
+}
+        #$(micro -options | grep -oE '^-[[:alnum:]@-]+' | tr '\n' ' ') \
+
+__micro


### PR DESCRIPTION
I have added shell completions for Bash, Zsh, and Nushell. I don't use Fish shell and on the first look it looked too complicated. Perhaps can be added in another PR.

This is a **Draft** PR because I don't know how in your build system these files should be integrated. On a typical linux distro bash should sit in `/usr/share/bash-completion/completions/` and should be renamed to `micro`, for zsh it should sit in `/usr/share/zsh/site-functions` and should be renamed to `_micro`.

As for Nushell, [the documentation](https://www.nushell.sh/book/custom_completions.html) is not clear about the path, so I think we should leave it as is, until a Nushell fan help us with that.