### PR TITLE
Add missing `<release>` entries in metainfo file

### DIFF
--- a/data/io.github.zyedidia.micro.metainfo.xml
+++ b/data/io.github.zyedidia.micro.metainfo.xml
@@ -25,7 +25,7 @@
 		<category>TextEditor</category>
 	</categories>
 	<releases>
-			<release version="2.0.13" date="2022-10-22"/>
+			<release version="2.0.13" date="2023-10-22"/>
 			<release version="2.0.12" date="2023-09-07"/>
 			<release version="2.0.11" date="2022-08-01"/>
 	</releases>

--- a/data/io.github.zyedidia.micro.metainfo.xml
+++ b/data/io.github.zyedidia.micro.metainfo.xml
@@ -25,6 +25,8 @@
 		<category>TextEditor</category>
 	</categories>
 	<releases>
+			<release version="2.0.13" date="2022-10-22"/>
+			<release version="2.0.12" date="2023-09-07"/>
 			<release version="2.0.11" date="2022-08-01"/>
 	</releases>
 	<provides>

--- a/data/io.github.zyedidia.micro.metainfo.xml
+++ b/data/io.github.zyedidia.micro.metainfo.xml
@@ -26,7 +26,7 @@
 	</categories>
 	<releases>
 			<release version="2.0.13" date="2023-10-22"/>
-			<release version="2.0.12" date="2023-09-07"/>
+			<release version="2.0.12" date="2023-09-06"/>
 			<release version="2.0.11" date="2022-08-01"/>
 	</releases>
 	<provides>


### PR DESCRIPTION
Because of them missing, the software stores and flathub website displays micro's version as 2.0.11 (the latest one that is mentioned in the metainfo file). And people think the flatpak isn't up-to-date (https://github.com/flathub/io.github.zyedidia.micro/issues/8).

Another project who's flatpak I am maintaining, Helix, has a file with a checklist with all the things that need to be done on a new release ([here](https://github.com/helix-editor/helix/blob/0dc67ff8852ce99d40ad4464062ebe212b0b03a1/docs/releases.md)). You can have something similar, or do something else to not forget to add a `<release>` entry on each release. 