### PR TITLE
Remove the `NoDisplay=true` from desktop file

### DIFF
--- a/assets/packaging/micro.desktop
+++ b/assets/packaging/micro.desktop
@@ -12,5 +12,4 @@ Keywords=text;editor;syntax;terminal;
 Exec=micro %F
 StartupNotify=false
 Terminal=true
-NoDisplay=true
 MimeType=text/plain;text/x-chdr;text/x-csrc;text/x-c++hdr;text/x-c++src;text/x-java;text/x-dsrc;text/x-pascal;text/x-perl;text/x-python;application/x-php;application/x-httpd-php3;application/x-httpd-php4;application/x-httpd-php5;application/xml;text/html;text/css;text/x-sql;text/x-diff;


### PR DESCRIPTION
Reverts #2864. People there seem to agree that this should be done.

TUI apps usually have their desktop files visible in system menus.

 Also, flathub no longer allows apps with invisible desktop files.