### PR TITLE
Update OSC52 info for Alacritty

### DIFF
--- a/runtime/help/copypaste.md
+++ b/runtime/help/copypaste.md
@@ -31,7 +31,8 @@ Here is a list of terminal emulators and their status:
 
 * `gnome-terminal`: does not support OSC 52.
 
-* `alacritty`: supported.
+* `alacritty`: supported. Since 0.13.0, reading has been disabled by default.
+  To reenable it, set the `terminal.osc52` option to `CopyPaste`.
 
 * `foot`: supported.
 


### PR DESCRIPTION
In Alacritty 0.13.0, OSC52 read has been disabled by default. This PR updates the documentation accordingly.

See https://github.com/alacritty/alacritty/releases/tag/v0.13.0.
