### PR TITLE
Forward resize event to both TabList and InfoBar

### DIFF
--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -472,7 +472,10 @@ func DoEvent() {
 	}
 
 	_, resize := event.(*tcell.EventResize)
-	if action.InfoBar.HasPrompt && !resize {
+	if resize {
+		action.InfoBar.HandleEvent(event)
+		action.Tabs.HandleEvent(event)
+	} else if action.InfoBar.HasPrompt {
 		action.InfoBar.HandleEvent(event)
 	} else {
 		action.Tabs.HandleEvent(event)

--- a/internal/action/infopane.go
+++ b/internal/action/infopane.go
@@ -83,6 +83,8 @@ func (h *InfoPane) Close() {
 
 func (h *InfoPane) HandleEvent(event tcell.Event) {
 	switch e := event.(type) {
+	case *tcell.EventResize:
+		// TODO
 	case *tcell.EventKey:
 		ke := KeyEvent{
 			code: e.Key(),


### PR DESCRIPTION
InfoBar should really receive the resize event, to know the window width in order to do horizontal scrolling of the command line when it doesn't fit in the screen. Although currently it doesn't scroll the command line at all (see issue #2527) and just ignores the resize event, but we should fix that anyway, so let's forward the resize event to it.