### PR TITLE
syntax: pipfile: add syntax highlight code for Pipfile files

### DIFF
--- a/runtime/syntax/pipfile.yaml
+++ b/runtime/syntax/pipfile.yaml
@@ -1,0 +1,7 @@
+filetype: Pipfile
+
+detect:
+  filename: "Pipfile$"
+
+rules:
+- include: toml


### PR DESCRIPTION
Adding Pipfile file syntax support.

![image](https://github.com/zyedidia/micro/assets/44283700/61e0d1c1-8e27-4542-bbba-49cd89b99804)
