### PR TITLE
Use tabs for `settings.json` as like for `bindings.json`

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -290,7 +290,7 @@ func WriteSettings(filename string) error {
 			}
 		}
 
-		txt, _ := json.MarshalIndent(parsedSettings, "", "    ")
+		txt, _ := json.MarshalIndent(parsedSettings, "", "\t")
 		err = ioutil.WriteFile(filename, append(txt, '\n'), 0644)
 	}
 	return err
@@ -312,7 +312,7 @@ func OverwriteSettings(filename string) error {
 			}
 		}
 
-		txt, _ := json.MarshalIndent(settings, "", "    ")
+		txt, _ := json.MarshalIndent(settings, "", "\t")
 		err = ioutil.WriteFile(filename, append(txt, '\n'), 0644)
 	}
 	return err


### PR DESCRIPTION
It is too much for separate issue or pr because I still doesn't have code so I will just write it here to grab your attention to very similar functions:

https://github.com/zyedidia/micro/blob/c64add289b396b35f790c5b20b9db9c750fb1706/internal/config/settings.go#L260-L319

I believe they could be merged into one with one additional parameter