### PR TITLE
Fix: help files use one style

### DIFF
--- a/runtime/help/colors.md
+++ b/runtime/help/colors.md
@@ -93,7 +93,7 @@ and set this variable yourself.
 * `solarized-tc`: this is the solarized colorscheme for true color.
 * `atom-dark`: this colorscheme is based off of Atom's "dark" colorscheme.
 * `cmc-tc`: A true colour variant of the cmc theme.  It requires true color to
-  look its best. Use cmc-16 if your terminal doesn't support true color.
+   look its best. Use cmc-16 if your terminal doesn't support true color.
 * `gruvbox-tc`: The true color version of the gruvbox colorscheme
 * `material-tc`: Colorscheme based off of Google's Material Design palette
 

--- a/runtime/help/colors.md
+++ b/runtime/help/colors.md
@@ -26,7 +26,7 @@ Modern terminals tend to have a palette of 16 user-configurable colors (these
 colors can often be configured in the terminal preferences), and additional
 color support comes in three flavors.
 
-* 16-color: A colorscheme that uses the 16 default colors will always work but
+* `16-color`: A colorscheme that uses the 16 default colors will always work but
   will only look good if the 16 default colors have been configured to the
   user's liking. Using a colorscheme that only uses the 16 colors from the
   terminal palette will also preserve the terminal's theme from other
@@ -34,7 +34,7 @@ color support comes in three flavors.
   applications. Default colorschemes of this type include `simple` and
   `solarized`.
 
-* 256-color: Almost all terminals support displaying an additional 240 colors
+* `256-color`: Almost all terminals support displaying an additional 240 colors
   on top of the 16 user-configurable colors (creating 256 colors total).
   Colorschemes which use 256-color are portable because they will look the
   same regardless of the configured 16-color palette. However, the color
@@ -42,7 +42,7 @@ color support comes in three flavors.
   Default 256-color colorschemes include `monokai`, `twilight`, `zenburn`,
   `darcula` and more.
 
-* true-color: Some terminals support displaying "true color" with 16 million
+* `true-color`: Some terminals support displaying "true color" with 16 million
   colors using standard RGB values. This mode will be able to support
   displaying any colorscheme, but it should be noted that the user-configured
   16-color palette is ignored when using true-color mode (this means the

--- a/runtime/help/colors.md
+++ b/runtime/help/colors.md
@@ -106,7 +106,7 @@ be found
 Custom colorschemes should be placed in the `~/.config/micro/colorschemes`
 directory.
 
-A number of custom directives are placed in a `.micro` file. Colorschemes are 
+A number of custom directives are placed in a `.micro` file. Colorschemes are
 typically only 18-30 lines in total.
 
 To create the colorscheme you need to link highlight groups with
@@ -152,7 +152,7 @@ Then you can use the terminals 256 colors by using their numbers 1-256 (numbers
 
 If the user's terminal supports true color, then you can also specify colors
 exactly using their hex codes. If the terminal is not true color but micro is
-told to use a true color colorscheme it will attempt to map the colors to the 
+told to use a true color colorscheme it will attempt to map the colors to the
 available 256 colors.
 
 Generally colorschemes which require true color terminals to look good are
@@ -213,7 +213,7 @@ that for highlighting strings. If it's not found, it will use constant instead.
 Micro tries to match the largest set of groups it can find in the colorscheme
 definitions, so if, for examle `constant.bool.true` is found then micro will
 use that. If `constant.bool.true` is not found but `constant.bool` is found
-micro will use `constant.bool`. If not, it uses `constant`. 
+micro will use `constant.bool`. If not, it uses `constant`.
 
 Here's a list of subgroups used in micro's built-in syntax files.
 
@@ -221,10 +221,10 @@ Here's a list of subgroups used in micro's built-in syntax files.
 * constant.bool
 * constant.bool.true
 * constant.bool.false
-* constant.number 
+* constant.number
 * constant.specialChar
 * constant.string
-* constant.string.url 
+* constant.string.url
 * identifier.class (Also used for functions)
 * identifier.macro
 * identifier.var
@@ -245,7 +245,7 @@ languages.
 
 Micro's builtin syntax highlighting tries very hard to be sane, sensible and
 provide ample coverage of the meaningful elements of a language. Micro has
-syntax files built in for over 100 languages now! However, there may be 
+syntax files built in for over 100 languages now! However, there may be
 situations where you find Micro's highlighting to be insufficient or not to
 your liking. The good news is that you can create your own syntax files, and
 place them in  `~/.config/micro/syntax` and Micro will use those instead.

--- a/runtime/help/commands.md
+++ b/runtime/help/commands.md
@@ -35,12 +35,12 @@ quotes here but these are not necessary when entering the command in micro.
    passed to jump inward from the end of the file; for example, -5 jumps
    to the 5th-last line in the file.
 
-* `replace 'search' 'value' ['flags']`: This will replace `search` with `value`. 
+* `replace 'search' 'value' ['flags']`: This will replace `search` with `value`.
    The `flags` are optional. Possible flags are:
    * `-a`: Replace all occurrences at once
    * `-l`: Do a literal search instead of a regex search
 
-   Note that `search` must be a valid regex (unless `-l` is passed). If one 
+   Note that `search` must be a valid regex (unless `-l` is passed). If one
    of the arguments does not have any spaces in it, you may omit the quotes.
 
    In case the search is done non-literal (without `-l`), the 'value'
@@ -63,7 +63,7 @@ quotes here but these are not necessary when entering the command in micro.
 
 * `show 'option'`: shows the current value of the given option.
 
-* `run 'sh-command'`: runs the given shell command in the background. The 
+* `run 'sh-command'`: runs the given shell command in the background. The
    command's output will be displayed in one line when it finishes running.
 
 * `vsplit ['filename']`: opens a vertical split with `filename`. If no filename

--- a/runtime/help/copypaste.md
+++ b/runtime/help/copypaste.md
@@ -90,7 +90,7 @@ sends a list of key events, this can cause issues because micro
 will think you manually entered each character and may add closing
 brackets or automatic indentation, which will mess up the pasted
 text. To avoid this, you can temporarily enable the `paste` option
-while you perform the paste. When paste option is on, micro will 
+while you perform the paste. When paste option is on, micro will
 aggregate lists of multiple key events into larger paste events.
 It is a good idea to disable the `paste` option during normal use
 as occasionally if you are typing quickly, the terminal will send

--- a/runtime/help/copypaste.md
+++ b/runtime/help/copypaste.md
@@ -32,7 +32,7 @@ Here is a list of terminal emulators and their status:
 * `gnome-terminal`: does not support OSC 52.
 
 * `alacritty`: supported. Since 0.13.0, reading has been disabled by default.
-  To reenable it, set the `terminal.osc52` option to `CopyPaste`.
+   To reenable it, set the `terminal.osc52` option to `CopyPaste`.
 
 * `foot`: supported.
 

--- a/runtime/help/copypaste.md
+++ b/runtime/help/copypaste.md
@@ -12,11 +12,11 @@ is limited support among terminal emulators for the terminal clipboard
 (which uses the OSC 52 protocol to communicate clipboard contents).
 Here is a list of terminal emulators and their status:
 
-* Kitty: supported, but only writing is enabled by default. To enable
+* `Kitty`: supported, but only writing is enabled by default. To enable
   reading, add `read-primary` and `read-clipboard` to the
   `clipboard_control` option.
 
-* iTerm2: only copying (writing to clipboard) is supported. Must be enabled in
+* `iTerm2`: only copying (writing to clipboard) is supported. Must be enabled in
   `Preferences->General-> Selection->Applications in terminal may access clipboard`.
   You can use Command-v to paste.
 

--- a/runtime/help/defaultkeys.md
+++ b/runtime/help/defaultkeys.md
@@ -129,7 +129,7 @@ you can use Ctrl-n and Ctrl-p to cycle through matches.
 
 ### Function keys.
 
-Warning! The function keys may not work in all terminals! 
+Warning! The function keys may not work in all terminals!
 
 | Key   | Description of function   |
 |------ |-------------------------- |

--- a/runtime/help/help.md
+++ b/runtime/help/help.md
@@ -39,17 +39,17 @@ this page.
 
 Here are the available help topics:
 
-* tutorial: A brief tutorial which gives an overview of all the other help
+* `tutorial`: A brief tutorial which gives an overview of all the other help
   topics
-* keybindings: Gives a full list of the default keybindings as well as how to
+* `keybindings`: Gives a full list of the default keybindings as well as how to
   rebind them
-* defaultkeys: Gives a more straight-forward list of the hotkey commands and
+* `defaultkeys`: Gives a more straight-forward list of the hotkey commands and
   what they do
-* commands: Gives a list of all the commands and what they do
-* options: Gives a list of all the options you can customize
-* plugins: Explains how micro's plugin system works and how to create your own
+* `commands`: Gives a list of all the commands and what they do
+* `options`: Gives a list of all the options you can customize
+* `plugins`: Explains how micro's plugin system works and how to create your own
   plugins
-* colors: Explains micro's colorscheme and syntax highlighting engine and how
+* `colors`: Explains micro's colorscheme and syntax highlighting engine and how
   to create your own colorschemes or add new languages to the engine
 
 For example, to open the help page on plugins you would run `> help plugins`.

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -137,8 +137,8 @@ Here are the available options:
 	default value: `true`
 
 * `fakecursor`: forces micro to render the cursor using terminal colors rather
-  than the actual terminal cursor. This is useful when the terminal's cursor is
-  slow or otherwise unavailable/undesirable to use.
+   than the actual terminal cursor. This is useful when the terminal's cursor is
+   slow or otherwise unavailable/undesirable to use.
 
     default value: `false`
 
@@ -167,7 +167,7 @@ Here are the available options:
 	default value: `unix` on Unix systems, `dos` on Windows
 
 * `filetype`: sets the filetype for the current buffer. Set this option to
-  `off` to completely disable filetype detection.
+   `off` to completely disable filetype detection.
 
 	default value: `unknown`. This will be automatically overridden depending
     on the file you open.
@@ -203,11 +203,11 @@ Here are the available options:
 	default value: `true`
 
 * `indentchar`: sets the indentation character. This will not be inserted into
-  files; it is only a visual indicator that whitespace is present. If set to a
-  printing character, it functions as a subset of the "show invisibles"
-  setting available in many other text editors. The color of this character is
-  determined by the `indent-char` field in the current theme rather than the
-  default text color.
+   files; it is only a visual indicator that whitespace is present. If set to a
+   printing character, it functions as a subset of the "show invisibles"
+   setting available in many other text editors. The color of this character is
+   determined by the `indent-char` field in the current theme rather than the
+   default text color.
 
 	default value: ` ` (space)
 
@@ -236,10 +236,10 @@ Here are the available options:
     default value: `true`
 
 * `matchbracestyle`: whether to underline or highlight matching braces when
-  `matchbrace` is enabled. The color of highlight is determined by the `match-brace`
-  field in the current theme. Possible values:
-  * `underline`: underline matching braces.
-  * `highlight`: use `match-brace` style from the current theme.
+   `matchbrace` is enabled. The color of highlight is determined by the
+   `match-brace` field in the current theme. Possible values:
+    * `underline`: underline matching braces.
+    * `highlight`: use `match-brace` style from the current theme.
 
    default value: `underline`
 
@@ -422,7 +422,7 @@ Here are the available options:
 	default value: `false`
 
 * `tabhighlight`: inverts the tab characters' (filename, save indicator, etc)
-  colors with respect to the tab bar.
+   colors with respect to the tab bar.
 
 	default value: false
 
@@ -454,7 +454,7 @@ Here are the available options:
 	default value: `false`
 
 * `xterm`: micro will assume that the terminal it is running in conforms to
-  `xterm-256color` regardless of what the `$TERM` variable actually contains.
+   `xterm-256color` regardless of what the `$TERM` variable actually contains.
    Enabling this option may cause unwanted effects if your terminal in fact
    does not conform to the `xterm-256color` standard.
 

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -11,7 +11,7 @@ if you have set either of the above environment variables).
 
 Here are the available options:
 
-* `autoindent`: when creating a new line, use the same indentation as the 
+* `autoindent`: when creating a new line, use the same indentation as the
    previous line.
 
 	default value: `true`
@@ -79,7 +79,7 @@ Here are the available options:
 
 	default value: `0`
 
-* `colorscheme`: loads the colorscheme stored in 
+* `colorscheme`: loads the colorscheme stored in
    $(configDir)/colorschemes/`option`.micro, This setting is `global only`.
 
 	default value: `default`
@@ -88,7 +88,7 @@ Here are the available options:
     are not located in configDir, because they are embedded in the micro
     binary.
 
-	The colorscheme can be selected from all the files in the 
+	The colorscheme can be selected from all the files in the
 	~/.config/micro/colorschemes/ directory. Micro comes by default with
 	three colorschemes:
 
@@ -328,9 +328,9 @@ Here are the available options:
 
 * `relativeruler`: make line numbers display relatively. If set to true, all
    lines except for the line that the cursor is located will display the distance
-   from the cursor's line. 
+   from the cursor's line.
 
-	default value: `false` 
+	default value: `false`
 
 * `savecursor`: remember where the cursor was last time the file was opened and
    put it there when you open the file again. Information is saved to
@@ -481,7 +481,7 @@ or disable them:
    recent Git commit rather than the diff since opening the file.
 
 Any option you set in the editor will be saved to the file
-~/.config/micro/settings.json so, in effect, your configuration file will be 
+~/.config/micro/settings.json so, in effect, your configuration file will be
 created for you. If you'd like to take your configuration with you to another
 machine, simply copy the settings.json to the other machine.
 


### PR DESCRIPTION
I also plan:

1. Use tabs everywhere inside:

	\`\`\`json
	\`\`\`

2. Use tabs or spaces before `default value:` in `runtime/help/options.md`. Currently there are both types of indents but I think spaces will suit better because tab can have different size

3. Yeah it is not about help files but about syntax files so I can then rename the PR to "Fix: runtime use one style". So should yaml files use tabs? I vote for tabs