### PR TITLE
improve Rust raw string literal highlighting

### DIFF
--- a/runtime/syntax/rust.yaml
+++ b/runtime/syntax/rust.yaml
@@ -29,8 +29,23 @@ rules:
             - constant.specialChar: '\\.'
 
     - constant.string:
-        start: "r#+\""
-        end: "\"#+"
+        start: "r#\""
+        end: "\"#"
+        rules: []
+
+    - constant.string:
+        start: "r##\""
+        end: "\"##"
+        rules: []
+
+    - constant.string:
+        start: "r###\""
+        end: "\"###"
+        rules: []
+
+    - constant.string:
+        start: "r####+\""
+        end: "\"####+"
         rules: []
 
     # Character literals


### PR DESCRIPTION
This only addresses the problem for up to three '#' characters but having more than that is excessively rare. I don't think there's any way to properly fix this with the current syntax highlighting system.

closes #3191