### PR TITLE
Fix crash when syntax file has no `rules`

### DIFF
--- a/pkg/highlight/parser.go
+++ b/pkg/highlight/parser.go
@@ -213,12 +213,12 @@ func ParseDef(f *File, header *Header) (s *Def, err error) {
 		}
 	}()
 
-	rules := f.yamlSrc
+	src := f.yamlSrc
 
 	s = new(Def)
 	s.Header = header
 
-	for k, v := range rules {
+	for k, v := range src {
 		if k == "rules" {
 			inputRules := v.([]interface{})
 
@@ -229,6 +229,11 @@ func ParseDef(f *File, header *Header) (s *Def, err error) {
 
 			s.rules = rules
 		}
+	}
+
+	if s.rules == nil {
+		// allow empty rules
+		s.rules = new(rules)
 	}
 
 	return s, err


### PR DESCRIPTION
If a syntax file `aaa.yaml` contains no `rules` directive, then after `set filetype aaa` micro crashes with `d.rules` nil pointer dereference in `HasIncludes()`:

```
Micro encountered an error: runtime.errorString runtime error: invalid memory address or nil pointer dereference
runtime/panic.go:221 (0x44c527)
runtime/panic.go:220 (0x44c4f7)
github.com/zyedidia/micro/v2/pkg/highlight/parser.go:239 (0x820919)
github.com/zyedidia/micro/v2/internal/buffer/buffer.go:830 (0x82b818)
github.com/zyedidia/micro/v2/internal/buffer/settings.go:33 (0x83b665)
github.com/zyedidia/micro/v2/internal/action/command.go:578 (0x87d75f)
github.com/zyedidia/micro/v2/internal/action/command.go:598 (0x87da79)
github.com/zyedidia/micro/v2/internal/action/command.go:634 (0x87de54)
github.com/zyedidia/micro/v2/internal/action/command.go:1030 (0x880f68)
github.com/zyedidia/micro/v2/internal/action/actions.go:1545 (0x870d72)
github.com/zyedidia/micro/v2/internal/info/infobuffer.go:152 (0x8421b4)
github.com/zyedidia/micro/v2/internal/action/infopane.go:208 (0x8854cc)
github.com/zyedidia/micro/v2/internal/action/infopane.go:54 (0x8844d6)
github.com/zyedidia/micro/v2/internal/action/infopane.go:131 (0x884d42)
github.com/zyedidia/micro/v2/internal/action/infopane.go:95 (0x8849ff)
github.com/zyedidia/micro/v2/cmd/micro/micro.go:481 (0x8bfb86)
github.com/zyedidia/micro/v2/cmd/micro/micro.go:397 (0x8bf63e)
runtime/proc.go:255 (0x438867)
runtime/asm_amd64.s:1581 (0x467a81)
```