### PR TITLE
Autocomplete `unknown` value in `set filetype ...`

### DIFF
--- a/internal/action/infocomplete.go
+++ b/internal/action/infocomplete.go
@@ -87,6 +87,10 @@ func filetypeComplete(input string) (string, []string) {
 		}
 	}
 
+	if strings.HasPrefix("unknown", input) {
+		suggestions = append(suggestions, "unknown")
+	}
+
 	var chosen string
 	if len(suggestions) == 1 {
 		chosen = suggestions[0]

--- a/internal/action/infocomplete.go
+++ b/internal/action/infocomplete.go
@@ -87,6 +87,9 @@ func filetypeComplete(input string) (string, []string) {
 		}
 	}
 
+	if strings.HasPrefix("off", input) {
+		suggestions = append(suggestions, "off")
+	}
 	if strings.HasPrefix("unknown", input) {
 		suggestions = append(suggestions, "unknown")
 	}


### PR DESCRIPTION
`unknown` is a valid value for the `filetype` option (and executing `set filetype unknown` does what is expected: it forces filetype autodetection). So let's add `unknown` to the autocomplete suggestions for `filetype`, along with actual filetypes.