### PR TITLE
Make `set filetype off` work as expected

### DIFF
--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -690,6 +690,8 @@ func (b *Buffer) UpdateRules() {
 	}
 	ft := b.Settings["filetype"].(string)
 	if ft == "off" {
+		b.ClearMatches()
+		b.SyntaxDef = nil
 		return
 	}
 


### PR DESCRIPTION
Clear syntax highlighting after setting filetype to `off`.