### PR TITLE
s/filename/filetype/ in `jsonnet` syntax file

### DIFF
--- a/pkg/highlight/parser.go
+++ b/pkg/highlight/parser.go
@@ -209,9 +209,17 @@ func ParseFile(input []byte) (f *File, err error) {
 		if k == "filetype" {
 			filetype := v.(string)
 
+			if filetype == "" {
+				return nil, errors.New("empty filetype")
+			}
+
 			f.FileType = filetype
 			break
 		}
+	}
+
+	if f.FileType == "" {
+		return nil, errors.New("missing filetype")
 	}
 
 	return f, err

--- a/runtime/syntax/jsonnet.yaml
+++ b/runtime/syntax/jsonnet.yaml
@@ -1,4 +1,4 @@
-filename: jsonnet
+filetype: jsonnet
 
 detect:
     filename: "\\.jsonnet$"


### PR DESCRIPTION
This typo causes a funny bug: the autodetected filetype for `*.jsonnet` files is an empty string instead of `jsonnet`.
    
Even funnier, when autocompleting `set filetype ` (with the fix from PR #3218), the first suggested filetype is this empty string.
