### PR TITLE
Don't initialize plugins and user settings in tests

### DIFF
--- a/cmd/micro/micro_test.go
+++ b/cmd/micro/micro_test.go
@@ -36,7 +36,6 @@ func startup(args []string) (tcell.SimulationScreen, error) {
 	}
 
 	config.InitRuntimeFiles()
-	config.InitPlugins()
 
 	err = config.ReadSettings()
 	if err != nil {

--- a/internal/buffer/buffer_test.go
+++ b/internal/buffer/buffer_test.go
@@ -20,8 +20,6 @@ type operation struct {
 
 func init() {
 	ulua.L = lua.NewState()
-	config.InitRuntimeFiles()
-	config.InitPlugins()
 	config.InitGlobalSettings()
 	config.GlobalSettings["backup"] = false
 	config.GlobalSettings["fastdirty"] = true

--- a/internal/config/rtfiles.go
+++ b/internal/config/rtfiles.go
@@ -39,6 +39,10 @@ type RuntimeFile interface {
 var allFiles [][]RuntimeFile
 var realFiles [][]RuntimeFile
 
+func init() {
+	initRuntimeVars()
+}
+
 func initRuntimeVars() {
 	allFiles = make([][]RuntimeFile, NumTypes)
 	realFiles = make([][]RuntimeFile, NumTypes)

--- a/internal/config/rtfiles_test.go
+++ b/internal/config/rtfiles_test.go
@@ -8,7 +8,6 @@ import (
 
 func init() {
 	InitRuntimeFiles()
-	InitPlugins()
 }
 
 func TestAddFile(t *testing.T) {


### PR DESCRIPTION
Adding `InitRuntimeFiles()` and `InitPlugins()` to `buffer_test.go` in PR #3062 (instead of just initializing runtime vars with empty values, as it was before) seems to cause sporadic failures of MacOS build tests on github, with crashes in various places but all beginning with lots of plugin failures:

```
2024/03/23 15:14:30 Plugin does not exist: autoclose at autoclose : &{autoclose autoclose <nil> [runtime/plugins/autoclose/autoclose.lua] false true}
2024/03/23 15:14:30 Plugin does not exist: comment at comment : &{comment comment <nil> [runtime/plugins/comment/comment.lua] false true}
2024/03/23 15:14:30 Plugin does not exist: diff at diff : &{diff diff <nil> [runtime/plugins/diff/diff.lua] false true}
2024/03/23 15:14:30 Plugin does not exist: ftoptions at ftoptions : &{ftoptions ftoptions <nil> [runtime/plugins/ftoptions/ftoptions.lua] false true}
...
```

I suppose tests should not rely on plugins, and more importantly, should not be affected by the contents of ~/.config/micro/ on the host.