### PR TITLE
Improve crontab filetype detection

### DIFF
--- a/runtime/syntax/crontab.yaml
+++ b/runtime/syntax/crontab.yaml
@@ -1,7 +1,7 @@
 filetype: crontab
 
 detect:
-    filename: "crontab$"
+    filename: "crontab$|/tmp/crontab\\.\\w+$"
     header: "^#.*?/etc/crontab"
 
 rules:


### PR DESCRIPTION
Support crontab filetype detection in the case crontab is opened via sudoedit. Also apparently this fixes crontab filetype detection when it is opened normally via `crontab -e` but in MacOS.

Fixes #3172