### PR TITLE
ReHighlightStates: sanity-check `startline` value

### DIFF
--- a/pkg/highlight/highlighter.go
+++ b/pkg/highlight/highlighter.go
@@ -363,7 +363,9 @@ func (h *Highlighter) ReHighlightStates(input LineStates, startline int) int {
 	h.lastRegion = nil
 	if startline > 0 {
 		input.Lock()
-		h.lastRegion = input.State(startline - 1)
+		if startline-1 < input.LinesNum() {
+			h.lastRegion = input.State(startline - 1)
+		}
 		input.Unlock()
 	}
 	for i := startline; ; i++ {


### PR DESCRIPTION
Check if `startline` value is valid before passing it to `input.State()`, to prevent a theoretically possible race when the number of lines changes in the meantime, causing an out of bounds access.

Actually this race cannot happen: `ReHighlightStates()` is only called from the main goroutine, and the line array is modified, again, only by the main goroutine. So for now this change is rather cosmetic: it is just to make the highligher API implementation self-sufficiently safe without assumptions about which goroutines are using which API functions and how.