### PR TITLE
Add `onAnyEvent` callback

### DIFF
--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -450,10 +450,6 @@ func DoEvent() {
 		os.Exit(0)
 	}
 
-	if event == nil {
-		return
-	}
-
 	if e, ok := event.(*tcell.EventError); ok {
 		log.Println("tcell event error: ", e.Error())
 
@@ -473,13 +469,20 @@ func DoEvent() {
 		return
 	}
 
-	_, resize := event.(*tcell.EventResize)
-	if resize {
-		action.InfoBar.HandleEvent(event)
-		action.Tabs.HandleEvent(event)
-	} else if action.InfoBar.HasPrompt {
-		action.InfoBar.HandleEvent(event)
-	} else {
-		action.Tabs.HandleEvent(event)
+	if event != nil {
+		_, resize := event.(*tcell.EventResize)
+		if resize {
+			action.InfoBar.HandleEvent(event)
+			action.Tabs.HandleEvent(event)
+		} else if action.InfoBar.HasPrompt {
+			action.InfoBar.HandleEvent(event)
+		} else {
+			action.Tabs.HandleEvent(event)
+		}
+	}
+
+	err := config.RunPluginFn("onAnyEvent")
+	if err != nil {
+		screen.TermMessage(err)
 	}
 }

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -72,6 +72,10 @@ which micro defines:
 
 * `preRune(bufpane, rune)`: runs before the composed rune will be inserted
 
+* `onAnyEvent()`: runs when literally anything happens. It is useful for
+   detecting various changes of micro's state that cannot be detected
+   using other callbacks.
+
 For example a function which is run every time the user saves the buffer
 would be:
 


### PR DESCRIPTION
Implement a radical approach to improving abilities of plugins to detect and handle various changes of micro's state: add `onAnyEvent` callback which is called, literally, after any event. A plugin can use this callback to compare a state after the previous event and after the current event, and thus is able to catch various events that cannot be detected using other callbacks.

This may be a crazy idea, but maybe let's try it.

Some examples of such events that can be detected with `onAnyEvent` but not with other callbacks:

- change of current working directory (see https://github.com/zyedidia/micro/discussions/3234)
- switching cursor focus between a bufpane and the command bar (see https://github.com/zyedidia/micro/discussions/3234)
- change of message text in the status bar (see https://github.com/zyedidia/micro/issues/3226#issuecomment-2046001446)