### PR TITLE
Fix issues with `onSetActive` callback

### DIFF
--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -679,6 +679,10 @@ func (h *BufPane) Close() {
 
 // SetActive marks this pane as active.
 func (h *BufPane) SetActive(b bool) {
+	if h.IsActive() == b {
+		return
+	}
+
 	h.BWindow.SetActive(b)
 	if b {
 		// Display any gutter messages for this line
@@ -694,8 +698,12 @@ func (h *BufPane) SetActive(b bool) {
 		if none && InfoBar.HasGutter {
 			InfoBar.ClearGutter()
 		}
-	}
 
+		err := config.RunPluginFn("onSetActive", luar.New(ulua.L, h))
+		if err != nil {
+			screen.TermMessage(err)
+		}
+	}
 }
 
 // BufKeyActions contains the list of all possible key actions the bufhandler could execute

--- a/internal/action/tab.go
+++ b/internal/action/tab.go
@@ -327,11 +327,6 @@ func (t *Tab) SetActive(i int) {
 			p.SetActive(false)
 		}
 	}
-
-	err := config.RunPluginFn("onSetActive", luar.New(ulua.L, MainTab().CurPane()))
-	if err != nil {
-		screen.TermMessage(err)
-	}
 }
 
 // GetPane returns the pane with the given split index

--- a/internal/action/tab.go
+++ b/internal/action/tab.go
@@ -147,6 +147,25 @@ func (t *TabList) Display() {
 	}
 }
 
+func (t *TabList) SetActive(a int) {
+	t.TabWindow.SetActive(a)
+
+	for i, p := range t.List {
+		if i == a {
+			if !p.isActive {
+				p.isActive = true
+
+				err := config.RunPluginFn("onSetActive", luar.New(ulua.L, p.CurPane()))
+				if err != nil {
+					screen.TermMessage(err)
+				}
+			}
+		} else {
+			p.isActive = false
+		}
+	}
+}
+
 // Tabs is the global tab list
 var Tabs *TabList
 
@@ -192,6 +211,9 @@ func MainTab() *Tab {
 type Tab struct {
 	*views.Node
 	*display.UIWindow
+
+	isActive bool
+
 	Panes  []Pane
 	active int
 

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -51,7 +51,7 @@ which micro defines:
 
 * `postinit()`: initialization function called after `init()`.
 
-* `onSetActive(bufpane)`: runs when changing the currently active panel.
+* `onSetActive(bufpane)`: runs when changing the currently active bufpane.
 
 * `onBufferOpen(buf)`: runs when a buffer is opened. The input contains
    the buffer object.

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -51,13 +51,13 @@ which micro defines:
 
 * `postinit()`: initialization function called after `init()`.
 
-* `onSetActive(bufpane)`: runs when changing the currently active bufpane.
-
 * `onBufferOpen(buf)`: runs when a buffer is opened. The input contains
    the buffer object.
 
 * `onBufPaneOpen(bufpane)`: runs when a bufpane is opened. The input
    contains the bufpane object.
+
+* `onSetActive(bufpane)`: runs when changing the currently active bufpane.
 
 * `onAction(bufpane)`: runs when `Action` is triggered by the user, where
    `Action` is a bindable action (see `> help keybindings`). A bufpane


### PR DESCRIPTION
- Call `onSetActive` when switching to another tab, not just when switching to another pane within the same tab.
- Don't call `onSetActive` for an already active pane (when the user clicks on it with the mouse).
- Minor documentation improvements