### PR TITLE
Add `onBufPaneOpen` error checking

### DIFF
--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -290,7 +290,11 @@ func NewBufPaneFromBuf(buf *buffer.Buffer, tab *Tab) *BufPane {
 func (h *BufPane) finishInitialize() {
 	h.initialRelocate()
 	h.initialized = true
-	config.RunPluginFn("onBufPaneOpen", luar.New(ulua.L, h))
+
+	err := config.RunPluginFn("onBufPaneOpen", luar.New(ulua.L, h))
+	if err != nil {
+		screen.TermMessage(err)
+	}
 }
 
 // Resize resizes the pane


### PR DESCRIPTION
If `onBufPaneOpen` callback execution fails (e.g. due to a Lua runtime error), report this error to the user, like we do for all other Lua callbacks, rather than silently continue working as if nothing happened.