### PR TITLE
add `public` keyword to Julia syntax file

### DIFF
--- a/runtime/syntax/julia.yaml
+++ b/runtime/syntax/julia.yaml
@@ -14,7 +14,7 @@ rules:
       # definitions
     - identifier: "[A-Za-z_][A-Za-z0-9_]*[[:space:]]*[(]"
       # keywords
-    - statement: "\\b(baremodule|begin|break|catch|const|continue|do|else|elseif|end|export|finally|for|function|global|if|import|let|local|macro|module|quote|return|struct|try|using|while)\\b"
+    - statement: "\\b(baremodule|begin|break|catch|const|continue|do|else|elseif|end|export|finally|for|function|global|if|import|let|local|macro|module|public|quote|return|struct|try|using|while)\\b"
     - statement: "\\b(abstract\\s+type|primitive\\s+type|mutable\\s+struct)\\b"
       # decorators
     - identifier.macro: "@[A-Za-z0-9_]+"


### PR DESCRIPTION
`public` is a new keyword in Julia 1.11, see [here](https://github.com/JuliaLang/julia/blob/v1.11.0-beta1/NEWS.md). It's not a reserved keyword, so one can also use it as a variable name. However, the same is true for `where`, which already gets syntax highlighting.