### PR TITLE
Relocate buffer view when reloading file

### DIFF
--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -415,6 +415,12 @@ func (h *BufPane) Name() string {
 	return n
 }
 
+// ReOpen reloads the file opened in the bufpane from disk
+func (h *BufPane) ReOpen() {
+	h.Buf.ReOpen()
+	h.Relocate()
+}
+
 func (h *BufPane) getReloadSetting() string {
 	reloadSetting := h.Buf.Settings["reload"]
 	return reloadSetting.(string)
@@ -433,11 +439,11 @@ func (h *BufPane) HandleEvent(event tcell.Event) {
 				if !yes || canceled {
 					h.Buf.UpdateModTime()
 				} else {
-					h.Buf.ReOpen()
+					h.ReOpen()
 				}
 			})
 		} else if reload == "auto" {
-			h.Buf.ReOpen()
+			h.ReOpen()
 		} else if reload == "disabled" {
 			h.Buf.DisableReload()
 		} else {

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -403,13 +403,13 @@ func (h *BufPane) ReopenCmd(args []string) {
 		InfoBar.YNPrompt("Save file before reopen?", func(yes, canceled bool) {
 			if !canceled && yes {
 				h.Save()
-				h.Buf.ReOpen()
+				h.ReOpen()
 			} else if !canceled {
-				h.Buf.ReOpen()
+				h.ReOpen()
 			}
 		})
 	} else {
-		h.Buf.ReOpen()
+		h.ReOpen()
 	}
 }
 


### PR DESCRIPTION
After reloading a file that has been externally modified, the buffer view may become invalid: the displayed subset of lines of the file may no longer exist, since the file may have been truncated. So relocate the buffer view in this case.

In particular, this fixes crashes caused by out of bounds accesses to the line array by displayBuffer() trying to display no longer existing lines (reported in https://github.com/zyedidia/micro/issues/742#issuecomment-1909958284)

Fixes #742