### PR TITLE
Follow-ups after adding `default.yaml` support

### DIFF
--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -741,10 +741,10 @@ func findRuntimeSyntaxDef(name string, header *highlight.Header) *highlight.Def 
 }
 
 func resolveIncludes(syndef *highlight.Def) {
-	if !highlight.HasIncludes(syndef) {
+	includes := highlight.GetIncludes(syndef)
+	if len(includes) == 0 {
 		return
 	}
-	includes := highlight.GetIncludes(syndef)
 
 	var files []*highlight.File
 	for _, f := range config.ListRuntimeFiles(config.RTSyntax) {

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -753,6 +753,8 @@ func (b *Buffer) UpdateRules() {
 		return
 	}
 
+	b.SyntaxDef = nil
+
 	// syntaxFileInfo is an internal helper structure
 	// to store properties of one single syntax file
 	type syntaxFileInfo struct {
@@ -945,16 +947,14 @@ func (b *Buffer) UpdateRules() {
 		highlight.ResolveIncludes(b.SyntaxDef, files)
 	}
 
-	if b.Highlighter == nil || syntaxFile != "" {
-		if b.SyntaxDef != nil {
-			b.Settings["filetype"] = b.SyntaxDef.FileType
-		} else {
-			// search for the default file in the user's custom syntax files
-			b.SyntaxDef = findRealRuntimeSyntaxDef("default", nil)
-			if b.SyntaxDef == nil {
-				// search for the default file in the runtime files
-				b.SyntaxDef = findRuntimeSyntaxDef("default", nil)
-			}
+	if b.SyntaxDef != nil {
+		b.Settings["filetype"] = b.SyntaxDef.FileType
+	} else {
+		// search for the default file in the user's custom syntax files
+		b.SyntaxDef = findRealRuntimeSyntaxDef("default", nil)
+		if b.SyntaxDef == nil {
+			// search for the default file in the runtime files
+			b.SyntaxDef = findRuntimeSyntaxDef("default", nil)
 		}
 	}
 

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -727,7 +727,7 @@ func findRealRuntimeSyntaxDef(name string, header *highlight.Header) *highlight.
 }
 
 // findRuntimeSyntaxDef finds a specific syntax definition
-// in the runtime files
+// in the built-in syntax files
 func findRuntimeSyntaxDef(name string, header *highlight.Header) *highlight.Def {
 	for _, f := range config.ListRuntimeFiles(config.RTSyntax) {
 		if f.Name() == name {
@@ -830,7 +830,7 @@ func (b *Buffer) UpdateRules() {
 	}
 
 	if !foundDef {
-		// search for the syntax file in the runtime files
+		// search for the syntax file in the built-in syntax files
 		for _, f := range config.ListRuntimeFiles(config.RTSyntaxHeader) {
 			data, err := f.Data()
 			if err != nil {
@@ -917,7 +917,7 @@ func (b *Buffer) UpdateRules() {
 		// search for the default file in the user's custom syntax files
 		b.SyntaxDef = findRealRuntimeSyntaxDef("default", nil)
 		if b.SyntaxDef == nil {
-			// search for the default file in the runtime files
+			// search for the default file in the built-in syntax files
 			b.SyntaxDef = findRuntimeSyntaxDef("default", nil)
 		}
 	}

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -911,6 +911,17 @@ func (b *Buffer) UpdateRules() {
 		b.SyntaxDef = findRuntimeSyntaxDef(syntaxFile, header)
 	}
 
+	if b.SyntaxDef != nil {
+		b.Settings["filetype"] = b.SyntaxDef.FileType
+	} else {
+		// search for the default file in the user's custom syntax files
+		b.SyntaxDef = findRealRuntimeSyntaxDef("default", nil)
+		if b.SyntaxDef == nil {
+			// search for the default file in the runtime files
+			b.SyntaxDef = findRuntimeSyntaxDef("default", nil)
+		}
+	}
+
 	if b.SyntaxDef != nil && highlight.HasIncludes(b.SyntaxDef) {
 		includes := highlight.GetIncludes(b.SyntaxDef)
 
@@ -945,17 +956,6 @@ func (b *Buffer) UpdateRules() {
 		}
 
 		highlight.ResolveIncludes(b.SyntaxDef, files)
-	}
-
-	if b.SyntaxDef != nil {
-		b.Settings["filetype"] = b.SyntaxDef.FileType
-	} else {
-		// search for the default file in the user's custom syntax files
-		b.SyntaxDef = findRealRuntimeSyntaxDef("default", nil)
-		if b.SyntaxDef == nil {
-			// search for the default file in the runtime files
-			b.SyntaxDef = findRuntimeSyntaxDef("default", nil)
-		}
 	}
 
 	if b.SyntaxDef != nil {

--- a/runtime/help/colors.md
+++ b/runtime/help/colors.md
@@ -392,3 +392,6 @@ example, the following is possible for html:
     rules:
         - include: "css"
 ```
+
+Note that nested include (i.e. including syntax files that include other syntax
+files) is not supported yet.


### PR DESCRIPTION
More follow-ups of #2933.

- Fix `set filetype unknown` not working as expected in some scenarios.
- Allow includes in `default.yaml`.
- There is still even more stuff to fix and to refactor in the existing `UpdateRules()` logic. Just added TODOs for now.