### PR TITLE
action: Stop processing chained actions/commands in the moment the current `Pane` is not a `BufPane` (fix crash)

### DIFF
--- a/cmd/micro/initlua.go
+++ b/cmd/micro/initlua.go
@@ -48,7 +48,7 @@ func luaImportMicro() *lua.LTable {
 	ulua.L.SetField(pkg, "InfoBar", luar.New(ulua.L, action.GetInfoBar))
 	ulua.L.SetField(pkg, "Log", luar.New(ulua.L, log.Println))
 	ulua.L.SetField(pkg, "SetStatusInfoFn", luar.New(ulua.L, display.SetStatusInfoFnLua))
-	ulua.L.SetField(pkg, "CurPane", luar.New(ulua.L, func() action.Pane {
+	ulua.L.SetField(pkg, "CurPane", luar.New(ulua.L, func() *action.BufPane {
 		return action.MainTab().CurPane()
 	}))
 	ulua.L.SetField(pkg, "CurTab", luar.New(ulua.L, action.MainTab))

--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -169,6 +169,10 @@ func BufMapEvent(k Event, action string) {
 			// if the action changed the current pane, update the reference
 			h = MainTab().CurPane()
 			success = innerSuccess
+			if h == nil {
+				// stop, in case the current pane is not a BufPane
+				break
+			}
 		}
 		return true
 	}

--- a/internal/action/termpane.go
+++ b/internal/action/termpane.go
@@ -81,6 +81,10 @@ func (t *TermPane) SetID(i uint64) {
 	t.id = i
 }
 
+func (t *TermPane) Name() string {
+	return t.Terminal.Name()
+}
+
 func (t *TermPane) SetTab(tab *Tab) {
 	t.tab = tab
 }


### PR DESCRIPTION
Actually the `TermPane` isn't really considered as a `Pane`, even it really is a `Pane`.
-> In the first version of this PR I added the `Name()` function to the `TermPane` to be able to consider the `TermPane` as a `Pane` in the future.

The main change to fix the crash is the check the return of `MainTab().CurPane()` against `nil` in the `BufMapEvent()` respective `bufAction()` function, because `CurPane()` will return it in the moment the current pane changes to a pane other than a `BufPane`.

Fixes #2288
Fixes #2307