### PR TITLE
bindings: Correct `KeySequenceEvent` comparison (fix crash)

### DIFF
--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -251,6 +251,24 @@ func findEvent(k string) (Event, error) {
 	return event, nil
 }
 
+func eventsEqual(e1 Event, e2 Event) bool {
+	seq1, ok1 := e1.(KeySequenceEvent)
+	seq2, ok2 := e2.(KeySequenceEvent)
+	if ok1 && ok2 {
+		if len(seq1.keys) != len(seq2.keys) {
+			return false
+		}
+		for i := 0; i < len(seq1.keys); i++ {
+			if seq1.keys[i] != seq2.keys[i] {
+				return false
+			}
+		}
+		return true
+	}
+
+	return e1 == e2
+}
+
 // TryBindKey tries to bind a key by writing to config.ConfigDir/bindings.json
 // Returns true if the keybinding already existed and a possible error
 func TryBindKey(k, v string, overwrite bool) (bool, error) {
@@ -278,7 +296,7 @@ func TryBindKey(k, v string, overwrite bool) (bool, error) {
 		found := false
 		for ev := range parsed {
 			if e, err := findEvent(ev); err == nil {
-				if e == key {
+				if eventsEqual(e, key) {
 					if overwrite {
 						parsed[ev] = v
 					}
@@ -327,7 +345,7 @@ func UnbindKey(k string) error {
 
 		for ev := range parsed {
 			if e, err := findEvent(ev); err == nil {
-				if e == key {
+				if eventsEqual(e, key) {
 					delete(parsed, ev)
 					break
 				}

--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -294,21 +294,23 @@ func TryBindKey(k, v string, overwrite bool) (bool, error) {
 		}
 
 		found := false
-		for ev := range parsed {
+		var ev string
+		for ev = range parsed {
 			if e, err := findEvent(ev); err == nil {
 				if eventsEqual(e, key) {
-					if overwrite {
-						parsed[ev] = v
-					}
 					found = true
 					break
 				}
 			}
 		}
 
-		if found && !overwrite {
-			return true, nil
-		} else if !found {
+		if found {
+			if overwrite {
+				parsed[ev] = v
+			} else {
+				return true, nil
+			}
+		} else {
 			parsed[k] = v
 		}
 


### PR DESCRIPTION
We've to iterate over the included elements, since slices can't be simply compared with the comparison operators.

Fixes #3194