### PR TITLE
Fix inconsistent cursor movement behavior after mouse selection

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -113,7 +113,7 @@ func (h *BufPane) MouseDrag(e *tcell.EventMouse) bool {
 	} else if h.doubleClick {
 		h.Cursor.AddWordToSelection()
 	} else {
-		h.Cursor.SetSelectionEnd(h.Cursor.Loc)
+		h.Cursor.SelectTo(h.Cursor.Loc)
 	}
 
 	h.Cursor.StoreVisualX()


### PR DESCRIPTION
Ensure that the selection start is always before the selection end, regardless of the direction of a mouse selection, to make `h.Cursor.Deselect()` handle its `start` argument correctly.

This makes the cursor behavior after mouse selections consistent with the cursor behavior after keyboard selections.

Together with @dustdfg 's fix #3091, this makes both keyboard and mouse selections work as expected. See also the discussion in #3091.

Fixes #3055