### PR TITLE
Add, move commands in shell syntax file

### DIFF
--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -30,10 +30,10 @@ rules:
     # Numbers
     - constant.number: "\\b[0-9]+\\b"
       # Conditionals and control flow
-    - statement: "\\b(case|do|done|elif|else|esac|exit|fi|for|function|if|in|local|read|return|select|shift|then|time|until|while)\\b"
+    - statement: "\\b(case|do|done|elif|else|esac|exit|fi|for|function|if|in|return|select|then|until|while)\\b"
     - special: "[`$<>!=&~^\\{\\}\\(\\)\\;\\]\\[]+"
       # Shell commands
-    - type: "\\b(cd|echo|export|let|set|umask|unset)\\b"
+    - type: "\\b(cd|echo|export|let|local|read|set|shift|time|umask|unset)\\b"
       # Common linux commands
     - type: "\\b((g|ig)?awk|bash|dash|find|\\w{0,4}grep|kill|killall|\\w{0,4}less|make|pkill|sed|sh|tar)\\b"
       # Coreutils commands

--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -30,12 +30,12 @@ rules:
     # Numbers
     - constant.number: "\\b[0-9]+\\b"
       # Conditionals and control flow
-    - statement: "\\b(case|do|done|elif|else|esac|exit|fi|for|function|if|in|return|select|then|until|while)\\b"
+    - statement: "\\b(break|case|continue|do|done|elif|else|esac|exec|exit|fi|for|function|if|in|return|select|then|trap|until|wait|while)\\b"
     - special: "[`$<>!=&~^\\{\\}\\(\\)\\;\\]\\[]+"
       # Shell commands
-    - type: "\\b(cd|echo|export|let|local|read|set|shift|time|umask|unset)\\b"
+    - type: "\\b(cd|command|echo|eval|export|getopts|let|local|read|set|shift|time|umask|unset)\\b"
       # Common linux commands
-    - type: "\\b((g|ig)?awk|bash|dash|find|\\w{0,4}grep|kill|killall|\\w{0,4}less|make|pkill|sed|sh|tar)\\b"
+    - type: "\\b((g|ig)?awk|bash|dash|find|getopt|\\w{0,4}grep|kill|killall|\\w{0,4}less|make|pkill|sed|sh|tar)\\b"
       # Coreutils commands
     - type: "\\b(base64|basename|cat|chcon|chgrp|chmod|chown|chroot|cksum|comm|cp|csplit|cut|date|dd|df|dir|dircolors|dirname|du|env|expand|expr|factor|false|fmt|fold|head|hostid|id|install|join|link|ln|logname|ls|md5sum|mkdir|mkfifo|mknod|mktemp|mv|nice|nl|nohup|nproc|numfmt|od|paste|pathchk|pinky|pr|printenv|printf|ptx|pwd|readlink|realpath|rm|rmdir|runcon|seq|(sha1|sha224|sha256|sha384|sha512)sum|shred|shuf|sleep|sort|split|stat|stdbuf|stty|sum|sync|tac|tail|tee|test|time|timeout|touch|tr|true|truncate|tsort|tty|uname|unexpand|uniq|unlink|users|vdir|wc|who|whoami|yes)\\b"
       # Conditional flags


### PR DESCRIPTION
The commands below are added in this pull request:
- `break`
- `command`
- `continue`
- `eval`
- `exec` - There are times the command is used with replacing the shell process and other commands in a script are not run when it is replaced, so it is added in the "Conditionals and control flow" group.
- `getopt`
- `getopts` - It is usually used in a `while` loop so it is added in the "Conditionals and control flow" group.
- `trap` - It is usually used with running a command when a signal is received so it is added in the "Conditionals and control flow" group.
- `wait` - The command returns when commands in background have finished running so it is added in the "Conditionals and control flow" group.

The commands below are highlighted using a different color group in this pull request:
- `local`
- `read`
- `shift`
- `time`

The commands that are added and moved except `getopt` are usually builtin commands in `sh` implementations so they can be looked up in reference pages of those implementations.