### PR TITLE
Fix lost mouse release events in case the pane becomes inactive

### DIFF
--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -500,11 +500,16 @@ func (h *BufPane) HandleEvent(event tcell.Event) {
 			// Mouse event with no click - mouse was just released.
 			// If there were multiple mouse buttons pressed, we don't know which one
 			// was actually released, so we assume they all were released.
+			pressed := len(h.mousePressed) > 0
 			for me := range h.mousePressed {
 				delete(h.mousePressed, me)
 
 				me.state = MouseRelease
 				h.DoMouseEvent(me, e)
+			}
+			if !pressed {
+				// Propagate the mouse release in case the press wasn't for this BufPane
+				Tabs.ResetMouse()
 			}
 		}
 	}

--- a/internal/action/tab.go
+++ b/internal/action/tab.go
@@ -124,6 +124,12 @@ func (t *TabList) HandleEvent(event tcell.Event) {
 					return
 				}
 			}
+		case tcell.ButtonNone:
+			if t.List[t.Active()].release {
+				// Mouse release received, while already released
+				t.ResetMouse()
+				return
+			}
 		case tcell.WheelUp:
 			if my == t.Y {
 				t.Scroll(4)
@@ -172,6 +178,10 @@ func (t *TabList) SetActive(a int) {
 // and the mouse state is still pressed.
 func (t *TabList) ResetMouse() {
 	for _, tab := range t.List {
+		if !tab.release && tab.resizing != nil {
+			tab.resizing = nil
+		}
+
 		tab.release = true
 
 		for _, p := range tab.Panes {


### PR DESCRIPTION
A first shot to fix the mouse releases received in a different pane/tab, while the one pressed still waits for his release.

Fixes #3251