### PR TITLE
save: Perform write process safe

### DIFF
--- a/cmd/micro/clean.go
+++ b/cmd/micro/clean.go
@@ -72,7 +72,7 @@ func CleanConfig() {
 			fmt.Printf("%s (value: %v)\n", s, config.GlobalSettings[s])
 		}
 
-		fmt.Printf("These options will be removed from %s\n", filepath.Join(config.ConfigDir, "settings.json"))
+		fmt.Printf("These options will be removed from %s\n", settingsFile)
 
 		if shouldContinue() {
 			for _, s := range unusedOptions {
@@ -90,12 +90,13 @@ func CleanConfig() {
 	}
 
 	// detect incorrectly formatted buffer/ files
-	files, err := ioutil.ReadDir(filepath.Join(config.ConfigDir, "buffers"))
+	buffersPath := filepath.Join(config.ConfigDir, "buffers")
+	files, err := ioutil.ReadDir(buffersPath)
 	if err == nil {
 		var badFiles []string
 		var buffer buffer.SerializedBuffer
 		for _, f := range files {
-			fname := filepath.Join(config.ConfigDir, "buffers", f.Name())
+			fname := filepath.Join(buffersPath, f.Name())
 			file, e := os.Open(fname)
 
 			if e == nil {
@@ -110,9 +111,9 @@ func CleanConfig() {
 		}
 
 		if len(badFiles) > 0 {
-			fmt.Printf("Detected %d files with an invalid format in %s\n", len(badFiles), filepath.Join(config.ConfigDir, "buffers"))
+			fmt.Printf("Detected %d files with an invalid format in %s\n", len(badFiles), buffersPath)
 			fmt.Println("These files store cursor and undo history.")
-			fmt.Printf("Removing badly formatted files in %s\n", filepath.Join(config.ConfigDir, "buffers"))
+			fmt.Printf("Removing badly formatted files in %s\n", buffersPath)
 
 			if shouldContinue() {
 				removed := 0

--- a/cmd/micro/clean.go
+++ b/cmd/micro/clean.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"encoding/gob"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/zyedidia/micro/v2/internal/buffer"
 	"github.com/zyedidia/micro/v2/internal/config"
+	"github.com/zyedidia/micro/v2/internal/util"
 )
 
 func shouldContinue() bool {
@@ -42,7 +44,11 @@ func CleanConfig() {
 	settingsFile := filepath.Join(config.ConfigDir, "settings.json")
 	err := config.WriteSettings(settingsFile)
 	if err != nil {
-		fmt.Println("Error writing settings.json file: " + err.Error())
+		if errors.Is(err, util.ErrOverwrite) {
+			fmt.Println(err.Error())
+		} else {
+			fmt.Println("Error writing settings.json file: " + err.Error())
+		}
 	}
 
 	// detect unused options
@@ -80,7 +86,11 @@ func CleanConfig() {
 
 			err := config.OverwriteSettings(settingsFile)
 			if err != nil {
-				fmt.Println("Error overwriting settings.json file: " + err.Error())
+				if errors.Is(err, util.ErrOverwrite) {
+					fmt.Println(err.Error())
+				} else {
+					fmt.Println("Error overwriting settings.json file: " + err.Error())
+				}
 			}
 
 			fmt.Println("Removed unused options")

--- a/cmd/micro/clean.go
+++ b/cmd/micro/clean.go
@@ -39,7 +39,12 @@ func CleanConfig() {
 	}
 
 	fmt.Println("Cleaning default settings")
-	config.WriteSettings(filepath.Join(config.ConfigDir, "settings.json"))
+
+	settingsFile := filepath.Join(config.ConfigDir, "settings.json")
+	err := config.WriteSettings(settingsFile)
+	if err != nil {
+		fmt.Println("Error writing settings.json file: " + err.Error())
+	}
 
 	// detect unused options
 	var unusedOptions []string
@@ -74,9 +79,9 @@ func CleanConfig() {
 				delete(config.GlobalSettings, s)
 			}
 
-			err := config.OverwriteSettings(filepath.Join(config.ConfigDir, "settings.json"))
+			err := config.OverwriteSettings(settingsFile)
 			if err != nil {
-				fmt.Println("Error writing settings.json file: " + err.Error())
+				fmt.Println("Error overwriting settings.json file: " + err.Error())
 			}
 
 			fmt.Println("Removed unused options")

--- a/cmd/micro/clean.go
+++ b/cmd/micro/clean.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/gob"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -91,7 +90,7 @@ func CleanConfig() {
 
 	// detect incorrectly formatted buffer/ files
 	buffersPath := filepath.Join(config.ConfigDir, "buffers")
-	files, err := ioutil.ReadDir(buffersPath)
+	files, err := os.ReadDir(buffersPath)
 	if err == nil {
 		var badFiles []string
 		var buffer buffer.SerializedBuffer

--- a/cmd/micro/debug.go
+++ b/cmd/micro/debug.go
@@ -18,7 +18,7 @@ func (NullWriter) Write(data []byte) (n int, err error) {
 // InitLog sets up the debug log system for micro if it has been enabled by compile-time variables
 func InitLog() {
 	if util.Debug == "ON" {
-		f, err := os.OpenFile("log.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+		f, err := os.OpenFile("log.txt", os.O_RDWR|os.O_CREATE|os.O_TRUNC, util.FileMode)
 		if err != nil {
 			log.Fatalf("error opening file: %v", err)
 		}

--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -209,7 +208,7 @@ func LoadInput(args []string) []*buffer.Buffer {
 		// Option 2
 		// The input is not a terminal, so something is being piped in
 		// and we should read from stdin
-		input, err = ioutil.ReadAll(os.Stdin)
+		input, err = io.ReadAll(os.Stdin)
 		if err != nil {
 			screen.TermMessage("Error reading from stdin: ", err)
 			input = []byte{}

--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -489,6 +489,8 @@ func DoEvent() {
 		}
 	case f := <-timerChan:
 		f()
+	case b := <-buffer.BackupCompleteChan:
+		b.RequestedBackup = false
 	case <-sighup:
 		exit(0)
 	case <-util.Sigterm:

--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -230,7 +230,7 @@ func checkBackup(name string) error {
 		input, err := os.ReadFile(backup)
 		if err == nil {
 			t := info.ModTime()
-			msg := fmt.Sprintf(buffer.BackupMsg, t.Format("Mon Jan _2 at 15:04, 2006"), backup)
+			msg := fmt.Sprintf(buffer.BackupMsg, target, t.Format("Mon Jan _2 at 15:04, 2006"), backup)
 			choice := screen.TermPrompt(msg, []string{"r", "i", "a", "recover", "ignore", "abort"}, true)
 
 			if choice%3 == 0 {

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1003,6 +1003,9 @@ func (h *BufPane) SaveAsCB(action string, callback func()) bool {
 						h.completeAction(action)
 						return
 					}
+				} else {
+					InfoBar.Error(err)
+					return
 				}
 			} else {
 				InfoBar.YNPrompt(

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1042,7 +1042,6 @@ func (h *BufPane) saveBufToFile(filename string, action string, callback func())
 				if err != nil {
 					InfoBar.Error(err)
 				} else {
-					h.Buf.Path = filename
 					h.Buf.SetName(filename)
 					InfoBar.Message("Saved " + filename)
 					if callback != nil {
@@ -1068,7 +1067,6 @@ func (h *BufPane) saveBufToFile(filename string, action string, callback func())
 			InfoBar.Error(err)
 		}
 	} else {
-		h.Buf.Path = filename
 		h.Buf.SetName(filename)
 		InfoBar.Message("Saved " + filename)
 		if callback != nil {

--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -15,6 +15,7 @@ import (
 	"github.com/micro-editor/json5"
 	"github.com/zyedidia/micro/v2/internal/config"
 	"github.com/zyedidia/micro/v2/internal/screen"
+	"github.com/zyedidia/micro/v2/internal/util"
 	"github.com/micro-editor/tcell/v2"
 )
 
@@ -26,7 +27,7 @@ var Binder = map[string]func(e Event, action string){
 
 func createBindingsIfNotExist(fname string) {
 	if _, e := os.Stat(fname); errors.Is(e, fs.ErrNotExist) {
-		ioutil.WriteFile(fname, []byte("{}"), 0644)
+		ioutil.WriteFile(fname, []byte("{}"), util.FileMode)
 	}
 }
 
@@ -305,7 +306,7 @@ func TryBindKey(k, v string, overwrite bool) (bool, error) {
 		BindKey(k, v, Binder["buffer"])
 
 		txt, _ := json.MarshalIndent(parsed, "", "    ")
-		return true, ioutil.WriteFile(filename, append(txt, '\n'), 0644)
+		return true, ioutil.WriteFile(filename, append(txt, '\n'), util.FileMode)
 	}
 	return false, e
 }
@@ -355,7 +356,7 @@ func UnbindKey(k string) error {
 		}
 
 		txt, _ := json.MarshalIndent(parsed, "", "    ")
-		return ioutil.WriteFile(filename, append(txt, '\n'), 0644)
+		return ioutil.WriteFile(filename, append(txt, '\n'), util.FileMode)
 	}
 	return e
 }

--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -27,7 +26,7 @@ var Binder = map[string]func(e Event, action string){
 
 func createBindingsIfNotExist(fname string) {
 	if _, e := os.Stat(fname); errors.Is(e, fs.ErrNotExist) {
-		ioutil.WriteFile(fname, []byte("{}"), util.FileMode)
+		os.WriteFile(fname, []byte("{}"), util.FileMode)
 	}
 }
 
@@ -39,7 +38,7 @@ func InitBindings() {
 	createBindingsIfNotExist(filename)
 
 	if _, e := os.Stat(filename); e == nil {
-		input, err := ioutil.ReadFile(filename)
+		input, err := os.ReadFile(filename)
 		if err != nil {
 			screen.TermMessage("Error reading bindings.json file: " + err.Error())
 			return
@@ -267,7 +266,7 @@ func TryBindKey(k, v string, overwrite bool) (bool, error) {
 	filename := filepath.Join(config.ConfigDir, "bindings.json")
 	createBindingsIfNotExist(filename)
 	if _, e = os.Stat(filename); e == nil {
-		input, err := ioutil.ReadFile(filename)
+		input, err := os.ReadFile(filename)
 		if err != nil {
 			return false, errors.New("Error reading bindings.json file: " + err.Error())
 		}
@@ -306,7 +305,7 @@ func TryBindKey(k, v string, overwrite bool) (bool, error) {
 		BindKey(k, v, Binder["buffer"])
 
 		txt, _ := json.MarshalIndent(parsed, "", "    ")
-		return true, ioutil.WriteFile(filename, append(txt, '\n'), util.FileMode)
+		return true, os.WriteFile(filename, append(txt, '\n'), util.FileMode)
 	}
 	return false, e
 }
@@ -319,7 +318,7 @@ func UnbindKey(k string) error {
 	filename := filepath.Join(config.ConfigDir, "bindings.json")
 	createBindingsIfNotExist(filename)
 	if _, e = os.Stat(filename); e == nil {
-		input, err := ioutil.ReadFile(filename)
+		input, err := os.ReadFile(filename)
 		if err != nil {
 			return errors.New("Error reading bindings.json file: " + err.Error())
 		}
@@ -356,7 +355,7 @@ func UnbindKey(k string) error {
 		}
 
 		txt, _ := json.MarshalIndent(parsed, "", "    ")
-		return ioutil.WriteFile(filename, append(txt, '\n'), util.FileMode)
+		return os.WriteFile(filename, append(txt, '\n'), util.FileMode)
 	}
 	return e
 }

--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -24,9 +24,13 @@ var Binder = map[string]func(e Event, action string){
 	"terminal": TermMapEvent,
 }
 
+func writeFile(name string, txt []byte) error {
+	return util.SafeWrite(name, txt, false)
+}
+
 func createBindingsIfNotExist(fname string) {
 	if _, e := os.Stat(fname); errors.Is(e, fs.ErrNotExist) {
-		os.WriteFile(fname, []byte("{}"), util.FileMode)
+		writeFile(fname, []byte("{}"))
 	}
 }
 
@@ -305,7 +309,8 @@ func TryBindKey(k, v string, overwrite bool) (bool, error) {
 		BindKey(k, v, Binder["buffer"])
 
 		txt, _ := json.MarshalIndent(parsed, "", "    ")
-		return true, os.WriteFile(filename, append(txt, '\n'), util.FileMode)
+		txt = append(txt, '\n')
+		return true, writeFile(filename, txt)
 	}
 	return false, e
 }
@@ -355,7 +360,8 @@ func UnbindKey(k string) error {
 		}
 
 		txt, _ := json.MarshalIndent(parsed, "", "    ")
-		return os.WriteFile(filename, append(txt, '\n'), util.FileMode)
+		txt = append(txt, '\n')
+		return writeFile(filename, txt)
 	}
 	return e
 }

--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -24,7 +25,7 @@ var Binder = map[string]func(e Event, action string){
 }
 
 func createBindingsIfNotExist(fname string) {
-	if _, e := os.Stat(fname); os.IsNotExist(e) {
+	if _, e := os.Stat(fname); errors.Is(e, fs.ErrNotExist) {
 		ioutil.WriteFile(fname, []byte("{}"), 0644)
 	}
 }

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -890,7 +890,10 @@ func (h *BufPane) SaveCmd(args []string) {
 	if len(args) == 0 {
 		h.Save()
 	} else {
-		h.Buf.SaveAs(args[0])
+		err := h.Buf.SaveAs(args[0])
+		if err != nil {
+			InfoBar.Error(err)
+		}
 	}
 }
 

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -658,7 +658,16 @@ func SetGlobalOptionNative(option string, nativeValue interface{}) error {
 		delete(b.LocalSettings, option)
 	}
 
-	return config.WriteSettings(filepath.Join(config.ConfigDir, "settings.json"))
+	err := config.WriteSettings(filepath.Join(config.ConfigDir, "settings.json"))
+	if err != nil {
+		if errors.Is(err, util.ErrOverwrite) {
+			screen.TermMessage(err)
+			err = errors.Unwrap(err)
+		}
+		return err
+	}
+
+	return nil
 }
 
 func SetGlobalOption(option, value string) error {
@@ -783,7 +792,11 @@ func (h *BufPane) BindCmd(args []string) {
 
 	_, err := TryBindKey(parseKeyArg(args[0]), args[1], true)
 	if err != nil {
-		InfoBar.Error(err)
+		if errors.Is(err, util.ErrOverwrite) {
+			screen.TermMessage(err)
+		} else {
+			InfoBar.Error(err)
+		}
 	}
 }
 
@@ -796,7 +809,11 @@ func (h *BufPane) UnbindCmd(args []string) {
 
 	err := UnbindKey(parseKeyArg(args[0]))
 	if err != nil {
-		InfoBar.Error(err)
+		if errors.Is(err, util.ErrOverwrite) {
+			screen.TermMessage(err)
+		} else {
+			InfoBar.Error(err)
+		}
 	}
 }
 

--- a/internal/buffer/autocomplete.go
+++ b/internal/buffer/autocomplete.go
@@ -2,7 +2,7 @@ package buffer
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"sort"
 	"strings"
@@ -109,15 +109,15 @@ func FileComplete(b *Buffer) ([]string, []string) {
 	sep := string(os.PathSeparator)
 	dirs := strings.Split(input, sep)
 
-	var files []os.FileInfo
+	var files []fs.DirEntry
 	var err error
 	if len(dirs) > 1 {
 		directories := strings.Join(dirs[:len(dirs)-1], sep) + sep
 
 		directories, _ = util.ReplaceHome(directories)
-		files, err = ioutil.ReadDir(directories)
+		files, err = os.ReadDir(directories)
 	} else {
-		files, err = ioutil.ReadDir(".")
+		files, err = os.ReadDir(".")
 	}
 
 	if err != nil {

--- a/internal/buffer/backup.go
+++ b/internal/buffer/backup.go
@@ -14,11 +14,15 @@ import (
 	"github.com/zyedidia/micro/v2/internal/util"
 )
 
-const BackupMsg = `A backup was detected for this file. This likely means that micro
-crashed while editing this file, or another instance of micro is currently
-editing this file.
+const BackupMsg = `A backup was detected for:
 
-The backup was created on %s, and the file is
+%s
+
+This likely means that micro crashed while editing this file,
+or another instance of micro is currently editing this file,
+or an error occurred while saving this file so it may be corrupted.
+
+The backup was created on %s and its path is:
 
 %s
 
@@ -131,7 +135,7 @@ func (b *Buffer) ApplyBackup(fsize int64) (bool, bool) {
 			if err == nil {
 				defer backup.Close()
 				t := info.ModTime()
-				msg := fmt.Sprintf(BackupMsg, t.Format("Mon Jan _2 at 15:04, 2006"), backupfile)
+				msg := fmt.Sprintf(BackupMsg, b.Path, t.Format("Mon Jan _2 at 15:04, 2006"), backupfile)
 				choice := screen.TermPrompt(msg, []string{"r", "i", "a", "recover", "ignore", "abort"}, true)
 
 				if choice%3 == 0 {

--- a/internal/buffer/backup.go
+++ b/internal/buffer/backup.go
@@ -6,8 +6,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"sync/atomic"
-	"time"
 
 	"github.com/zyedidia/micro/v2/internal/config"
 	"github.com/zyedidia/micro/v2/internal/screen"
@@ -34,27 +32,7 @@ The backup was created on %s and its path is:
 
 Options: [r]ecover, [i]gnore, [a]bort: `
 
-var backupRequestChan chan *Buffer
-
-func backupThread() {
-	for {
-		time.Sleep(time.Second * 8)
-
-		for len(backupRequestChan) > 0 {
-			b := <-backupRequestChan
-			bfini := atomic.LoadInt32(&(b.fini)) != 0
-			if !bfini {
-				b.Backup()
-			}
-		}
-	}
-}
-
-func init() {
-	backupRequestChan = make(chan *Buffer, 10)
-
-	go backupThread()
-}
+const backupSeconds = 8
 
 func (b *Buffer) RequestBackup() {
 	if !b.requestedBackup {

--- a/internal/buffer/backup.go
+++ b/internal/buffer/backup.go
@@ -88,7 +88,7 @@ func (b *Buffer) Backup() error {
 
 	name := util.DetermineEscapePath(backupdir, b.AbsPath)
 	if _, err := os.Stat(name); errors.Is(err, fs.ErrNotExist) {
-		_, err = b.overwriteFile(name, false)
+		_, err = b.overwriteFile(name)
 		if err == nil {
 			b.requestedBackup = false
 		}
@@ -96,7 +96,7 @@ func (b *Buffer) Backup() error {
 	}
 
 	tmp := util.AppendBackupSuffix(name)
-	_, err := b.overwriteFile(tmp, false)
+	_, err := b.overwriteFile(tmp)
 	if err != nil {
 		os.Remove(tmp)
 		return err

--- a/internal/buffer/backup.go
+++ b/internal/buffer/backup.go
@@ -87,7 +87,12 @@ func (b *Buffer) Backup() error {
 		}
 
 		// end of line
-		eol := []byte{'\n'}
+		var eol []byte
+		if b.Endings == FFDos {
+			eol = []byte{'\r', '\n'}
+		} else {
+			eol = []byte{'\n'}
+		}
 
 		// write lines
 		if _, e = file.Write(b.lines[0].data); e != nil {

--- a/internal/buffer/backup.go
+++ b/internal/buffer/backup.go
@@ -1,8 +1,10 @@
 package buffer
 
 import (
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sync/atomic"
@@ -73,7 +75,7 @@ func (b *Buffer) Backup() error {
 	if backupdir == "" || err != nil {
 		backupdir = filepath.Join(config.ConfigDir, "backups")
 	}
-	if _, err := os.Stat(backupdir); os.IsNotExist(err) {
+	if _, err := os.Stat(backupdir); errors.Is(err, fs.ErrNotExist) {
 		os.Mkdir(backupdir, os.ModePerm)
 	}
 

--- a/internal/buffer/backup.go
+++ b/internal/buffer/backup.go
@@ -14,7 +14,7 @@ import (
 	"github.com/zyedidia/micro/v2/internal/util"
 )
 
-const backupMsg = `A backup was detected for this file. This likely means that micro
+const BackupMsg = `A backup was detected for this file. This likely means that micro
 crashed while editing this file, or another instance of micro is currently
 editing this file.
 
@@ -131,7 +131,7 @@ func (b *Buffer) ApplyBackup(fsize int64) (bool, bool) {
 			if err == nil {
 				defer backup.Close()
 				t := info.ModTime()
-				msg := fmt.Sprintf(backupMsg, t.Format("Mon Jan _2 at 15:04, 2006"), backupfile)
+				msg := fmt.Sprintf(BackupMsg, t.Format("Mon Jan _2 at 15:04, 2006"), backupfile)
 				choice := screen.TermPrompt(msg, []string{"r", "i", "a", "recover", "ignore", "abort"}, true)
 
 				if choice%3 == 0 {

--- a/internal/buffer/backup.go
+++ b/internal/buffer/backup.go
@@ -88,7 +88,7 @@ func (b *Buffer) Backup() error {
 
 	name := util.DetermineEscapePath(backupdir, b.AbsPath)
 	if _, err := os.Stat(name); errors.Is(err, fs.ErrNotExist) {
-		_, err = b.overwrite(name, false)
+		_, err = b.overwriteFile(name, false)
 		if err == nil {
 			b.requestedBackup = false
 		}
@@ -96,7 +96,7 @@ func (b *Buffer) Backup() error {
 	}
 
 	tmp := util.AppendBackupSuffix(name)
-	_, err := b.overwrite(tmp, false)
+	_, err := b.overwriteFile(tmp, false)
 	if err != nil {
 		os.Remove(tmp)
 		return err

--- a/internal/buffer/backup.go
+++ b/internal/buffer/backup.go
@@ -82,6 +82,9 @@ func (b *Buffer) Backup() error {
 	name := filepath.Join(backupdir, util.EscapePath(b.AbsPath))
 
 	err = overwriteFile(name, encoding.Nop, func(file io.Writer) (e error) {
+		b.Lock()
+		defer b.Unlock()
+
 		if len(b.lines) == 0 {
 			return
 		}

--- a/internal/buffer/backup.go
+++ b/internal/buffer/backup.go
@@ -79,7 +79,7 @@ func (b *Buffer) Backup() error {
 		os.Mkdir(backupdir, os.ModePerm)
 	}
 
-	name := filepath.Join(backupdir, util.EscapePath(b.AbsPath))
+	name := util.DetermineEscapePath(backupdir, b.AbsPath)
 
 	err = overwriteFile(name, encoding.Nop, func(file io.Writer) (e error) {
 		b.Lock()
@@ -123,7 +123,7 @@ func (b *Buffer) RemoveBackup() {
 	if !b.Settings["backup"].(bool) || b.Settings["permbackup"].(bool) || b.Path == "" || b.Type != BTDefault {
 		return
 	}
-	f := filepath.Join(config.ConfigDir, "backups", util.EscapePath(b.AbsPath))
+	f := util.DetermineEscapePath(filepath.Join(config.ConfigDir, "backups"), b.AbsPath)
 	os.Remove(f)
 }
 
@@ -131,13 +131,13 @@ func (b *Buffer) RemoveBackup() {
 // Returns true if a backup was applied
 func (b *Buffer) ApplyBackup(fsize int64) (bool, bool) {
 	if b.Settings["backup"].(bool) && !b.Settings["permbackup"].(bool) && len(b.Path) > 0 && b.Type == BTDefault {
-		backupfile := filepath.Join(config.ConfigDir, "backups", util.EscapePath(b.AbsPath))
+		backupfile := util.DetermineEscapePath(filepath.Join(config.ConfigDir, "backups"), b.AbsPath)
 		if info, err := os.Stat(backupfile); err == nil {
 			backup, err := os.Open(backupfile)
 			if err == nil {
 				defer backup.Close()
 				t := info.ModTime()
-				msg := fmt.Sprintf(backupMsg, t.Format("Mon Jan _2 at 15:04, 2006"), util.EscapePath(b.AbsPath))
+				msg := fmt.Sprintf(backupMsg, t.Format("Mon Jan _2 at 15:04, 2006"), backupfile)
 				choice := screen.TermPrompt(msg, []string{"r", "i", "a", "recover", "ignore", "abort"}, true)
 
 				if choice%3 == 0 {

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -99,7 +99,7 @@ type SharedBuffer struct {
 	diffLock          sync.RWMutex
 	diff              map[int]DiffStatus
 
-	requestedBackup bool
+	RequestedBackup bool
 	forceKeepBackup bool
 
 	// ReloadDisabled allows the user to disable reloads if they

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -30,8 +30,6 @@ import (
 	"golang.org/x/text/transform"
 )
 
-const backupTime = 8000
-
 var (
 	// OpenBuffers is a list of the currently open buffers
 	OpenBuffers []*Buffer

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -237,10 +237,6 @@ func NewBufferFromFileAtLoc(path string, btype BufType, cursorLoc Loc) (*Buffer,
 		return nil, err
 	}
 
-	f, err := os.OpenFile(filename, os.O_WRONLY, 0)
-	readonly := os.IsPermission(err)
-	f.Close()
-
 	fileInfo, serr := os.Stat(filename)
 	if serr != nil && !os.IsNotExist(serr) {
 		return nil, serr
@@ -248,6 +244,13 @@ func NewBufferFromFileAtLoc(path string, btype BufType, cursorLoc Loc) (*Buffer,
 	if serr == nil && fileInfo.IsDir() {
 		return nil, errors.New("Error: " + filename + " is a directory and cannot be opened")
 	}
+	if serr == nil && !fileInfo.Mode().IsRegular() {
+		return nil, errors.New("Error: " + filename + " is not a regular file and cannot be opened")
+	}
+
+	f, err := os.OpenFile(filename, os.O_WRONLY, 0)
+	readonly := os.IsPermission(err)
+	f.Close()
 
 	file, err := os.Open(filename)
 	if err == nil {

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -102,6 +102,7 @@ type SharedBuffer struct {
 	diff              map[int]DiffStatus
 
 	requestedBackup bool
+	forceKeepBackup bool
 
 	// ReloadDisabled allows the user to disable reloads if they
 	// are viewing a file that is constantly changing

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -544,7 +543,7 @@ func (b *Buffer) ReOpen() error {
 	}
 
 	reader := bufio.NewReader(transform.NewReader(file, enc.NewDecoder()))
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	txt := string(data)
 
 	if err != nil {

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -25,6 +25,7 @@ import (
 	"github.com/zyedidia/micro/v2/internal/screen"
 	"github.com/zyedidia/micro/v2/internal/util"
 	"github.com/zyedidia/micro/v2/pkg/highlight"
+	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/htmlindex"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
@@ -86,6 +87,8 @@ type SharedBuffer struct {
 	Settings map[string]interface{}
 	// LocalSettings customized by the user for this buffer only
 	LocalSettings map[string]bool
+
+	encoding encoding.Encoding
 
 	Suggestions   []string
 	Completions   []string
@@ -337,9 +340,9 @@ func NewBuffer(r io.Reader, size int64, path string, startcursor Loc, btype BufT
 		}
 		config.UpdatePathGlobLocals(b.Settings, absPath)
 
-		enc, err := htmlindex.Get(b.Settings["encoding"].(string))
+		b.encoding, err = htmlindex.Get(b.Settings["encoding"].(string))
 		if err != nil {
-			enc = unicode.UTF8
+			b.encoding = unicode.UTF8
 			b.Settings["encoding"] = "utf-8"
 		}
 
@@ -350,7 +353,7 @@ func NewBuffer(r io.Reader, size int64, path string, startcursor Loc, btype BufT
 			return NewBufferFromString("", "", btype)
 		}
 		if !hasBackup {
-			reader := bufio.NewReader(transform.NewReader(r, enc.NewDecoder()))
+			reader := bufio.NewReader(transform.NewReader(r, b.encoding.NewDecoder()))
 
 			var ff FileFormat = FFAuto
 

--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -103,6 +103,9 @@ func (b *Buffer) overwrite(name string, withSudo bool) (int, error) {
 
 	var size int
 	fwriter := func(file io.Writer) error {
+		b.Lock()
+		defer b.Unlock()
+
 		if len(b.lines) == 0 {
 			return err
 		}

--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -18,7 +18,6 @@ import (
 	"github.com/zyedidia/micro/v2/internal/config"
 	"github.com/zyedidia/micro/v2/internal/screen"
 	"github.com/zyedidia/micro/v2/internal/util"
-	"golang.org/x/text/encoding/htmlindex"
 	"golang.org/x/text/transform"
 )
 
@@ -118,12 +117,7 @@ func openFile(name string, withSudo bool) (wrappedFile, error) {
 }
 
 func (wf wrappedFile) Write(b *Buffer) (int, error) {
-	enc, err := htmlindex.Get(b.Settings["encoding"].(string))
-	if err != nil {
-		return 0, err
-	}
-
-	file := bufio.NewWriter(transform.NewWriter(wf.writeCloser, enc.NewEncoder()))
+	file := bufio.NewWriter(transform.NewWriter(wf.writeCloser, b.encoding.NewEncoder()))
 
 	b.Lock()
 	defer b.Unlock()
@@ -142,7 +136,7 @@ func (wf wrappedFile) Write(b *Buffer) (int, error) {
 
 	if !wf.withSudo {
 		f := wf.writeCloser.(*os.File)
-		err = f.Truncate(0)
+		err := f.Truncate(0)
 		if err != nil {
 			return 0, err
 		}

--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -316,6 +316,10 @@ func (b *Buffer) saveToFile(filename string, withSudo bool, autoSave bool) error
 	result := <-saveResponseChan
 	err = result.err
 	if err != nil {
+		if errors.Is(err, util.ErrOverwrite) {
+			screen.TermMessage(err)
+			err = errors.Unwrap(err)
+		}
 		return err
 	}
 
@@ -371,6 +375,7 @@ func (b *Buffer) safeWrite(path string, withSudo bool, newFile bool) (int, error
 	b.forceKeepBackup = true
 	size, err := file.Write(b)
 	if err != nil {
+		err = util.OverwriteError{err, backupName}
 		return size, err
 	}
 	b.forceKeepBackup = false

--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -57,7 +57,7 @@ func overwriteFile(name string, enc encoding.Encoding, fn func(io.Writer) error,
 
 			return
 		}
-	} else if writeCloser, err = os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666); err != nil {
+	} else if writeCloser, err = os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, util.FileMode); err != nil {
 		return
 	}
 

--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -263,12 +263,6 @@ func (b *Buffer) saveToFile(filename string, withSudo bool, autoSave bool) error
 		}
 	}
 
-	// Update the last time this file was updated after saving
-	defer func() {
-		b.ModTime, _ = util.GetModTime(filename)
-		err = b.Serialize()
-	}()
-
 	filename, err = util.ReplaceHome(filename)
 	if err != nil {
 		return err
@@ -319,6 +313,8 @@ func (b *Buffer) saveToFile(filename string, withSudo bool, autoSave bool) error
 		if errors.Is(err, util.ErrOverwrite) {
 			screen.TermMessage(err)
 			err = errors.Unwrap(err)
+
+			b.UpdateModTime()
 		}
 		return err
 	}
@@ -335,7 +331,10 @@ func (b *Buffer) saveToFile(filename string, withSudo bool, autoSave bool) error
 	b.Path = filename
 	b.AbsPath = absFilename
 	b.isModified = false
+	b.UpdateModTime()
 	b.ReloadSettings(true)
+
+	err = b.Serialize()
 	return err
 }
 

--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -162,6 +162,17 @@ func (b *Buffer) saveToFile(filename string, withSudo bool, autoSave bool) error
 	// Removes any tilde and replaces with the absolute path to home
 	absFilename, _ := util.ReplaceHome(filename)
 
+	fileInfo, err := os.Stat(absFilename)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return err
+	}
+	if err == nil && fileInfo.IsDir() {
+		return errors.New("Error: " + absFilename + " is a directory and cannot be saved")
+	}
+	if err == nil && !fileInfo.Mode().IsRegular() {
+		return errors.New("Error: " + absFilename + " is not a regular file and cannot be saved")
+	}
+
 	// Get the leading path to the file | "." is returned if there's no leading path provided
 	if dirname := filepath.Dir(absFilename); dirname != "." {
 		// Check if the parent dirs don't exist

--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -164,7 +165,7 @@ func (b *Buffer) saveToFile(filename string, withSudo bool, autoSave bool) error
 	// Get the leading path to the file | "." is returned if there's no leading path provided
 	if dirname := filepath.Dir(absFilename); dirname != "." {
 		// Check if the parent dirs don't exist
-		if _, statErr := os.Stat(dirname); os.IsNotExist(statErr) {
+		if _, statErr := os.Stat(dirname); errors.Is(statErr, fs.ErrNotExist) {
 			// Prompt to make sure they want to create the dirs that are missing
 			if b.Settings["mkparents"].(bool) {
 				// Create all leading dir(s) since they don't exist

--- a/internal/buffer/serialize.go
+++ b/internal/buffer/serialize.go
@@ -31,7 +31,7 @@ func (b *Buffer) Serialize() error {
 		return nil
 	}
 
-	name := filepath.Join(config.ConfigDir, "buffers", util.EscapePath(b.AbsPath))
+	name := util.DetermineEscapePath(filepath.Join(config.ConfigDir, "buffers"), b.AbsPath)
 
 	return overwriteFile(name, encoding.Nop, func(file io.Writer) error {
 		err := gob.NewEncoder(file).Encode(SerializedBuffer{
@@ -50,7 +50,7 @@ func (b *Buffer) Unserialize() error {
 	if b.Path == "" {
 		return nil
 	}
-	file, err := os.Open(filepath.Join(config.ConfigDir, "buffers", util.EscapePath(b.AbsPath)))
+	file, err := os.Open(util.DetermineEscapePath(filepath.Join(config.ConfigDir, "buffers"), b.AbsPath))
 	if err == nil {
 		defer file.Close()
 		var buffer SerializedBuffer

--- a/internal/buffer/settings.go
+++ b/internal/buffer/settings.go
@@ -7,6 +7,8 @@ import (
 	"github.com/zyedidia/micro/v2/internal/config"
 	ulua "github.com/zyedidia/micro/v2/internal/lua"
 	"github.com/zyedidia/micro/v2/internal/screen"
+	"golang.org/x/text/encoding/htmlindex"
+	"golang.org/x/text/encoding/unicode"
 	luar "layeh.com/gopher-luar"
 )
 
@@ -97,6 +99,12 @@ func (b *Buffer) DoSetOptionNative(option string, nativeValue interface{}) {
 			b.UpdateRules()
 		}
 	} else if option == "encoding" {
+		enc, err := htmlindex.Get(b.Settings["encoding"].(string))
+		if err != nil {
+			enc = unicode.UTF8
+			b.Settings["encoding"] = "utf-8"
+		}
+		b.encoding = enc
 		b.isModified = true
 	} else if option == "readonly" && b.Type.Kind == BTDefault.Kind {
 		b.Type.Readonly = nativeValue.(bool)

--- a/internal/config/plugin_installer.go
+++ b/internal/config/plugin_installer.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -396,7 +395,7 @@ func (pv *PluginVersion) DownloadAndInstall(out io.Writer) error {
 		return err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/internal/config/rtfiles.go
+++ b/internal/config/rtfiles.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"errors"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -81,7 +80,7 @@ func (rf realFile) Name() string {
 }
 
 func (rf realFile) Data() ([]byte, error) {
-	return ioutil.ReadFile(string(rf))
+	return os.ReadFile(string(rf))
 }
 
 func (af assetFile) Name() string {
@@ -107,7 +106,7 @@ func AddRealRuntimeFile(fileType RTFiletype, file RuntimeFile) {
 // AddRuntimeFilesFromDirectory registers each file from the given directory for
 // the filetype which matches the file-pattern
 func AddRuntimeFilesFromDirectory(fileType RTFiletype, directory, pattern string) {
-	files, _ := ioutil.ReadDir(directory)
+	files, _ := os.ReadDir(directory)
 	for _, f := range files {
 		if ok, _ := filepath.Match(pattern, f.Name()); !f.IsDir() && ok {
 			fullPath := filepath.Join(directory, f.Name())
@@ -194,14 +193,14 @@ func InitPlugins() {
 
 	// Search ConfigDir for plugin-scripts
 	plugdir := filepath.Join(ConfigDir, "plug")
-	files, _ := ioutil.ReadDir(plugdir)
+	files, _ := os.ReadDir(plugdir)
 
 	isID := regexp.MustCompile(`^[_A-Za-z0-9]+$`).MatchString
 
 	for _, d := range files {
 		plugpath := filepath.Join(plugdir, d.Name())
 		if stat, err := os.Stat(plugpath); err == nil && stat.IsDir() {
-			srcs, _ := ioutil.ReadDir(plugpath)
+			srcs, _ := os.ReadDir(plugpath)
 			p := new(Plugin)
 			p.Name = d.Name()
 			p.DirName = d.Name()
@@ -209,7 +208,7 @@ func InitPlugins() {
 				if strings.HasSuffix(f.Name(), ".lua") {
 					p.Srcs = append(p.Srcs, realFile(filepath.Join(plugdir, d.Name(), f.Name())))
 				} else if strings.HasSuffix(f.Name(), ".json") {
-					data, err := ioutil.ReadFile(filepath.Join(plugdir, d.Name(), f.Name()))
+					data, err := os.ReadFile(filepath.Join(plugdir, d.Name(), f.Name()))
 					if err != nil {
 						continue
 					}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -356,7 +356,7 @@ func WriteSettings(filename string) error {
 		}
 
 		txt, _ := json.MarshalIndent(parsedSettings, "", "    ")
-		err = ioutil.WriteFile(filename, append(txt, '\n'), 0644)
+		err = ioutil.WriteFile(filename, append(txt, '\n'), util.FileMode)
 	}
 	return err
 }
@@ -378,7 +378,7 @@ func OverwriteSettings(filename string) error {
 		}
 
 		txt, _ := json.MarshalIndent(settings, "", "    ")
-		err = ioutil.WriteFile(filename, append(txt, '\n'), 0644)
+		err = ioutil.WriteFile(filename, append(txt, '\n'), util.FileMode)
 	}
 	return err
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -222,7 +221,7 @@ func ReadSettings() error {
 	parsedSettings = make(map[string]interface{})
 	filename := filepath.Join(ConfigDir, "settings.json")
 	if _, e := os.Stat(filename); e == nil {
-		input, err := ioutil.ReadFile(filename)
+		input, err := os.ReadFile(filename)
 		if err != nil {
 			settingsParseError = true
 			return errors.New("Error reading settings.json file: " + err.Error())
@@ -356,7 +355,7 @@ func WriteSettings(filename string) error {
 		}
 
 		txt, _ := json.MarshalIndent(parsedSettings, "", "    ")
-		err = ioutil.WriteFile(filename, append(txt, '\n'), util.FileMode)
+		err = os.WriteFile(filename, append(txt, '\n'), util.FileMode)
 	}
 	return err
 }
@@ -378,7 +377,7 @@ func OverwriteSettings(filename string) error {
 		}
 
 		txt, _ := json.MarshalIndent(settings, "", "    ")
-		err = ioutil.WriteFile(filename, append(txt, '\n'), util.FileMode)
+		err = os.WriteFile(filename, append(txt, '\n'), util.FileMode)
 	}
 	return err
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -155,6 +155,10 @@ var (
 	VolatileSettings map[string]bool
 )
 
+func writeFile(name string, txt []byte) error {
+	return util.SafeWrite(name, txt, false)
+}
+
 func init() {
 	ModifiedSettings = make(map[string]bool)
 	VolatileSettings = make(map[string]bool)
@@ -355,7 +359,8 @@ func WriteSettings(filename string) error {
 		}
 
 		txt, _ := json.MarshalIndent(parsedSettings, "", "    ")
-		err = os.WriteFile(filename, append(txt, '\n'), util.FileMode)
+		txt = append(txt, '\n')
+		err = writeFile(filename, txt)
 	}
 	return err
 }
@@ -376,8 +381,9 @@ func OverwriteSettings(filename string) error {
 			}
 		}
 
-		txt, _ := json.MarshalIndent(settings, "", "    ")
-		err = os.WriteFile(filename, append(txt, '\n'), util.FileMode)
+		txt, _ := json.MarshalIndent(parsedSettings, "", "    ")
+		txt = append(txt, '\n')
+		err = writeFile(filename, txt)
 	}
 	return err
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -46,6 +46,9 @@ var (
 	Sigterm chan os.Signal
 )
 
+// To be used for file writes before umask is applied
+const FileMode os.FileMode = 0666
+
 func init() {
 	var err error
 	SemVersion, err = semver.Make(Version)

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -412,6 +412,10 @@ func GetModTime(path string) (time.Time, error) {
 	return info.ModTime(), nil
 }
 
+func AppendBackupSuffix(path string) string {
+	return path + ".micro-backup"
+}
+
 // EscapePathUrl encodes the path in URL query form
 func EscapePathUrl(path string) string {
 	return url.QueryEscape(filepath.ToSlash(path))

--- a/runtime/syntax/make_headers.go
+++ b/runtime/syntax/make_headers.go
@@ -6,7 +6,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -34,7 +33,7 @@ func main() {
 	if len(os.Args) > 1 {
 		os.Chdir(os.Args[1])
 	}
-	files, _ := ioutil.ReadDir(".")
+	files, _ := os.ReadDir(".")
 	for _, f := range files {
 		fname := f.Name()
 		if strings.HasSuffix(fname, ".yaml") {
@@ -46,7 +45,7 @@ func main() {
 func convert(name string) {
 	filename := name + ".yaml"
 	var hdr HeaderYaml
-	source, err := ioutil.ReadFile(filename)
+	source, err := os.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}
@@ -68,7 +67,7 @@ func encode(name string, c HeaderYaml) {
 
 func decode(name string) Header {
 	start := time.Now()
-	data, _ := ioutil.ReadFile(name + ".hdr")
+	data, _ := os.ReadFile(name + ".hdr")
 	strs := bytes.Split(data, []byte{'\n'})
 	var hdr Header
 	hdr.FileType = string(strs[0])

--- a/runtime/syntax/syntax_converter.go
+++ b/runtime/syntax/syntax_converter.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -161,6 +160,6 @@ func main() {
 		return
 	}
 
-	data, _ := ioutil.ReadFile(os.Args[1])
+	data, _ := os.ReadFile(os.Args[1])
 	fmt.Print(generateFile(parseFile(string(data), os.Args[1])))
 }

--- a/tools/info-plist.go
+++ b/tools/info-plist.go
@@ -37,7 +37,7 @@ func main() {
 	</plist>
 	`
 
-	err := os.WriteFile("/tmp/micro-info.plist", []byte(rawInfoPlist), 0644)
+	err := os.WriteFile("/tmp/micro-info.plist", []byte(rawInfoPlist), 0666)
 	if err != nil {
 		panic(err)
 	}

--- a/tools/remove-nightly-assets.go
+++ b/tools/remove-nightly-assets.go
@@ -4,7 +4,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os/exec"
 	"strings"
@@ -19,7 +19,7 @@ func main() {
 		return
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	var data interface{}
 

--- a/tools/testgen.go
+++ b/tools/testgen.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"regexp"
@@ -210,7 +209,7 @@ func main() {
 	var tests []test
 
 	for _, filename := range os.Args[1:] {
-		source, err := ioutil.ReadFile(filename)
+		source, err := os.ReadFile(filename)
 		if err != nil {
 			log.Fatalln(err)
 		}


### PR DESCRIPTION
The target situation shall be, that `micro` checks if the file to be stored already exists and if so it shall work with a temporary file first, before the target file is overwritten respective the temporary file renamed to the target file.
Possible symlinks pointing to the target file will be resolved, before the save takes place. This shall guarantee that this symlink isn't renamed by the new approach.

TODOs:

- [x] Properly handle all of the irregular file types and character devices etc.pp.
- [x] Simplify the chosen `overwriteFile()` interface (see: https://github.com/zyedidia/micro/pull/3273#discussion_r1599061478)
- [x] `util.EscapePath(b.AbsPath)` does not uniquely encode the file path (see: https://github.com/zyedidia/micro/pull/3273/files#r1599137940)
- [x] `b.Backup()` executed asynchronously (from `backupThread`) is accessing the line array without locking.  (see: https://github.com/zyedidia/micro/pull/3273/files#r1599137940)
- [x] Decouple the backup step from the target file write (see: https://github.com/zyedidia/micro/pull/3273/files#r1600795305)
- [x] Remove broken backup (see: https://github.com/zyedidia/micro/pull/3273/files#r1599076040)
- [x] Rework save & backup trigger (see: https://github.com/zyedidia/micro/pull/3273#discussion_r1749177778)

Fixes #1916
Fixes #3148
Fixes #3196