### PR TITLE
Diffgutter: simplify + fix race

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1480,9 +1480,7 @@ func (h *BufPane) HalfPageDown() bool {
 func (h *BufPane) ToggleDiffGutter() bool {
 	if !h.Buf.Settings["diffgutter"].(bool) {
 		h.Buf.Settings["diffgutter"] = true
-		h.Buf.UpdateDiff(func(synchronous bool) {
-			screen.Redraw()
-		})
+		h.Buf.UpdateDiff()
 		InfoBar.Message("Enabled diff gutter")
 	} else {
 		h.Buf.Settings["diffgutter"] = false

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -1320,13 +1320,9 @@ func (b *Buffer) updateDiffSync() {
 
 // UpdateDiff computes the diff between the diff base and the buffer content.
 // The update may be performed synchronously or asynchronously.
-// UpdateDiff calls the supplied callback when the update is complete.
-// The argument passed to the callback is set to true if and only if
-// the update was performed synchronously.
 // If an asynchronous update is already pending when UpdateDiff is called,
-// UpdateDiff does not schedule another update, in which case the callback
-// is not called.
-func (b *Buffer) UpdateDiff(callback func(bool)) {
+// UpdateDiff does not schedule another update.
+func (b *Buffer) UpdateDiff() {
 	if b.updateDiffTimer != nil {
 		return
 	}
@@ -1338,19 +1334,17 @@ func (b *Buffer) UpdateDiff(callback func(bool)) {
 
 	if lineCount < 1000 {
 		b.updateDiffSync()
-		callback(true)
 	} else if lineCount < 30000 {
 		b.updateDiffTimer = time.AfterFunc(500*time.Millisecond, func() {
 			b.updateDiffTimer = nil
 			b.updateDiffSync()
-			callback(false)
+			screen.Redraw()
 		})
 	} else {
 		// Don't compute diffs for very large files
 		b.diffLock.Lock()
 		b.diff = make(map[int]DiffStatus)
 		b.diffLock.Unlock()
-		callback(true)
 	}
 }
 
@@ -1362,9 +1356,7 @@ func (b *Buffer) SetDiffBase(diffBase []byte) {
 	} else {
 		b.diffBaseLineCount = strings.Count(string(diffBase), "\n")
 	}
-	b.UpdateDiff(func(synchronous bool) {
-		screen.Redraw()
-	})
+	b.UpdateDiff()
 }
 
 // DiffStatus returns the diff status for a line in the buffer

--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -384,18 +384,7 @@ func (w *BufWindow) displayBuffer() {
 
 	if b.ModifiedThisFrame {
 		if b.Settings["diffgutter"].(bool) {
-			b.UpdateDiff(func(synchronous bool) {
-				// If the diff was updated asynchronously, the outer call to
-				// displayBuffer might already be completed and we need to
-				// schedule a redraw in order to display the new diff.
-				// Note that this cannot lead to an infinite recursion
-				// because the modifications were cleared above so there won't
-				// be another call to UpdateDiff when displayBuffer is called
-				// during the redraw.
-				if !synchronous {
-					screen.Redraw()
-				}
-			})
+			b.UpdateDiff()
 		}
 		b.ModifiedThisFrame = false
 	}


### PR DESCRIPTION
- Simplify `UpdateDiff()` interface: remove unneeded callback (since `UpdateDiff()` can simply call `screen.Redraw()` directly in the async case, and doesn't need to call it at all in the sync case).
- Add linearray locking in async diff update, to fix potential race when the buffer is modified in the meantime (just like in other similar cases fixed recently in https://github.com/zyedidia/micro/pull/3224).