### PR TITLE
Fixing escape key getting filtered on Windows

### DIFF
--- a/cmd/micro/micro_test.go
+++ b/cmd/micro/micro_test.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"testing"
+	"runtime"
 
 	"github.com/go-errors/errors"
 	"github.com/stretchr/testify/assert"
@@ -333,7 +334,12 @@ func TestSearchAndReplace(t *testing.T) {
 	injectString(fmt.Sprintf("replace %s %s", "string", "foo"))
 	injectKey(tcell.KeyEnter, rune(tcell.KeyEnter), tcell.ModNone)
 	injectString("ynyny")
-	injectKey(tcell.KeyEscape, 0, tcell.ModNone)
+
+	if runtime.GOOS == "windows" {
+		injectKey(tcell.KeyRune, 27, tcell.ModNone)
+	} else {
+		injectKey(tcell.KeyEscape, 0, tcell.ModNone)
+	}
 
 	injectKey(tcell.KeyCtrlS, rune(tcell.KeyCtrlS), tcell.ModCtrl)
 

--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 	"strings"
 	"unicode"
+	"runtime"
 
 	"github.com/zyedidia/json5"
 	"github.com/zyedidia/micro/v2/internal/config"
@@ -177,8 +178,8 @@ modSearch:
 		k = string(unicode.ToUpper(rune(k[0]))) + k[1:]
 		if code, ok := keyEvents["Ctrl"+k]; ok {
 			var r tcell.Key
-			// Special case for escape, for some reason tcell doesn't send it with the esc character
-			if code < 256 && code != 27 {
+			// Special case for escape for unix, for some reason tcell doesn't send it with the esc character
+			if code < 256 && (runtime.GOOS == "windows" || code != 27) {
 				r = code
 			}
 			// It is, we're done.
@@ -193,8 +194,8 @@ modSearch:
 	// See if we can find the key in bindingKeys
 	if code, ok := keyEvents[k]; ok {
 		var r tcell.Key
-		// Special case for escape, for some reason tcell doesn't send it with the esc character
-		if code < 256 && code != 27 {
+		// Special case for escape for unix, for some reason tcell doesn't send it with the esc character
+		if code < 256 && (runtime.GOOS == "windows" || code != 27) {
 			r = code
 		}
 		return KeyEvent{


### PR DESCRIPTION
This should fix #2947

I will put a comment once I have tested this on a Windows and Linux machine.
