### PR TITLE
Reordered prompt done callback to avoid accessing out of bound history

### DIFF
--- a/internal/info/infobuffer.go
+++ b/internal/info/infobuffer.go
@@ -159,6 +159,7 @@ func (i *InfoBuf) DonePrompt(canceled bool) {
 						break
 					}
 				}
+
 				i.PromptCallback(resp, false)
 			}
 			// i.PromptCallback = nil

--- a/internal/info/infobuffer.go
+++ b/internal/info/infobuffer.go
@@ -143,13 +143,12 @@ func (i *InfoBuf) DonePrompt(canceled bool) {
 		if i.PromptCallback != nil {
 			if canceled {
 				i.Replace(i.Start(), i.End(), "")
-				i.PromptCallback("", true)
 				h := i.History[i.PromptType]
 				i.History[i.PromptType] = h[:len(h)-1]
+				i.PromptCallback("", true)
 			} else {
 				resp := string(i.LineBytes(0))
 				i.Replace(i.Start(), i.End(), "")
-				i.PromptCallback(resp, false)
 				h := i.History[i.PromptType]
 				h[len(h)-1] = resp
 
@@ -160,6 +159,7 @@ func (i *InfoBuf) DonePrompt(canceled bool) {
 						break
 					}
 				}
+				i.PromptCallback(resp, false)
 			}
 			// i.PromptCallback = nil
 		}


### PR DESCRIPTION
According to https://pkg.go.dev/github.com/zyedidia/micro/v2@v2.0.13/internal/info#InfoBuf.Prompt
A lua script can provide a done callback when the prompt has finished (enter is pressed).

This works fine until the done callback itself wants to have another prompt, for example multiple questions to configure an action.

The behavior in main right now will crash with 
```text
Micro encountered an error: runtime.boundsError runtime error: index out of range [22] with length 22
runtime/panic.go:114 (0x43c59c)
github.com/zyedidia/micro/v2/internal/action/infopane.go:115 (0x8d658f)
github.com/zyedidia/micro/v2/cmd/micro/micro.go:478 (0x90e0a6)
github.com/zyedidia/micro/v2/cmd/micro/micro.go:397 (0x90d9af)
runtime/internal/atomic/types.go:194 (0x44111d)
runtime/asm_amd64.s:1695 (0x4754e1)

If you can reproduce this error, please report it at https://github.com/zyedidia/micro/issues
```

So if I have something like this
```lua
micro.InfoBar():Prompt("Question 1 > ", "", "", nil, OnQuestion1Done)

local Answer1 = ""

function OnQuestion1Done(resp, cancelled)
    if cancelled then return end
    Answer1 = resp
    micro.InfoBar():Prompt("Question 2 > ", "", "", nil, OnQuestion2Done)
end


function OnQuestion2Done(resp, cancelled)
    if cancelled then return end
    -- Do something with Answer1 and resp...
end
```

It won't work and crash inside the 2nd prompt.

This is due to the 2nd call in the prompt trying to access history while the first prompt has not finished modifying the history.
See 
https://github.com/zyedidia/micro/blob/e9bd1b35f4ee62352a361fdec94684accd6f4874/internal/info/infobuffer.go#L97-L109

and https://github.com/zyedidia/micro/blob/e9bd1b35f4ee62352a361fdec94684accd6f4874/internal/info/infobuffer.go#L150-L154
where line 152 is calling the done callback and we are still modifying the history for the current prompt on line 153+


The proposed solution just needs to reorder the done callback to the end of the block where we have finished modifying the history so that the next prompt call can safely modify it.
