### PR TITLE
Improve `FindMatchingBrace()` interface and implementation

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1394,21 +1394,15 @@ func (h *BufPane) paste(clip string) {
 // JumpToMatchingBrace moves the cursor to the matching brace if it is
 // currently on a brace
 func (h *BufPane) JumpToMatchingBrace() bool {
-	for _, bp := range buffer.BracePairs {
-		r := h.Cursor.RuneUnder(h.Cursor.X)
-		rl := h.Cursor.RuneUnder(h.Cursor.X - 1)
-		if r == bp[0] || r == bp[1] || rl == bp[0] || rl == bp[1] {
-			matchingBrace, left, found := h.Buf.FindMatchingBrace(bp, h.Cursor.Loc)
-			if found {
-				if left {
-					h.Cursor.GotoLoc(matchingBrace)
-				} else {
-					h.Cursor.GotoLoc(matchingBrace.Move(1, h.Buf))
-				}
-				h.Relocate()
-				return true
-			}
+	matchingBrace, left, found := h.Buf.FindMatchingBrace(h.Cursor.Loc)
+	if found {
+		if left {
+			h.Cursor.GotoLoc(matchingBrace)
+		} else {
+			h.Cursor.GotoLoc(matchingBrace.Move(1, h.Buf))
 		}
+		h.Relocate()
+		return true
 	}
 	return false
 }

--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -392,28 +392,20 @@ func (w *BufWindow) displayBuffer() {
 	var matchingBraces []buffer.Loc
 	// bracePairs is defined in buffer.go
 	if b.Settings["matchbrace"].(bool) {
-		for _, bp := range buffer.BracePairs {
-			for _, c := range b.GetCursors() {
-				if c.HasSelection() {
-					continue
-				}
-				curX := c.X
-				curLoc := c.Loc
+		for _, c := range b.GetCursors() {
+			if c.HasSelection() {
+				continue
+			}
 
-				r := c.RuneUnder(curX)
-				rl := c.RuneUnder(curX - 1)
-				if r == bp[0] || r == bp[1] || rl == bp[0] || rl == bp[1] {
-					mb, left, found := b.FindMatchingBrace(bp, curLoc)
-					if found {
-						matchingBraces = append(matchingBraces, mb)
-						if !left {
-							if b.Settings["matchbracestyle"].(string) != "highlight" {
-								matchingBraces = append(matchingBraces, curLoc)
-							}
-						} else {
-							matchingBraces = append(matchingBraces, curLoc.Move(-1, b))
-						}
+			mb, left, found := b.FindMatchingBrace(c.Loc)
+			if found {
+				matchingBraces = append(matchingBraces, mb)
+				if !left {
+					if b.Settings["matchbracestyle"].(string) != "highlight" {
+						matchingBraces = append(matchingBraces, c.Loc)
 					}
+				} else {
+					matchingBraces = append(matchingBraces, c.Loc.Move(-1, b))
 				}
 			}
 		}


### PR DESCRIPTION
Rework `FindMatchingBrace()` interface and implementation: instead of passing a single brace pair to `FindMatchingBrace()`, make it traverse all brace pairs in `buffer.BracePairs` on its own.

This has the following advantages:

1. Makes `FindMatchingBrace()` easier to use, in particular much easier to use from Lua. See #3308)

2. Lets `FindMatchingBrace()` ensure that we use just one matching brace - the higher-priority one. This fixes the following issues (first found in https://github.com/zyedidia/micro/pull/2876#issuecomment-1821792035):

```
    ([foo]bar)
     ^
```

when the cursor is on `[`:

- Both `[]` and `()` pairs are highlighted, whereas the expected behavior is that only one pair is highlighted - the one that has higher priority, i.e. the one the `JumpToMatchingBrace` action would jump to.

- `JumpToMatchingBrace` incorrectly jumps to `)` instead of `]` (which should take higher priority in this case).

In contrast, with `((foo)bar)` it works correctly.