### PR TITLE
Update Zig syntax to handle ZON (Zig Object Notation) files.

### DIFF
--- a/runtime/syntax/zig.yaml
+++ b/runtime/syntax/zig.yaml
@@ -1,7 +1,7 @@
 filetype: zig
 
 detect:
-    filename: "\\.zig$"
+    filename: "\\.z(ig|on)$"
 
 rules:
       # Reserved words


### PR DESCRIPTION
Technically ZON is a subset of Zig, but this at least gets syntax highlighting working. Future work here would be to factor this out into a separate grammar.