### PR TITLE
Implemented `ResetSearch` and allow action chaining of `FindNext` and `FindPrevious`

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1072,6 +1072,15 @@ func (h *BufPane) UnhighlightSearch() bool {
 	return true
 }
 
+// ResetSearch resets the last used search term
+func (h *BufPane) ResetSearch() bool {
+	if h.Buf.LastSearch != "" {
+		h.Buf.LastSearch = ""
+		return true
+	}
+	return false
+}
+
 // FindNext searches forwards for the last used search term
 func (h *BufPane) FindNext() bool {
 	if h.Buf.LastSearch == "" {

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1074,6 +1074,9 @@ func (h *BufPane) UnhighlightSearch() bool {
 
 // FindNext searches forwards for the last used search term
 func (h *BufPane) FindNext() bool {
+	if h.Buf.LastSearch == "" {
+		return false
+	}
 	// If the cursor is at the start of a selection and we search we want
 	// to search from the end of the selection in the case that
 	// the selection is a search result in which case we wouldn't move at
@@ -1100,6 +1103,9 @@ func (h *BufPane) FindNext() bool {
 
 // FindPrevious searches backwards for the last used search term
 func (h *BufPane) FindPrevious() bool {
+	if h.Buf.LastSearch == "" {
+		return false
+	}
 	// If the cursor is at the end of a selection and we search we want
 	// to search from the beginning of the selection in the case that
 	// the selection is a search result in which case we wouldn't move at

--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -815,6 +815,7 @@ var BufKeyActions = map[string]BufKeyAction{
 	"ToggleRuler":               (*BufPane).ToggleRuler,
 	"ToggleHighlightSearch":     (*BufPane).ToggleHighlightSearch,
 	"UnhighlightSearch":         (*BufPane).UnhighlightSearch,
+	"ResetSearch":               (*BufPane).ResetSearch,
 	"ClearStatus":               (*BufPane).ClearStatus,
 	"ShellMode":                 (*BufPane).ShellMode,
 	"CommandMode":               (*BufPane).CommandMode,

--- a/runtime/help/keybindings.md
+++ b/runtime/help/keybindings.md
@@ -241,6 +241,7 @@ ToggleHelp
 ToggleDiffGutter
 ToggleRuler
 JumpLine
+ResetSearch
 ClearStatus
 ShellMode
 CommandMode


### PR DESCRIPTION

This is a small feature to reset previously initiated searches and to use `FindNext` and `FindPrevious` in chained actions.

Personally I never could get used to use different shortcuts for initiating and continuing a search. (First `Ctrl-f`, then `Ctrl-n` or `Ctrl-p`)

Assuming that the option `hlsearch` is set to `false`, my preferred workflow is:

- Initiation of a search:
	- `Ctrl-f` (to open the search query box in the command bar)
	- Enter the search term
	- Press `Enter` to start the search
	Expectation: The first occurrence of the search term is being highlighted

- Continuation of a previously initiated search:
	- Just press `Enter` to continue the search
	Expectation: The next occurrence of the search term is being highlighted.
	You can repeat this step as often as you like. Each `Enter` highlights the next occurrence.

- Exit the search operation when you found what you are looking for
	- Press `Esc` to exit
	Expectation: The search term found is still highlighted and you can continue with normal text editing.

To achieve this chaining actions seems like the way to go. Like:
```
"Ctrl-f": "Find",
"Enter": "FindNext|InsertNewline",
```
But this didn't work, since [`BufPane.FindNext()`](https://github.com/zyedidia/micro/blob/9eb8782ff2ce4b2bab358317bcaeb6ea11efb56c/internal/action/actions.go#L1076) and [`BufPane.FindPrevious()`](https://github.com/zyedidia/micro/blob/9eb8782ff2ce4b2bab358317bcaeb6ea11efb56c/internal/action/actions.go#L1102) always return `true`, which prevents all subsequent actions from being executed.
I'm not sure if this is intentional for some reason. It seems more likely that this case was omitted or forgotten because it generally excludes the possibility of chaining actions.
[`Buffer.FindNext()`](https://github.com/zyedidia/micro/blob/9eb8782ff2ce4b2bab358317bcaeb6ea11efb56c/internal/buffer/search.go#L110) handles the case of a search term being empty. But it would also [reset the selection](https://github.com/zyedidia/micro/blob/9eb8782ff2ce4b2bab358317bcaeb6ea11efb56c/internal/action/actions.go#L1096) when adding a `return false` there.
So adding a guard clause at the top of the function may be the best solution and should not break any potential user bindings out there.

The missing piece left was to add `ResetSearch()` which allows to exit a previously initiated search. Like:
```
"Esc": "ResetSearch|RemoveAllMultiCursors|Escape",
```

Just as a bonus:
The following snippet adds a visual representation for being in search mode to the status line, which is IMHO quite nice.

```lua

micro.SetStatusInfoFn("initlua.tabSearch")

function tabSearch(buf)
    if buf.LastSearch == '' then
        return ''
    end
    return string.format(' [search=%s]', buf.LastSearch)
end
```
