### PR TITLE
Fix usage of tcell's `Rune()`

### DIFF
--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -176,31 +176,18 @@ modSearch:
 		// see if the key is in bindingKeys with the Ctrl prefix.
 		k = string(unicode.ToUpper(rune(k[0]))) + k[1:]
 		if code, ok := keyEvents["Ctrl"+k]; ok {
-			var r tcell.Key
-			// Special case for escape, for some reason tcell doesn't send it with the esc character
-			if code < 256 && code != 27 {
-				r = code
-			}
-			// It is, we're done.
 			return KeyEvent{
 				code: code,
 				mod:  modifiers,
-				r:    rune(r),
 			}, true
 		}
 	}
 
 	// See if we can find the key in bindingKeys
 	if code, ok := keyEvents[k]; ok {
-		var r tcell.Key
-		// Special case for escape, for some reason tcell doesn't send it with the esc character
-		if code < 256 && code != 27 {
-			r = code
-		}
 		return KeyEvent{
 			code: code,
 			mod:  modifiers,
-			r:    rune(r),
 		}, true
 	}
 

--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -469,13 +469,7 @@ func (h *BufPane) HandleEvent(event tcell.Event) {
 		h.paste(e.Text())
 		h.Relocate()
 	case *tcell.EventKey:
-		ke := KeyEvent{
-			code: e.Key(),
-			mod:  metaToAlt(e.Modifiers()),
-		}
-		if e.Key() == tcell.KeyRune {
-			ke.r = e.Rune()
-		}
+		ke := keyEvent(e)
 
 		done := h.DoKeyEvent(ke)
 		if !done && e.Key() == tcell.KeyRune {

--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -472,7 +472,9 @@ func (h *BufPane) HandleEvent(event tcell.Event) {
 		ke := KeyEvent{
 			code: e.Key(),
 			mod:  metaToAlt(e.Modifiers()),
-			r:    e.Rune(),
+		}
+		if e.Key() == tcell.KeyRune {
+			ke.r = e.Rune()
 		}
 
 		done := h.DoKeyEvent(ke)

--- a/internal/action/events.go
+++ b/internal/action/events.go
@@ -44,6 +44,17 @@ func metaToAlt(mod tcell.ModMask) tcell.ModMask {
 	return mod
 }
 
+func keyEvent(e *tcell.EventKey) KeyEvent {
+	ke := KeyEvent{
+		code: e.Key(),
+		mod:  metaToAlt(e.Modifiers()),
+	}
+	if e.Key() == tcell.KeyRune {
+		ke.r = e.Rune()
+	}
+	return ke
+}
+
 func (k KeyEvent) Name() string {
 	if k.any {
 		return "<any>"
@@ -155,14 +166,7 @@ func (m MouseEvent) Name() string {
 func ConstructEvent(event tcell.Event) (Event, error) {
 	switch e := event.(type) {
 	case *tcell.EventKey:
-		ke := KeyEvent{
-			code: e.Key(),
-			mod:  metaToAlt(e.Modifiers()),
-		}
-		if e.Key() == tcell.KeyRune {
-			ke.r = e.Rune()
-		}
-		return ke, nil
+		return keyEvent(e), nil
 	case *tcell.EventRaw:
 		return RawEvent{
 			esc: e.EscSeq(),

--- a/internal/action/events.go
+++ b/internal/action/events.go
@@ -68,7 +68,7 @@ func (k KeyEvent) Name() string {
 		if k.code == tcell.KeyRune {
 			s = string(k.r)
 		} else {
-			s = fmt.Sprintf("Key[%d,%d]", k.code, int(k.r))
+			s = fmt.Sprintf("Key[%d]", k.code)
 		}
 	}
 	if len(m) != 0 {
@@ -155,11 +155,14 @@ func (m MouseEvent) Name() string {
 func ConstructEvent(event tcell.Event) (Event, error) {
 	switch e := event.(type) {
 	case *tcell.EventKey:
-		return KeyEvent{
+		ke := KeyEvent{
 			code: e.Key(),
 			mod:  metaToAlt(e.Modifiers()),
-			r:    e.Rune(),
-		}, nil
+		}
+		if e.Key() == tcell.KeyRune {
+			ke.r = e.Rune()
+		}
+		return ke, nil
 	case *tcell.EventRaw:
 		return RawEvent{
 			esc: e.EscSeq(),

--- a/internal/action/infopane.go
+++ b/internal/action/infopane.go
@@ -89,7 +89,9 @@ func (h *InfoPane) HandleEvent(event tcell.Event) {
 		ke := KeyEvent{
 			code: e.Key(),
 			mod:  metaToAlt(e.Modifiers()),
-			r:    e.Rune(),
+		}
+		if e.Key() == tcell.KeyRune {
+			ke.r = e.Rune()
 		}
 
 		done := h.DoKeyEvent(ke)

--- a/internal/action/infopane.go
+++ b/internal/action/infopane.go
@@ -86,13 +86,7 @@ func (h *InfoPane) HandleEvent(event tcell.Event) {
 	case *tcell.EventResize:
 		// TODO
 	case *tcell.EventKey:
-		ke := KeyEvent{
-			code: e.Key(),
-			mod:  metaToAlt(e.Modifiers()),
-		}
-		if e.Key() == tcell.KeyRune {
-			ke.r = e.Rune()
-		}
+		ke := keyEvent(e)
 
 		done := h.DoKeyEvent(ke)
 		hasYN := h.HasYN

--- a/internal/action/termpane.go
+++ b/internal/action/termpane.go
@@ -128,7 +128,9 @@ func (t *TermPane) HandleEvent(event tcell.Event) {
 		ke := KeyEvent{
 			code: e.Key(),
 			mod:  metaToAlt(e.Modifiers()),
-			r:    e.Rune(),
+		}
+		if e.Key() == tcell.KeyRune {
+			ke.r = e.Rune()
 		}
 		action, more := TermBindings.NextEvent(ke, nil)
 

--- a/internal/action/termpane.go
+++ b/internal/action/termpane.go
@@ -125,13 +125,7 @@ func (t *TermPane) Unsplit() {
 // copy-paste
 func (t *TermPane) HandleEvent(event tcell.Event) {
 	if e, ok := event.(*tcell.EventKey); ok {
-		ke := KeyEvent{
-			code: e.Key(),
-			mod:  metaToAlt(e.Modifiers()),
-		}
-		if e.Key() == tcell.KeyRune {
-			ke.r = e.Rune()
-		}
+		ke := keyEvent(e)
 		action, more := TermBindings.NextEvent(ke, nil)
 
 		if !more {


### PR DESCRIPTION
According to [tcell documentation](https://pkg.go.dev/github.com/gdamore/tcell#EventKey.Rune
), `Rune()` should only be used for `KeyRune` events. Otherwise its return value is not guaranteed and should not be relied upon.

This fixes issue #2947: `Esc` key not working on Windows, since tcell sends lone `Esc` key event with rune == 0 on Unix but with rune == 27 (the keycode) on Windows.

This also allows us to remove the hack in `findSingleEvent()` treating `Esc` as a special case.

Fixes #2947