### PR TITLE
Update README.md to add brew install on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,9 @@ for other operating systems. These packages are not guaranteed to be up-to-date.
     * `pkd_add -v micro`.
 * NetBSD, macOS, Linux, Illumos, etc. with [pkgsrc](http://www.pkgsrc.org/)-current:
     * `pkg_add micro`
-* macOS with [MacPorts](https://www.macports.org):
-    * `sudo port install micro`
+* macOS: Available in package managers. 
+    * `sudo port install micro` (with [MacPorts](https://www.macports.org))
+    * `brew install micro` (with [Homebrew](https://brew.sh/))
 
 **Note for Linux desktop environments:**
 


### PR DESCRIPTION
Add installation option for Homebrew on MacOS. Homebrew is a popular package manager on MacOS - likely more popular than MacPorts.