### PR TITLE
Update README.md to include nix install and flox install

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,9 @@ for other operating systems. These packages are not guaranteed to be up-to-date.
     * `eopkg install micro` (Solus).
     * `pacstall -I micro` (Pacstall).
     * See [wiki](https://github.com/zyedidia/micro/wiki/Installing-Micro) for details about CRUX, Termux.
+* Linux: Available in distro-agnostic package managers.
+    * `nix profile install nixpkgs#micro` (with [Nix](https://nixos.org/) and flakes enabled)
+    * `flox install micro` (with [Flox](https://flox.dev))
 * Windows: [Chocolatey](https://chocolatey.org) and [Scoop](https://github.com/lukesampson/scoop).
     * `choco install micro`.
     * `scoop install micro`.
@@ -154,9 +157,11 @@ for other operating systems. These packages are not guaranteed to be up-to-date.
     * `pkd_add -v micro`.
 * NetBSD, macOS, Linux, Illumos, etc. with [pkgsrc](http://www.pkgsrc.org/)-current:
     * `pkg_add micro`
-* macOS: Available in package managers. 
+* macOS: Available in package managers.
     * `sudo port install micro` (with [MacPorts](https://www.macports.org))
     * `brew install micro` (with [Homebrew](https://brew.sh/))
+    * `nix profile install nixpkgs#micro` (with [Nix](https://nixos.org/) and flakes enabled)
+    * `flox install micro` (with [Flox](https://flox.dev))
 
 **Note for Linux desktop environments:**
 

--- a/README.md
+++ b/README.md
@@ -138,18 +138,19 @@ for other operating systems. These packages are not guaranteed to be up-to-date.
 
 <!-- * `apt install micro` (Ubuntu 20.04 `focal`, and Debian `unstable | testing | buster-backports`). At the moment, this package (2.0.1-1) is outdated and has a known bug where debug mode is enabled. -->
 
-* Linux: Available in distro-specific package managers.
-    * `dnf install micro` (Fedora).
-    * `apt install micro` (Ubuntu and Debian).
-    * `pacman -S micro` (Arch Linux).
-    * `emerge app-editors/micro` (Gentoo).
-    * `zypper install micro-editor` (SUSE)
-    * `eopkg install micro` (Solus).
-    * `pacstall -I micro` (Pacstall).
-    * See [wiki](https://github.com/zyedidia/micro/wiki/Installing-Micro) for details about CRUX, Termux.
-* Linux: Available in distro-agnostic package managers.
-    * `nix profile install nixpkgs#micro` (with [Nix](https://nixos.org/) and flakes enabled)
-    * `flox install micro` (with [Flox](https://flox.dev))
+* Linux:
+    * distro-specific package managers:
+        * `dnf install micro` (Fedora).
+        * `apt install micro` (Ubuntu and Debian).
+        * `pacman -S micro` (Arch Linux).
+        * `emerge app-editors/micro` (Gentoo).
+        * `zypper install micro-editor` (SUSE)
+        * `eopkg install micro` (Solus).
+        * `pacstall -I micro` (Pacstall).
+        * See [wiki](https://github.com/zyedidia/micro/wiki/Installing-Micro) for details about CRUX, Termux.
+    * distro-agnostic package managers:
+        * `nix profile install nixpkgs#micro` (with [Nix](https://nixos.org/) and flakes enabled)
+        * `flox install micro` (with [Flox](https://flox.dev))
 * Windows: [Chocolatey](https://chocolatey.org) and [Scoop](https://github.com/lukesampson/scoop).
     * `choco install micro`.
     * `scoop install micro`.


### PR DESCRIPTION
`micro` is available in Nix and Flox, and seems to be working today!
Since Flox and Nix are related, I added links for both Nix and Flox.
If you have any questions about Nix and/or Flox, please let me know. 😊