### PR TITLE
Fix highlighting of `load` and `reference` directives in Cake syntax.

### DIFF
--- a/runtime/syntax/cake.yaml
+++ b/runtime/syntax/cake.yaml
@@ -4,4 +4,4 @@ detect:
 
 rules:
     - include: "csharp"
-    - preproc: "^[[:space:]]*#(addin|break|l|load|module|r|reference|tool)"
+    - preproc: "^[[:space:]]*#(addin|break|l(oad)?|module|r(eference)?|tool)"


### PR DESCRIPTION
Correct a couple of mistakes in #3125.