### PR TITLE
Rework `filetype` change, `reload` command and `autosave`

### DIFF
--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -356,9 +356,9 @@ func main() {
 		log.Println(clipErr, " or change 'clipboard' option")
 	}
 
+	config.StartAutoSave()
 	if a := config.GetGlobalOption("autosave").(float64); a > 0 {
 		config.SetAutoTime(a)
-		config.StartAutoSave()
 	}
 
 	screen.Events = make(chan tcell.Event)

--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -273,6 +273,10 @@ func main() {
 				screen.TermMessage(err)
 				continue
 			}
+			if err = config.OptionIsValid(k, nativeValue); err != nil {
+				screen.TermMessage(err)
+				continue
+			}
 			config.GlobalSettings[k] = nativeValue
 			config.VolatileSettings[k] = true
 		}

--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -357,7 +357,7 @@ func main() {
 	}
 
 	if a := config.GetGlobalOption("autosave").(float64); a > 0 {
-		config.SetAutoTime(int(a))
+		config.SetAutoTime(a)
 		config.StartAutoSave()
 	}
 

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -552,7 +552,7 @@ func doSetGlobalOptionNative(option string, nativeValue interface{}) error {
 		}
 	} else if option == "autosave" {
 		if nativeValue.(float64) > 0 {
-			config.SetAutoTime(int(nativeValue.(float64)))
+			config.SetAutoTime(nativeValue.(float64))
 			config.StartAutoSave()
 		} else {
 			config.SetAutoTime(0)

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -410,6 +410,10 @@ func reloadRuntime(reloadPlugins bool) {
 	for _, b := range buffer.OpenBuffers {
 		config.InitLocalSettings(b.Settings, b.Path)
 		for k, v := range b.Settings {
+			if _, ok := b.LocalSettings[k]; ok {
+				// reload should not override local settings
+				continue
+			}
 			b.DoSetOptionNative(k, v)
 		}
 		b.UpdateRules()

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -410,7 +410,7 @@ func reloadRuntime(reloadPlugins bool) {
 	for _, b := range buffer.OpenBuffers {
 		config.InitLocalSettings(b.Settings, b.Path)
 		for k, v := range b.Settings {
-			b.SetOptionNative(k, v)
+			b.DoSetOptionNative(k, v)
 		}
 		b.UpdateRules()
 	}
@@ -610,9 +610,8 @@ func SetGlobalOptionNative(option string, nativeValue interface{}) error {
 
 	// ...at last check the buffer locals
 	for _, b := range buffer.OpenBuffers {
-		if err := b.SetOptionNative(option, nativeValue); err != nil {
-			return err
-		}
+		b.DoSetOptionNative(option, nativeValue)
+		delete(b.LocalSettings, option)
 	}
 
 	return config.WriteSettings(filepath.Join(config.ConfigDir, "settings.json"))

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -592,6 +592,10 @@ func doSetGlobalOptionNative(option string, nativeValue interface{}) error {
 }
 
 func SetGlobalOptionNative(option string, nativeValue interface{}) error {
+	if err := config.OptionIsValid(option, nativeValue); err != nil {
+		return err
+	}
+
 	// check for local option first...
 	for _, s := range config.LocalSettings {
 		if s == option {

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -553,7 +553,6 @@ func doSetGlobalOptionNative(option string, nativeValue interface{}) error {
 	} else if option == "autosave" {
 		if nativeValue.(float64) > 0 {
 			config.SetAutoTime(nativeValue.(float64))
-			config.StartAutoSave()
 		} else {
 			config.SetAutoTime(0)
 		}

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -634,16 +634,10 @@ func (h *BufPane) ResetCmd(args []string) {
 	}
 
 	option := args[0]
+	defaults := config.DefaultAllSettings()
 
-	defaultGlobals := config.DefaultGlobalSettings()
-	defaultLocals := config.DefaultCommonSettings()
-
-	if _, ok := defaultGlobals[option]; ok {
-		SetGlobalOptionNative(option, defaultGlobals[option])
-		return
-	}
-	if _, ok := defaultLocals[option]; ok {
-		h.Buf.SetOptionNative(option, defaultLocals[option])
+	if _, ok := defaults[option]; ok {
+		SetGlobalOptionNative(option, defaults[option])
 		return
 	}
 	InfoBar.Error(config.ErrInvalidOption)

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
@@ -531,6 +532,10 @@ func (h *BufPane) NewTabCmd(args []string) {
 }
 
 func doSetGlobalOptionNative(option string, nativeValue interface{}) error {
+	if reflect.DeepEqual(config.GlobalSettings[option], nativeValue) {
+		return nil
+	}
+
 	config.GlobalSettings[option] = nativeValue
 	config.ModifiedSettings[option] = true
 	delete(config.VolatileSettings, option)

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -361,6 +361,11 @@ func reloadRuntime(reloadPlugins bool) {
 		parsedSettings := config.ParsedSettings()
 		defaultSettings := config.DefaultAllSettings()
 		for k := range defaultSettings {
+			if _, ok := config.VolatileSettings[k]; ok {
+				// reload should not override volatile settings
+				continue
+			}
+
 			if _, ok := parsedSettings[k]; ok {
 				err = doSetGlobalOptionNative(k, parsedSettings[k])
 			} else {

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -357,10 +357,16 @@ func reloadRuntime(reloadPlugins bool) {
 	err := config.ReadSettings()
 	if err != nil {
 		screen.TermMessage(err)
-	}
-	err = config.InitGlobalSettings()
-	if err != nil {
-		screen.TermMessage(err)
+	} else {
+		parsedSettings := config.ParsedSettings()
+		defaultSettings := config.DefaultAllSettings()
+		for k := range defaultSettings {
+			if _, ok := parsedSettings[k]; ok {
+				SetGlobalOptionNative(k, parsedSettings[k])
+			} else {
+				SetGlobalOptionNative(k, defaultSettings[k])
+			}
+		}
 	}
 
 	if reloadPlugins {
@@ -393,6 +399,10 @@ func reloadRuntime(reloadPlugins bool) {
 		screen.TermMessage(err)
 	}
 	for _, b := range buffer.OpenBuffers {
+		config.InitLocalSettings(b.Settings, b.Path)
+		for k, v := range b.Settings {
+			b.SetOptionNative(k, v)
+		}
 		b.UpdateRules()
 	}
 }

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -408,15 +408,7 @@ func reloadRuntime(reloadPlugins bool) {
 		screen.TermMessage(err)
 	}
 	for _, b := range buffer.OpenBuffers {
-		config.InitLocalSettings(b.Settings, b.Path)
-		for k, v := range b.Settings {
-			if _, ok := b.LocalSettings[k]; ok {
-				// reload should not override local settings
-				continue
-			}
-			b.DoSetOptionNative(k, v)
-		}
-		b.UpdateRules()
+		b.ReloadSettings(true)
 	}
 }
 

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -362,9 +362,12 @@ func reloadRuntime(reloadPlugins bool) {
 		defaultSettings := config.DefaultAllSettings()
 		for k := range defaultSettings {
 			if _, ok := parsedSettings[k]; ok {
-				SetGlobalOptionNative(k, parsedSettings[k])
+				err = SetGlobalOptionNative(k, parsedSettings[k])
 			} else {
-				SetGlobalOptionNative(k, defaultSettings[k])
+				err = SetGlobalOptionNative(k, defaultSettings[k])
+			}
+			if err != nil {
+				screen.TermMessage(err)
 			}
 		}
 	}
@@ -526,8 +529,7 @@ func SetGlobalOptionNative(option string, nativeValue interface{}) error {
 	// check for local option first...
 	for _, s := range config.LocalSettings {
 		if s == option {
-			MainTab().CurPane().Buf.SetOptionNative(option, nativeValue)
-			return nil
+			return MainTab().CurPane().Buf.SetOptionNative(option, nativeValue)
 		}
 	}
 
@@ -585,7 +587,9 @@ func SetGlobalOptionNative(option string, nativeValue interface{}) error {
 	}
 
 	for _, b := range buffer.OpenBuffers {
-		b.SetOptionNative(option, nativeValue)
+		if err := b.SetOptionNative(option, nativeValue); err != nil {
+			return err
+		}
 	}
 
 	return config.WriteSettings(filepath.Join(config.ConfigDir, "settings.json"))

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -367,6 +367,9 @@ func NewBuffer(r io.Reader, size int64, path string, startcursor Loc, btype BufT
 				case "dos":
 					ff = FFDos
 				}
+			} else {
+				// in case of autodetection treat as locally set
+				b.LocalSettings["fileformat"] = true
 			}
 
 			b.LineArray = NewLineArray(uint64(size), ff, reader)

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -86,6 +86,8 @@ type SharedBuffer struct {
 
 	// Settings customized by the user
 	Settings map[string]interface{}
+	// LocalSettings customized by the user for this buffer only
+	LocalSettings map[string]bool
 
 	Suggestions   []string
 	Completions   []string
@@ -326,6 +328,7 @@ func NewBuffer(r io.Reader, size int64, path string, startcursor Loc, btype BufT
 		// assigning the filetype.
 		settings := config.DefaultCommonSettings()
 		b.Settings = config.DefaultCommonSettings()
+		b.LocalSettings = make(map[string]bool)
 		for k, v := range config.GlobalSettings {
 			if _, ok := config.DefaultGlobalOnlySettings[k]; !ok {
 				// make sure setting is not global-only

--- a/internal/buffer/settings.go
+++ b/internal/buffer/settings.go
@@ -26,15 +26,6 @@ func (b *Buffer) SetOptionNative(option string, nativeValue interface{}) error {
 	} else if option == "statusline" {
 		screen.Redraw()
 	} else if option == "filetype" {
-		config.InitRuntimeFiles(true)
-		err := config.ReadSettings()
-		if err != nil {
-			screen.TermMessage(err)
-		}
-		err = config.InitGlobalSettings()
-		if err != nil {
-			screen.TermMessage(err)
-		}
 		config.InitLocalSettings(b.Settings, b.Path)
 		b.UpdateRules()
 	} else if option == "fileformat" {

--- a/internal/buffer/settings.go
+++ b/internal/buffer/settings.go
@@ -8,6 +8,43 @@ import (
 	"github.com/zyedidia/micro/v2/internal/screen"
 )
 
+func (b *Buffer) ReloadSettings(reloadFiletype bool) {
+	settings := config.ParsedSettings()
+
+	if _, ok := b.LocalSettings["filetype"]; !ok && reloadFiletype {
+		// need to update filetype before updating other settings based on it
+		b.Settings["filetype"] = "unknown"
+		if v, ok := settings["filetype"]; ok {
+			b.Settings["filetype"] = v
+		}
+	}
+
+	// update syntax rules, which will also update filetype if needed
+	b.UpdateRules()
+	settings["filetype"] = b.Settings["filetype"]
+
+	config.InitLocalSettings(settings, b.Path)
+	for k, v := range config.DefaultCommonSettings() {
+		if k == "filetype" {
+			// prevent recursion
+			continue
+		}
+		if _, ok := config.VolatileSettings[k]; ok {
+			// reload should not override volatile settings
+			continue
+		}
+		if _, ok := b.LocalSettings[k]; ok {
+			// reload should not override local settings
+			continue
+		}
+		if _, ok := settings[k]; ok {
+			b.DoSetOptionNative(k, settings[k])
+		} else {
+			b.DoSetOptionNative(k, v)
+		}
+	}
+}
+
 func (b *Buffer) DoSetOptionNative(option string, nativeValue interface{}) {
 	if reflect.DeepEqual(b.Settings[option], nativeValue) {
 		return
@@ -31,28 +68,7 @@ func (b *Buffer) DoSetOptionNative(option string, nativeValue interface{}) {
 	} else if option == "statusline" {
 		screen.Redraw()
 	} else if option == "filetype" {
-		settings := config.ParsedSettings()
-		settings["filetype"] = nativeValue
-		config.InitLocalSettings(settings, b.Path)
-		for k, v := range config.DefaultCommonSettings() {
-			if k == "filetype" {
-				continue
-			}
-			if _, ok := config.VolatileSettings[k]; ok {
-				// filetype should not override volatile settings
-				continue
-			}
-			if _, ok := b.LocalSettings[k]; ok {
-				// filetype should not override local settings
-				continue
-			}
-			if _, ok := settings[k]; ok {
-				b.DoSetOptionNative(k, settings[k])
-			} else {
-				b.DoSetOptionNative(k, v)
-			}
-		}
-		b.UpdateRules()
+		b.ReloadSettings(false)
 	} else if option == "fileformat" {
 		switch b.Settings["fileformat"].(string) {
 		case "unix":

--- a/internal/buffer/settings.go
+++ b/internal/buffer/settings.go
@@ -26,7 +26,23 @@ func (b *Buffer) SetOptionNative(option string, nativeValue interface{}) error {
 	} else if option == "statusline" {
 		screen.Redraw()
 	} else if option == "filetype" {
-		config.InitLocalSettings(b.Settings, b.Path)
+		settings := config.ParsedSettings()
+		settings["filetype"] = nativeValue
+		config.InitLocalSettings(settings, b.Path)
+		for k, v := range config.DefaultCommonSettings() {
+			if k == "filetype" {
+				continue
+			}
+			if _, ok := config.VolatileSettings[k]; ok {
+				// filetype should not override volatile settings
+				continue
+			}
+			if _, ok := settings[k]; ok {
+				b.SetOptionNative(k, settings[k])
+			} else {
+				b.SetOptionNative(k, v)
+			}
+		}
 		b.UpdateRules()
 	} else if option == "fileformat" {
 		switch b.Settings["fileformat"].(string) {

--- a/internal/buffer/settings.go
+++ b/internal/buffer/settings.go
@@ -9,6 +9,10 @@ import (
 )
 
 func (b *Buffer) SetOptionNative(option string, nativeValue interface{}) error {
+	if err := config.OptionIsValid(option, nativeValue); err != nil {
+		return err
+	}
+
 	if reflect.DeepEqual(b.Settings[option], nativeValue) {
 		return nil
 	}

--- a/internal/buffer/settings.go
+++ b/internal/buffer/settings.go
@@ -2,12 +2,17 @@ package buffer
 
 import (
 	"crypto/md5"
+	"reflect"
 
 	"github.com/zyedidia/micro/v2/internal/config"
 	"github.com/zyedidia/micro/v2/internal/screen"
 )
 
 func (b *Buffer) SetOptionNative(option string, nativeValue interface{}) error {
+	if reflect.DeepEqual(b.Settings[option], nativeValue) {
+		return nil
+	}
+
 	b.Settings[option] = nativeValue
 
 	if option == "fastdirty" {

--- a/internal/config/autosave.go
+++ b/internal/config/autosave.go
@@ -1,37 +1,49 @@
 package config
 
 import (
-	"sync"
 	"time"
 )
 
 var Autosave chan bool
-var autotime float64
-
-// lock for autosave
-var autolock sync.Mutex
+var autotime chan float64
 
 func init() {
 	Autosave = make(chan bool)
+	autotime = make(chan float64)
 }
 
 func SetAutoTime(a float64) {
-	autolock.Lock()
-	autotime = a
-	autolock.Unlock()
+	autotime <- a
 }
 
 func StartAutoSave() {
 	go func() {
+		var a float64
+		var t *time.Timer
+		var elapsed <-chan time.Time
 		for {
-			autolock.Lock()
-			a := autotime
-			autolock.Unlock()
-			if a <= 0 {
-				break
+			select {
+			case a = <-autotime:
+				if t != nil {
+					t.Stop()
+					for len(elapsed) > 0 {
+						<-elapsed
+					}
+				}
+				if a > 0 {
+					if t != nil {
+						t.Reset(time.Duration(a * float64(time.Second)))
+					} else {
+						t = time.NewTimer(time.Duration(a * float64(time.Second)))
+						elapsed = t.C
+					}
+				}
+			case <-elapsed:
+				if a > 0 {
+					t.Reset(time.Duration(a * float64(time.Second)))
+					Autosave <- true
+				}
 			}
-			time.Sleep(time.Duration(a * float64(time.Second)))
-			Autosave <- true
 		}
 	}()
 }

--- a/internal/config/autosave.go
+++ b/internal/config/autosave.go
@@ -6,7 +6,7 @@ import (
 )
 
 var Autosave chan bool
-var autotime int
+var autotime float64
 
 // lock for autosave
 var autolock sync.Mutex
@@ -15,7 +15,7 @@ func init() {
 	Autosave = make(chan bool)
 }
 
-func SetAutoTime(a int) {
+func SetAutoTime(a float64) {
 	autolock.Lock()
 	autotime = a
 	autolock.Unlock()
@@ -27,10 +27,10 @@ func StartAutoSave() {
 			autolock.Lock()
 			a := autotime
 			autolock.Unlock()
-			if a < 1 {
+			if a <= 0 {
 				break
 			}
-			time.Sleep(time.Duration(a) * time.Second)
+			time.Sleep(time.Duration(a * float64(time.Second)))
 			Autosave <- true
 		}
 	}()

--- a/internal/config/autosave.go
+++ b/internal/config/autosave.go
@@ -21,13 +21,6 @@ func SetAutoTime(a int) {
 	autolock.Unlock()
 }
 
-func GetAutoTime() int {
-	autolock.Lock()
-	a := autotime
-	autolock.Unlock()
-	return a
-}
-
 func StartAutoSave() {
 	go func() {
 		for {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -273,7 +273,7 @@ func verifySetting(option string, value interface{}, def interface{}) error {
 // Must be called after ReadSettings
 func InitGlobalSettings() error {
 	var err error
-	GlobalSettings = DefaultGlobalSettings()
+	GlobalSettings = DefaultAllSettings()
 
 	for k, v := range parsedSettings {
 		if !strings.HasPrefix(reflect.TypeOf(v).String(), "map") {
@@ -319,7 +319,7 @@ func WriteSettings(filename string) error {
 
 	var err error
 	if _, e := os.Stat(ConfigDir); e == nil {
-		defaults := DefaultGlobalSettings()
+		defaults := DefaultAllSettings()
 
 		// remove any options froms parsedSettings that have since been marked as default
 		for k, v := range parsedSettings {
@@ -354,7 +354,7 @@ func OverwriteSettings(filename string) error {
 
 	var err error
 	if _, e := os.Stat(ConfigDir); e == nil {
-		defaults := DefaultGlobalSettings()
+		defaults := DefaultAllSettings()
 		for k, v := range GlobalSettings {
 			if def, ok := defaults[k]; !ok || !reflect.DeepEqual(v, def) {
 				if _, wr := ModifiedSettings[k]; wr {
@@ -420,8 +420,8 @@ func GetInfoBarOffset() int {
 	return offset
 }
 
-// DefaultCommonSettings returns the default global settings for micro
-// Note that colorscheme is a global only option
+// DefaultCommonSettings returns a map of all common buffer settings
+// and their default values
 func DefaultCommonSettings() map[string]interface{} {
 	commonsettings := make(map[string]interface{})
 	for k, v := range defaultCommonSettings {
@@ -430,21 +430,8 @@ func DefaultCommonSettings() map[string]interface{} {
 	return commonsettings
 }
 
-// DefaultGlobalSettings returns the default global settings for micro
-// Note that colorscheme is a global only option
-func DefaultGlobalSettings() map[string]interface{} {
-	globalsettings := make(map[string]interface{})
-	for k, v := range defaultCommonSettings {
-		globalsettings[k] = v
-	}
-	for k, v := range DefaultGlobalOnlySettings {
-		globalsettings[k] = v
-	}
-	return globalsettings
-}
-
-// DefaultAllSettings returns a map of all settings and their
-// default values (both common and global settings)
+// DefaultAllSettings returns a map of all common buffer & global-only settings
+// and their default values
 func DefaultAllSettings() map[string]interface{} {
 	allsettings := make(map[string]interface{})
 	for k, v := range defaultCommonSettings {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -154,10 +154,10 @@ var (
 func init() {
 	ModifiedSettings = make(map[string]bool)
 	VolatileSettings = make(map[string]bool)
-	parsedSettings = make(map[string]interface{})
 }
 
 func ReadSettings() error {
+	parsedSettings = make(map[string]interface{})
 	filename := filepath.Join(ConfigDir, "settings.json")
 	if _, e := os.Stat(filename); e == nil {
 		input, err := ioutil.ReadFile(filename)
@@ -187,6 +187,14 @@ func ReadSettings() error {
 		}
 	}
 	return nil
+}
+
+func ParsedSettings() map[string]interface{} {
+	s := make(map[string]interface{})
+	for k, v := range parsedSettings {
+		s[k] = v
+	}
+	return s
 }
 
 func verifySetting(option string, value reflect.Type, def reflect.Type) bool {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -480,13 +480,13 @@ func OptionIsValid(option string, value interface{}) error {
 // Option validators
 
 func validatePositiveValue(option string, value interface{}) error {
-	tabsize, ok := value.(float64)
+	nativeValue, ok := value.(float64)
 
 	if !ok {
 		return errors.New("Expected numeric type for " + option)
 	}
 
-	if tabsize < 1 {
+	if nativeValue < 1 {
 		return errors.New(option + " must be greater than 0")
 	}
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -456,11 +456,11 @@ func GetNativeValue(option string, realValue interface{}, value string) (interfa
 	} else if kind == reflect.String {
 		native = value
 	} else if kind == reflect.Float64 {
-		i, err := strconv.Atoi(value)
+		f, err := strconv.ParseFloat(value, 64)
 		if err != nil {
 			return nil, ErrInvalidValue
 		}
-		native = float64(i)
+		native = f
 	} else {
 		return nil, ErrInvalidValue
 	}

--- a/runtime/plugins/comment/comment.lua
+++ b/runtime/plugins/comment/comment.lua
@@ -66,9 +66,9 @@ local last_ft
 function updateCommentType(buf)
     if buf.Settings["commenttype"] == nil or (last_ft ~= buf.Settings["filetype"] and last_ft ~= nil) then
         if ft[buf.Settings["filetype"]] ~= nil then
-            buf.Settings["commenttype"] = ft[buf.Settings["filetype"]]
+            buf:SetOptionNative("commenttype", ft[buf.Settings["filetype"]])
         else
-            buf.Settings["commenttype"] = "# %s"
+            buf:SetOptionNative("commenttype", "# %s")
         end
 
         last_ft = buf.Settings["filetype"]


### PR DESCRIPTION
* the change of the `filetype` could cause unexpected behavior depending on global options being reset, while a volatile setting has been used.
* the `reload` command could cause the same unexpected behavior and additionally doesn't really reload the user settings
* `autosave` is now aborted in case his value has changed to something smaller or equal to 0.

Fixes #3342