### PR TITLE
detect .pyw files

### DIFF
--- a/runtime/syntax/python3.yaml
+++ b/runtime/syntax/python3.yaml
@@ -1,7 +1,7 @@
 filetype: python
 
 detect:
-    filename: "\\.py(3)?$"
+    filename: "\\.py(3|w)?$"
     header: "^#!.*/(env +)?python(3)?$"
 
 rules:


### PR DESCRIPTION
.pyw files are used for Python scripts that should run using pythonw.exe (which does not open a console window) on Windows OS. This came up on the discussions page: https://github.com/zyedidia/micro/discussions/3345