### PR TITLE
Improve return values of some actions + some improvements

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1577,10 +1577,9 @@ func (h *BufPane) ToggleRuler() bool {
 	return true
 }
 
-// ClearStatus clears the messenger bar
+// ClearStatus clears the infobar. It is an alias for ClearInfo.
 func (h *BufPane) ClearStatus() bool {
-	InfoBar.Message("")
-	return true
+	return h.ClearInfo()
 }
 
 // ToggleHelp toggles the help screen

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1068,6 +1068,9 @@ func (h *BufPane) ToggleHighlightSearch() bool {
 
 // UnhighlightSearch unhighlights all instances of the last used search term
 func (h *BufPane) UnhighlightSearch() bool {
+	if !h.Buf.HighlightSearch {
+		return false
+	}
 	h.Buf.HighlightSearch = false
 	return true
 }
@@ -1632,12 +1635,18 @@ func (h *BufPane) Escape() bool {
 
 // Deselect deselects on the current cursor
 func (h *BufPane) Deselect() bool {
+	if !h.Cursor.HasSelection() {
+		return false
+	}
 	h.Cursor.Deselect(true)
 	return true
 }
 
 // ClearInfo clears the infobar
 func (h *BufPane) ClearInfo() bool {
+	if InfoBar.Msg == "" {
+		return false
+	}
 	InfoBar.Message("")
 	return true
 }
@@ -1728,6 +1737,10 @@ func (h *BufPane) AddTab() bool {
 // PreviousTab switches to the previous tab in the tab list
 func (h *BufPane) PreviousTab() bool {
 	tabsLen := len(Tabs.List)
+	if tabsLen == 1 {
+		return false
+	}
+
 	a := Tabs.Active() + tabsLen
 	Tabs.SetActive((a - 1) % tabsLen)
 
@@ -1736,8 +1749,13 @@ func (h *BufPane) PreviousTab() bool {
 
 // NextTab switches to the next tab in the tab list
 func (h *BufPane) NextTab() bool {
+	tabsLen := len(Tabs.List)
+	if tabsLen == 1 {
+		return false
+	}
+
 	a := Tabs.Active()
-	Tabs.SetActive((a + 1) % len(Tabs.List))
+	Tabs.SetActive((a + 1) % tabsLen)
 
 	return true
 }
@@ -1773,6 +1791,10 @@ func (h *BufPane) Unsplit() bool {
 
 // NextSplit changes the view to the next split
 func (h *BufPane) NextSplit() bool {
+	if len(h.tab.Panes) == 1 {
+		return false
+	}
+
 	a := h.tab.active
 	if a < len(h.tab.Panes)-1 {
 		a++
@@ -1787,6 +1809,10 @@ func (h *BufPane) NextSplit() bool {
 
 // PreviousSplit changes the view to the previous split
 func (h *BufPane) PreviousSplit() bool {
+	if len(h.tab.Panes) == 1 {
+		return false
+	}
+
 	a := h.tab.active
 	if a > 0 {
 		a--

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -2023,8 +2023,10 @@ func (h *BufPane) RemoveMultiCursor() bool {
 		h.Buf.RemoveCursor(h.Buf.NumCursors() - 1)
 		h.Buf.SetCurCursor(h.Buf.NumCursors() - 1)
 		h.Buf.UpdateCursors()
-	} else {
+	} else if h.multiWord {
 		h.multiWord = false
+	} else {
+		return false
 	}
 	h.Relocate()
 	return true
@@ -2032,8 +2034,12 @@ func (h *BufPane) RemoveMultiCursor() bool {
 
 // RemoveAllMultiCursors removes all cursors except the base cursor
 func (h *BufPane) RemoveAllMultiCursors() bool {
-	h.Buf.ClearCursors()
-	h.multiWord = false
+	if h.Buf.NumCursors() > 1 || h.multiWord {
+		h.Buf.ClearCursors()
+		h.multiWord = false
+	} else {
+		return false
+	}
 	h.Relocate()
 	return true
 }

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -2013,6 +2013,9 @@ func (h *BufPane) MouseMultiCursor(e *tcell.EventMouse) bool {
 // SkipMultiCursor moves the current multiple cursor to the next available position
 func (h *BufPane) SkipMultiCursor() bool {
 	lastC := h.Buf.GetCursor(h.Buf.NumCursors() - 1)
+	if !lastC.HasSelection() {
+		return false
+	}
 	sel := lastC.GetSelection()
 	searchStart := lastC.CurSelection[1]
 

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -2053,6 +2053,7 @@ func (h *BufPane) RemoveMultiCursor() bool {
 		h.Buf.UpdateCursors()
 	} else if h.multiWord {
 		h.multiWord = false
+		h.Cursor.Deselect(true)
 	} else {
 		return false
 	}

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1163,7 +1163,9 @@ func (h *BufPane) DiffPrevious() bool {
 
 // Undo undoes the last action
 func (h *BufPane) Undo() bool {
-	h.Buf.Undo()
+	if !h.Buf.Undo() {
+		return false
+	}
 	InfoBar.Message("Undid action")
 	h.Relocate()
 	return true
@@ -1171,7 +1173,9 @@ func (h *BufPane) Undo() bool {
 
 // Redo redoes the last action
 func (h *BufPane) Redo() bool {
-	h.Buf.Redo()
+	if !h.Buf.Redo() {
+		return false
+	}
 	InfoBar.Message("Redid action")
 	h.Relocate()
 	return true

--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -150,10 +150,10 @@ func BufMapEvent(k Event, action string) {
 		actionfns = append(actionfns, afn)
 	}
 	bufAction := func(h *BufPane, te *tcell.EventMouse) bool {
-		cursors := h.Buf.GetCursors()
 		success := true
 		for i, a := range actionfns {
 			innerSuccess := true
+			cursors := h.Buf.GetCursors()
 			for j, c := range cursors {
 				if c == nil {
 					continue
@@ -589,6 +589,9 @@ func (h *BufPane) execAction(action BufAction, name string, cursor int, te *tcel
 
 			return success
 		}
+	} else {
+		// do nothing but return true, to not break the chain
+		return true
 	}
 
 	return false

--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -150,27 +150,29 @@ func BufMapEvent(k Event, action string) {
 		actionfns = append(actionfns, afn)
 	}
 	bufAction := func(h *BufPane, te *tcell.EventMouse) bool {
-		success := true
 		for i, a := range actionfns {
-			innerSuccess := true
-			cursors := h.Buf.GetCursors()
-			for j, c := range cursors {
-				if c == nil {
-					continue
+			var success bool
+			if _, ok := MultiActions[names[i]]; ok {
+				success = true
+				for _, c := range h.Buf.GetCursors() {
+					h.Buf.SetCurCursor(c.Num)
+					h.Cursor = c
+					success = success && h.execAction(a, names[i], te)
 				}
-				h.Buf.SetCurCursor(c.Num)
-				h.Cursor = c
-				if i == 0 || (success && types[i-1] == '&') || (!success && types[i-1] == '|') || (types[i-1] == ',') {
-					innerSuccess = innerSuccess && h.execAction(a, names[i], j, te)
-				} else {
-					break
-				}
+			} else {
+				h.Buf.SetCurCursor(0)
+				h.Cursor = h.Buf.GetActiveCursor()
+				success = h.execAction(a, names[i], te)
 			}
+
 			// if the action changed the current pane, update the reference
 			h = MainTab().CurPane()
-			success = innerSuccess
 			if h == nil {
 				// stop, in case the current pane is not a BufPane
+				break
+			}
+
+			if (!success && types[i] == '&') || (success && types[i] == '|') {
 				break
 			}
 		}
@@ -562,39 +564,33 @@ func (h *BufPane) DoKeyEvent(e Event) bool {
 	return more
 }
 
-func (h *BufPane) execAction(action BufAction, name string, cursor int, te *tcell.EventMouse) bool {
+func (h *BufPane) execAction(action BufAction, name string, te *tcell.EventMouse) bool {
 	if name != "Autocomplete" && name != "CycleAutocompleteBack" {
 		h.Buf.HasSuggestions = false
 	}
 
-	_, isMulti := MultiActions[name]
-	if (!isMulti && cursor == 0) || isMulti {
-		if h.PluginCB("pre" + name) {
-			var success bool
-			switch a := action.(type) {
-			case BufKeyAction:
-				success = a(h)
-			case BufMouseAction:
-				success = a(h, te)
-			}
-			success = success && h.PluginCB("on"+name)
-
-			if isMulti {
-				if recordingMacro {
-					if name != "ToggleMacro" && name != "PlayMacro" {
-						curmacro = append(curmacro, action)
-					}
-				}
-			}
-
-			return success
-		}
-	} else {
-		// do nothing but return true, to not break the chain
-		return true
+	if !h.PluginCB("pre" + name) {
+		return false
 	}
 
-	return false
+	var success bool
+	switch a := action.(type) {
+	case BufKeyAction:
+		success = a(h)
+	case BufMouseAction:
+		success = a(h, te)
+	}
+	success = success && h.PluginCB("on"+name)
+
+	if _, ok := MultiActions[name]; ok {
+		if recordingMacro {
+			if name != "ToggleMacro" && name != "PlayMacro" {
+				curmacro = append(curmacro, action)
+			}
+		}
+	}
+
+	return success
 }
 
 func (h *BufPane) completeAction(action string) {

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -1089,7 +1089,7 @@ func (b *Buffer) ClearCursors() {
 	b.cursors = b.cursors[:1]
 	b.UpdateCursors()
 	b.curCursor = 0
-	b.GetActiveCursor().ResetSelection()
+	b.GetActiveCursor().Deselect(true)
 }
 
 // MoveLinesUp moves the range of lines up one row

--- a/internal/buffer/eventhandler.go
+++ b/internal/buffer/eventhandler.go
@@ -253,11 +253,11 @@ func (eh *EventHandler) Execute(t *TextEvent) {
 	ExecuteTextEvent(t, eh.buf)
 }
 
-// Undo the first event in the undo stack
-func (eh *EventHandler) Undo() {
+// Undo the first event in the undo stack. Returns false if the stack is empty.
+func (eh *EventHandler) Undo() bool {
 	t := eh.UndoStack.Peek()
 	if t == nil {
-		return
+		return false
 	}
 
 	startTime := t.Time.UnixNano() / int64(time.Millisecond)
@@ -266,15 +266,16 @@ func (eh *EventHandler) Undo() {
 	for {
 		t = eh.UndoStack.Peek()
 		if t == nil {
-			return
+			break
 		}
 
 		if t.Time.UnixNano()/int64(time.Millisecond) < endTime {
-			return
+			break
 		}
 
 		eh.UndoOneEvent()
 	}
+	return true
 }
 
 // UndoOneEvent undoes one event
@@ -303,11 +304,11 @@ func (eh *EventHandler) UndoOneEvent() {
 	eh.RedoStack.Push(t)
 }
 
-// Redo the first event in the redo stack
-func (eh *EventHandler) Redo() {
+// Redo the first event in the redo stack. Returns false if the stack is empty.
+func (eh *EventHandler) Redo() bool {
 	t := eh.RedoStack.Peek()
 	if t == nil {
-		return
+		return false
 	}
 
 	startTime := t.Time.UnixNano() / int64(time.Millisecond)
@@ -316,15 +317,16 @@ func (eh *EventHandler) Redo() {
 	for {
 		t = eh.RedoStack.Peek()
 		if t == nil {
-			return
+			break
 		}
 
 		if t.Time.UnixNano()/int64(time.Millisecond) > endTime {
-			return
+			break
 		}
 
 		eh.RedoOneEvent()
 	}
+	return true
 }
 
 // RedoOneEvent redoes one event

--- a/runtime/help/keybindings.md
+++ b/runtime/help/keybindings.md
@@ -242,6 +242,7 @@ ToggleDiffGutter
 ToggleRuler
 JumpLine
 ResetSearch
+ClearInfo
 ClearStatus
 ShellMode
 CommandMode


### PR DESCRIPTION
Currently most actions always return true, regardless of whether they succeeded to do their job or not. This means that for most actions the user cannot really take advantage of action chaining with `|` or `&`.

So, to facilitate efficient usage of action chaining, improve return values of some actions, namely:
- `Undo`
- `Redo`
- `Deselect`
- `UnhighlightSearch`
- `ClearInfo`
- `ClearStatus`
- `NextTab`
- `PreviousTab`
- `NextSplit`
- `PreviousSplit`
- `RemoveMultiCursor`
- `RemoveAllMultiCursors`

The rules are straightforward: `Undo` returns false if there is nothing to undo, `Deselect` return false if there is nothing selected, `NextTab` returns false if there is just one tab, and so on.

Additionally:
- Some fixes and improvements in the behavior of `RemoveMultiCursor`, `RemoveAllMultiCursors` and `SkipMultiCursor` actions.
- ~~Removed `ClearStatus` action as redundant (since `ClearInfo` does the same things).~~ I've changed my mind and restored it (compatibility concerns) but documented that it is an alias for `ClearInfo`.
- Refactored action execution code, to make it both simpler and more correct.