### PR TITLE
Fix non-working mouse events at the top line of the screen

### DIFF
--- a/internal/action/tab.go
+++ b/internal/action/tab.go
@@ -107,23 +107,18 @@ func (t *TabList) HandleEvent(event tcell.Event) {
 		mx, my := e.Position()
 		switch e.Buttons() {
 		case tcell.Button1:
-			if len(t.List) > 1 {
-				if my == t.Y && mx == 0 {
+			if my == t.Y && len(t.List) > 1 {
+				if mx == 0 {
 					t.Scroll(-4)
-					return
-				} else if my == t.Y && mx == t.Width-1 {
+				} else if mx == t.Width-1 {
 					t.Scroll(4)
-					return
+				} else {
+					ind := t.LocFromVisual(buffer.Loc{mx, my})
+					if ind != -1 {
+						t.SetActive(ind)
+					}
 				}
-
-				ind := t.LocFromVisual(buffer.Loc{mx, my})
-				if ind != -1 {
-					t.SetActive(ind)
-					return
-				}
-				if my == 0 {
-					return
-				}
+				return
 			}
 		case tcell.ButtonNone:
 			if t.List[t.Active()].release {

--- a/internal/action/tab.go
+++ b/internal/action/tab.go
@@ -107,14 +107,15 @@ func (t *TabList) HandleEvent(event tcell.Event) {
 		mx, my := e.Position()
 		switch e.Buttons() {
 		case tcell.Button1:
-			if my == t.Y && mx == 0 {
-				t.Scroll(-4)
-				return
-			} else if my == t.Y && mx == t.Width-1 {
-				t.Scroll(4)
-				return
-			}
 			if len(t.List) > 1 {
+				if my == t.Y && mx == 0 {
+					t.Scroll(-4)
+					return
+				} else if my == t.Y && mx == t.Width-1 {
+					t.Scroll(4)
+					return
+				}
+
 				ind := t.LocFromVisual(buffer.Loc{mx, my})
 				if ind != -1 {
 					t.SetActive(ind)

--- a/internal/action/tab.go
+++ b/internal/action/tab.go
@@ -132,12 +132,12 @@ func (t *TabList) HandleEvent(event tcell.Event) {
 				return
 			}
 		case tcell.WheelUp:
-			if my == t.Y {
+			if my == t.Y && len(t.List) > 1 {
 				t.Scroll(4)
 				return
 			}
 		case tcell.WheelDown:
-			if my == t.Y {
+			if my == t.Y && len(t.List) > 1 {
 				t.Scroll(-4)
 				return
 			}


### PR DESCRIPTION
- Fix non-working mouse click on the top-left and the top-right cells of the screen when there is no tab bar (i.e. just one tab open).
- Fix non-working mouse wheel scrolling on the top line of the screen when there is no tab bar (i.e. just one tab open).

Fixes #3349