### PR TITLE
autosave: don't save unmodified buffer

### DIFF
--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -95,6 +95,11 @@ func (b *Buffer) Save() error {
 
 // AutoSave saves the buffer to its default path
 func (b *Buffer) AutoSave() error {
+	// Doing full b.Modified() check every time would be costly, due to the hash
+	// calculation. So use just isModified even if fastdirty is not set.
+	if !b.isModified {
+		return nil
+	}
 	return b.saveToFile(b.Path, false, true)
 }
 


### PR DESCRIPTION
Saving a buffer every time without even checking if it was modified (i.e. even when the user is not editing the buffer) is wasteful, especially if the autosave period is set to a short value.