### PR TITLE
Fixing tabmove not working properly when there's a split in pane

### DIFF
--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -198,7 +198,7 @@ func (h *BufPane) TabMoveCmd(args []string) {
 	idxTo = util.Clamp(idxTo, 0, len(Tabs.List)-1)
 
 	activeTab := Tabs.List[idxFrom]
-	Tabs.RemoveTab(activeTab.ID())
+	Tabs.RemoveTab(activeTab.Panes[0].ID())
 	Tabs.List = append(Tabs.List, nil)
 	copy(Tabs.List[idxTo+1:], Tabs.List[idxTo:])
 	Tabs.List[idxTo] = activeTab


### PR DESCRIPTION
This fixes #3072 . Please see the issue for the problem.

It now uses the first pane ID inside the tab instead of the tab ID itself.

To test this,
1. Create 3 tabs with the middle tab that has split panes.
2. Either open files for each tab or type something in them to differentiate them.
3. Do `tabmove -1` or `tabmove 1` when you are at the middle tab.

- If you are in master, it will fail to remove the original tab and the tab is copied and the states are linked between the original and cloned tab, instead of "moving" the tab
- If you are in the PR branch, it will be able to "move" the tab to the desired location by creating a copy and removing the original tab.


