### PR TITLE
Improve Haskell syntax highlighting

### DIFF
--- a/runtime/syntax/haskell.yaml
+++ b/runtime/syntax/haskell.yaml
@@ -4,35 +4,39 @@ detect:
     filename: "\\.hs$"
 
 rules:
+    - symbol.operator: "[!#$%&:*+/<=>?@.\\\\^\\|~\\p{Sm}\\-]+"
+
+    # Identifiers (with or without a module name)
+    - type: "\\b([A-Z][A-Za-z0-9_]*\\.)*[A-Z]+[A-Za-z0-9_']*\\b"
+    - default: "\\b([A-Z][A-Za-z0-9_]*\\.)*[a-z][A-Za-z0-9_']*\\b"
+
+    - statement: ";"
+    - symbol.bracket: "[\\(\\)\\[\\]\\{\\}]"
+    - special: "`[A-Za-z0-9']+`"
+
     # Keywords
-    - statement: "\\b(as|case|of|class|data|default|deriving|do|forall|foreign|hiding|if|then|else|import|infix|infixl|infixr|instance|let|in|mdo|module|newtype|qualified|type|where)\\b"
+    - statement: "\\b(case|of|class|data|default|deriving|do|forall|foreign|hiding|if|then|else|import|infix|infixl|infixr|instance|let|in|mdo|module|newtype|qualified|type|where)\\b"
 
-      # Various symbols
-    - symbol: "(\\||@|!|:|_|~|=|\\\\|;|\\(\\)|,|\\[|\\]|\\{|\\})"
-
-      # Operators
-    - symbol.operator: "(==|/=|&&|\\|\\||<|>|<=|>=)"
-
-      # Various symbols
-    - special: "(->|<-)"
-    - symbol: "\\.|\\$"
-
-      # Data constructors
+    # Data constructors
     - constant.bool: "\\b(True|False)\\b"
     - constant: "\\b(Nothing|Just|Left|Right|LT|EQ|GT)\\b"
 
-      # Data classes
-    - identifier.class: "\\b(Read|Show|Enum|Eq|Ord|Data|Bounded|Typeable|Num|Real|Fractional|Integral|RealFrac|Floating|RealFloat|Monad|MonadPlus|Functor|Foldable|Additive|Zip)[ ]"
+    - constant: "\\(\\)"  # Unit
+    - constant.number: "\\b(0[xX][0-9A-Fa-f]+|0[oO][0-7]+|[-]?[0-9]+([.][0-9]+)?([eE][+-]?[0-9]+)?)\\b"
 
-      # Strings
+    # Data classes
+    - identifier.class: "\\b(Additive|Applicative|Bounded|Data|Enum|Eq|Floating|Foldable|Fractional|Functor|Integral|Monad|MonadPlus|Monoid|Num|Ord|Read|Real|RealFloat|RealFrac|Semigroup|Show|Traversable|Typeable|Zip)[ ]"
+
+    # Strings
     - constant.string:
         start: "\""
         end: "\""
         skip: "\\\\."
         rules:
-            - constant.specialChar: "\\\\."
+            - special: "\\\\&"
+            - constant.specialChar: "\\\\([abfnrtv\"'\\\\]|[0-9]+|x[0-9a-fA-F]+|o[0-7]+|NUL|SOH|STX|ETX|EOT|ENQ|ACK|BEL|BS|HT|LF|VT|FF|CR|SO|SI|DLE|DC[1-4]|NAK|SYN|ETB|CAN|EM|SUB|ESC|FS|GS|RS|US|SP|DEL)"
 
-      # Comments
+    # Comments
     - comment:
         start: "--"
         end: "$"
@@ -45,4 +49,4 @@ rules:
         rules:
             - todo: "(TODO|XXX|FIXME):?"
 
-    - identifier.micro: "undefined"
+    - identifier.macro: "undefined"

--- a/runtime/syntax/haskell.yaml
+++ b/runtime/syntax/haskell.yaml
@@ -22,7 +22,7 @@ rules:
     - constant: "\\b(Nothing|Just|Left|Right|LT|EQ|GT)\\b"
 
     - constant: "\\(\\)"  # Unit
-    - constant.number: "\\b(0[xX][0-9A-Fa-f]+|0[oO][0-7]+|[-]?[0-9]+([.][0-9]+)?([eE][+-]?[0-9]+)?)\\b"
+    - constant.number: "\\b(0[xX][0-9A-Fa-f]+|0[oO][0-7]+|0[bB][01]+|[-]?[0-9]+([.][0-9]+)?([eE][+-]?[0-9]+)?)\\b"
 
     # Data classes
     - identifier.class: "\\b(Additive|Applicative|Bounded|Data|Enum|Eq|Floating|Foldable|Fractional|Functor|Integral|Monad|MonadPlus|Monoid|Num|Ord|Read|Real|RealFloat|RealFrac|Semigroup|Show|Traversable|Typeable|Zip)[ ]"


### PR DESCRIPTION
Various improvements and fixes to the Haskell syntax:
* Better highlighting of operators (including user-defined ones)
* Highlight `SomeType` and `T.SomeType` as type but `T.someFunction` using default color. Capitalized identifiers in Haskell can be module names, type classes, types, or type/data constructors. Micro's syntax highlighting is not powerful enough to properly distinguish between these but I found using `type` for all of them a reasonable compromise.
* Add highlighting for unit instance (`()`) and numeric literals (int/float/octal/hexadecimal)
* Improve highlighting for [escape sequences in strings](https://book.realworldhaskell.org/read/characters-strings-and-escaping-rules.html#escapes.escape)
* Remove `as` from the list of keywords because it only works like a keyword in the context of `import ... as ...`, and it is very commonly used as an identifier
* Add highlighting for infix function application (eg. ``5 `div` 3``)
* Add highlighting for SemiGroup / Applicative / Monoid type classes

![screenshot showing the difference to current syntax highlighting](https://github.com/zyedidia/micro/assets/10672443/5ddd0d92-cd97-4a60-8c32-86b34091a625)