### PR TITLE
Change `TryBindKey()` behavior to prevent plugins from needlessly rewriting `bindings.json`

### DIFF
--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -256,8 +256,11 @@ func eventsEqual(e1 Event, e2 Event) bool {
 	return e1 == e2
 }
 
-// TryBindKey tries to bind a key by writing to config.ConfigDir/bindings.json
-// Returns true if the keybinding already existed and a possible error
+// TryBindKey tries to bind a key to an action. If there is already a binding
+// for this key and `overwrite` is true, TryBindKey replaces this binding with
+// the new one and writes the new binding to `bindings.json`.
+// Returns true if the new binding has been applied, and a possible error
+// if failed to write to `bindings.json`.
 func TryBindKey(k, v string, overwrite bool) (bool, error) {
 	var e error
 	var parsed map[string]interface{}
@@ -303,8 +306,12 @@ func TryBindKey(k, v string, overwrite bool) (bool, error) {
 
 		BindKey(k, v, Binder["buffer"])
 
-		txt, _ := json.MarshalIndent(parsed, "", "    ")
-		return true, ioutil.WriteFile(filename, append(txt, '\n'), 0644)
+		if overwrite {
+			txt, _ := json.MarshalIndent(parsed, "", "    ")
+			return true, ioutil.WriteFile(filename, append(txt, '\n'), 0644)
+		}
+
+		return true, nil
 	}
 	return false, e
 }

--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -298,7 +298,7 @@ func TryBindKey(k, v string, overwrite bool) (bool, error) {
 			if overwrite {
 				parsed[ev] = v
 			} else {
-				return true, nil
+				return parsed[ev] == v, nil
 			}
 		} else {
 			parsed[k] = v

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -166,8 +166,8 @@ The packages and their contents are listed below (in Go type signatures):
     - `NoComplete`: no autocompletion suggestions
 
     - `TryBindKey(k, v string, overwrite bool) (bool, error)`: bind the key
-       `k` to the string `v` in the `bindings.json` file.  If `overwrite` is
-       true, this will overwrite any existing binding to key `k`. Returns true
+       `k` to the action `v`. If `overwrite` is true, this will overwrite any
+       existing binding to key `k` in the `bindings.json` file. Returns true
        if the binding was made, and a possible error (for example writing to
        `bindings.json` can cause an error).
 


### PR DESCRIPTION
Change the (documented) behavior of `TryBindKey()`: unless the `overwrite` argument is true, never write to `bindings.json`, even if the new binding has been successfully applied.

`TryBindKey()` with overwrite=false is mainly used by plugins for adding their own default keybindings. It is not really necessary for them to write those default bindings to `bindings.json`: even if the binding is not saved in `bindings.json`, it will be still applied by the plugin calling `TryBindKey()` every time micro starts.

This fixes undesirable behavior mentioned in https://github.com/zyedidia/micro/issues/2194#issuecomment-2221721547: unless there is already a binding for the given key in `bindings.json`, a plugin forcibly rewrites `bindings.json`, in particular removing any user's comments from it. With this change, `bindings.json` will be only rewritten by micro in the case when the user runs `bind` or `unbind` command, not automatically by plugins (unless there is a plugin calling `TryBindKey()` with overwrite=true, which is unlikely).