### PR TITLE
Fix termpane not closing automatically after terminal job finished

### DIFF
--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -422,6 +422,7 @@ func DoEvent() {
 			b.AutoSave()
 		}
 	case <-shell.CloseTerms:
+		action.Tabs.CloseTerms()
 	case event = <-screen.Events:
 	case <-screen.DrawChan():
 		for len(screen.DrawChan()) > 0 {

--- a/internal/action/tab.go
+++ b/internal/action/tab.go
@@ -188,6 +188,17 @@ func (t *TabList) ResetMouse() {
 	}
 }
 
+// CloseTerms notifies term panes that a terminal job has finished.
+func (t *TabList) CloseTerms() {
+	for _, tab := range t.List {
+		for _, p := range tab.Panes {
+			if tp, ok := p.(*TermPane); ok {
+				tp.HandleTermClose()
+			}
+		}
+	}
+}
+
 // Tabs is the global tab list
 var Tabs *TabList
 

--- a/internal/action/termpane.go
+++ b/internal/action/termpane.go
@@ -159,9 +159,9 @@ func (t *TermPane) HandleEvent(event tcell.Event) {
 		if t.Status != shell.TTDone {
 			t.WriteString(event.EscSeq())
 		}
-	} else if e, ok := event.(*tcell.EventMouse); e != nil && (!ok || t.State.Mode(terminal.ModeMouseMask)) {
+	} else if e, ok := event.(*tcell.EventMouse); !ok || t.State.Mode(terminal.ModeMouseMask) {
 		// t.WriteString(event.EscSeq())
-	} else if e != nil {
+	} else {
 		x, y := e.Position()
 		v := t.GetView()
 		x -= v.X
@@ -188,7 +188,12 @@ func (t *TermPane) HandleEvent(event tcell.Event) {
 			t.mouseReleased = true
 		}
 	}
+}
 
+// HandleTermClose is called when a terminal has finished its job
+// and should be closed. If that terminal is this termpane's terminal,
+// HandleTermClose will close the terminal and the termpane itself.
+func (t *TermPane) HandleTermClose() {
 	if t.Status == shell.TTClose {
 		t.Quit()
 	}


### PR DESCRIPTION
Fix regression caused by the fix 0de16334d384 ("micro: Don't forward nil events into the sub event handler") reported in https://github.com/zyedidia/micro/pull/2992#issuecomment-2216647788: even if the terminal was started with `wait` set to false, it is not closed immediately after it finished its job, instead it shows "Press enter to close".

The reason is that since the commit b68461cf72cb ("Terminal plugin callback support") the termpane code has been (slightly hackily) relying on nil events as notifications to close the terminal after it finished its job. So fix this by introducing a separate `CloseTerms()` function for notifying termpanes about that, decoupled from `HandleEvent()` which is for tcell events only.