### PR TITLE
Exposing replacement functions for deprecated IOUtil functions

### DIFF
--- a/internal/lua/lua.go
+++ b/internal/lua/lua.go
@@ -125,6 +125,7 @@ func importIo() *lua.LTable {
 	L.SetField(pkg, "MultiWriter", luar.New(L, io.MultiWriter))
 	L.SetField(pkg, "NewSectionReader", luar.New(L, io.NewSectionReader))
 	L.SetField(pkg, "Pipe", luar.New(L, io.Pipe))
+	L.SetField(pkg, "ReadAll", luar.New(L, io.ReadAll))
 	L.SetField(pkg, "ReadAtLeast", luar.New(L, io.ReadAtLeast))
 	L.SetField(pkg, "ReadFull", luar.New(L, io.ReadFull))
 	L.SetField(pkg, "TeeReader", luar.New(L, io.TeeReader))
@@ -370,6 +371,8 @@ func importOs() *lua.LTable {
 	L.SetField(pkg, "PathListSeparator", luar.New(L, os.PathListSeparator))
 	L.SetField(pkg, "PathSeparator", luar.New(L, os.PathSeparator))
 	L.SetField(pkg, "Pipe", luar.New(L, os.Pipe))
+	L.SetField(pkg, "ReadDir", luar.New(L, os.ReadDir))
+	L.SetField(pkg, "ReadFile", luar.New(L, os.ReadFile))
 	L.SetField(pkg, "Readlink", luar.New(L, os.Readlink))
 	L.SetField(pkg, "Remove", luar.New(L, os.Remove))
 	L.SetField(pkg, "RemoveAll", luar.New(L, os.RemoveAll))
@@ -388,6 +391,7 @@ func importOs() *lua.LTable {
 	L.SetField(pkg, "TempDir", luar.New(L, os.TempDir))
 	L.SetField(pkg, "Truncate", luar.New(L, os.Truncate))
 	L.SetField(pkg, "UserHomeDir", luar.New(L, os.UserHomeDir))
+	L.SetField(pkg, "WriteFile", luar.New(L, os.WriteFile))
 
 	return pkg
 }


### PR DESCRIPTION
The ioutil functions we have at the moment are deprecated by go.

These are 
- `ReadAll()`
- `ReadDir()`
- `ReadFile()`
- `WriteFile()`

We should instead use the functions mentioned on the [doc](https://pkg.go.dev/io/ioutil@go1.22.5)