### PR TITLE
Support `-bom` in encoding option and detect BOM

### DIFF
--- a/LICENSE-THIRD-PARTY
+++ b/LICENSE-THIRD-PARTY
@@ -1304,3 +1304,208 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+github.com/dimchansky/utfbom
+=================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright (c) 2018-2020, Dmitrij Koniajev (dimchansky@gmail.com)
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/zyedidia/micro/v2
 
 require (
 	github.com/blang/semver v3.5.1+incompatible
+	github.com/dimchansky/utfbom v1.1.1
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-errors/errors v1.0.1
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dimchansky/utfbom v1.1.1 h1:vV6w1AhK4VMnhBno/TPVCoK9U/LP0PkLCS9tbxHdi/U=
+github.com/dimchansky/utfbom v1.1.1/go.mod h1:SxdoEBH5qIqFocHMyGOXVAybYJdr71b1Q/j0mACtrfE=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -19,12 +19,14 @@ import (
 
 	luar "layeh.com/gopher-luar"
 
+	"github.com/dimchansky/utfbom"
 	dmp "github.com/sergi/go-diff/diffmatchpatch"
 	"github.com/zyedidia/micro/v2/internal/config"
 	ulua "github.com/zyedidia/micro/v2/internal/lua"
 	"github.com/zyedidia/micro/v2/internal/screen"
 	"github.com/zyedidia/micro/v2/internal/util"
 	"github.com/zyedidia/micro/v2/pkg/highlight"
+	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )
@@ -354,6 +356,11 @@ func NewBuffer(r io.Reader, size int64, path string, startcursor Loc, btype BufT
 			return NewBufferFromString("", "", btype)
 		}
 		if !hasBackup {
+			var bomenc encoding.Encoding
+			if r, bomenc = skipBOM(b, r); bomenc != nil {
+				enc = bomenc
+			}
+
 			reader := bufio.NewReader(transform.NewReader(r, enc.NewDecoder()))
 
 			var ff FileFormat = FFAuto
@@ -427,6 +434,50 @@ func NewBuffer(r io.Reader, size int64, path string, startcursor Loc, btype BufT
 	OpenBuffers = append(OpenBuffers, b)
 
 	return b
+}
+
+// skipBOM returns a reader where BOM is skipped and the encoding that is
+// detected
+func skipBOM(b *Buffer, r io.Reader) (io.Reader, encoding.Encoding) {
+	var offset int64
+	seeker, _ := r.(io.Seeker)
+	if seeker != nil {
+		var err error
+		if offset, err = seeker.Seek(0, io.SeekCurrent); err != nil {
+			seeker = nil
+		}
+	}
+
+	sr, bom := utfbom.Skip(r)
+	if bom == utfbom.Unknown {
+		return sr, nil
+	} else if enc, encname := bomToEncoding(bom); enc != nil {
+		b.Settings["encoding"] = encname
+		return sr, enc
+	}
+
+	if seeker != nil {
+		if _, err := seeker.Seek(offset, io.SeekStart); err == nil {
+			return r, nil
+		}
+	}
+
+	b.Settings["fastdirty"] = true
+	b.isModified = true
+	return r, nil
+}
+
+func bomToEncoding(bom utfbom.Encoding) (encoding.Encoding, string) {
+	switch bom {
+	case utfbom.UTF8:
+		return unicode.UTF8, "utf-8-bom"
+	case utfbom.UTF16BigEndian:
+		return unicode.UTF16(unicode.BigEndian, unicode.IgnoreBOM), "utf-16be-bom"
+	case utfbom.UTF16LittleEndian:
+		return unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM), "utf-16le-bom"
+	default:
+		return nil, ""
+	}
 }
 
 // CloseOpenBuffers removes all open buffers

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -25,7 +25,6 @@ import (
 	"github.com/zyedidia/micro/v2/internal/screen"
 	"github.com/zyedidia/micro/v2/internal/util"
 	"github.com/zyedidia/micro/v2/pkg/highlight"
-	"golang.org/x/text/encoding/htmlindex"
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )
@@ -342,7 +341,7 @@ func NewBuffer(r io.Reader, size int64, path string, startcursor Loc, btype BufT
 		b.Settings["filetype"] = settings["filetype"]
 		b.Settings["syntax"] = settings["syntax"]
 
-		enc, err := htmlindex.Get(settings["encoding"].(string))
+		enc, err := util.GetEncoding(settings["encoding"].(string))
 		if err != nil {
 			enc = unicode.UTF8
 			b.Settings["encoding"] = "utf-8"
@@ -538,7 +537,7 @@ func (b *Buffer) ReOpen() error {
 		return err
 	}
 
-	enc, err := htmlindex.Get(b.Settings["encoding"].(string))
+	enc, err := util.GetEncoding(b.Settings["encoding"].(string))
 	if err != nil {
 		return err
 	}

--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -16,7 +16,6 @@ import (
 	"github.com/zyedidia/micro/v2/internal/screen"
 	"github.com/zyedidia/micro/v2/internal/util"
 	"golang.org/x/text/encoding"
-	"golang.org/x/text/encoding/htmlindex"
 	"golang.org/x/text/transform"
 )
 
@@ -174,7 +173,7 @@ func (b *Buffer) saveToFile(filename string, withSudo bool, autoSave bool) error
 
 	var fileSize int
 
-	enc, err := htmlindex.Get(b.Settings["encoding"].(string))
+	enc, err := util.GetEncoding(b.Settings["encoding"].(string))
 	if err != nil {
 		return err
 	}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -15,7 +15,6 @@ import (
 	"github.com/zyedidia/glob"
 	"github.com/zyedidia/json5"
 	"github.com/zyedidia/micro/v2/internal/util"
-	"golang.org/x/text/encoding/htmlindex"
 )
 
 type optionValidator func(string, interface{}) error
@@ -507,6 +506,6 @@ func validateColorscheme(option string, value interface{}) error {
 }
 
 func validateEncoding(option string, value interface{}) error {
-	_, err := htmlindex.Get(value.(string))
+	_, err := util.GetEncoding(value.(string))
 	return err
 }

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -20,6 +20,9 @@ import (
 
 	"github.com/blang/semver"
 	runewidth "github.com/mattn/go-runewidth"
+	"golang.org/x/text/encoding"
+	"golang.org/x/text/encoding/htmlindex"
+	tunicode "golang.org/x/text/encoding/unicode"
 )
 
 var (
@@ -503,6 +506,31 @@ func Clamp(val, min, max int) int {
 		val = max
 	}
 	return val
+}
+
+// GetEncoding returns the encoding for the given name which may end in '-bom'
+func GetEncoding(name string) (encoding.Encoding, error) {
+	withbom := strings.HasSuffix(name, "-bom")
+	if withbom {
+		name = strings.TrimSuffix(name, "-bom")
+	}
+
+	enc, err := htmlindex.Get(name)
+	if err != nil || !withbom {
+		return enc, err
+	}
+
+	n, _ := htmlindex.Name(enc)
+	switch strings.ToLower(n) {
+	case "utf-8":
+		return tunicode.UTF8BOM, nil
+	case "utf-16be":
+		return tunicode.UTF16(tunicode.BigEndian, tunicode.UseBOM), nil
+	case "utf-16le":
+		return tunicode.UTF16(tunicode.LittleEndian, tunicode.UseBOM), nil
+	default:
+		return nil, errors.New("Encoding does not support BOM")
+	}
 }
 
 // IsAutocomplete returns whether a character should begin an autocompletion.

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -127,7 +127,8 @@ Here are the available options:
     default value: `true`
 
 * `encoding`: the encoding to open and save files with. Supported encodings
-   are listed at https://www.w3.org/TR/encoding/.
+   are listed at https://www.w3.org/TR/encoding/. The name of the encoding can
+   end in `-bom` to open and save files with BOM (byte order mark).
 
     default value: `utf-8`
 

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -128,7 +128,8 @@ Here are the available options:
 
 * `encoding`: the encoding to open and save files with. Supported encodings
    are listed at https://www.w3.org/TR/encoding/. The name of the encoding can
-   end in `-bom` to open and save files with BOM (byte order mark).
+   end in `-bom` to open and save files with BOM (byte order mark). The encoding
+   will be automatically detected and set when you open a file with BOM.
 
     default value: `utf-8`
 


### PR DESCRIPTION
The characters the BOM is decoded as are not displayed and can be edited so  BOM is detected when creating a buffer in this pull request. 2 options will have to be checked if valid when set if another option is added so the `encoding` option is changed. BOM is read and written if `-bom` is included at the end of the value of `encoding`.

Setting `encoding` to UTF-32 is not supported so UTF-32 is not detected. utfbom package is added in `go.mod` and BOM is detected using utfbom. This pull request has not been tested much yet with files with BOM and no BOM but BOM is usually supported in programs where files in other encodings can be loaded.

Closes #3369