### PR TITLE
release: Use GitHub Actions for manually triggered builds and artifact uploads

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,36 @@
+name: Release builds
+on:
+  workflow_dispatch: # Allows manual trigger
+  # push:
+  #   tags:
+  #     - 'v*.*.*' # automatically react on semantic versioned tags
+jobs:
+  release:
+    strategy:
+      matrix:
+        go-version: [1.19.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Setup
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ matrix.go-version }}
+        cache: false
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
+
+    - name: Build
+      run: tools/cross-compile.sh
+
+    - name: Publish
+      uses: softprops/action-gh-release@v2
+      with:
+        files: binaries/*
+
+    - name: Cleanup
+      run: rm -rf binaries


### PR DESCRIPTION
The release will by default include the description (title and body) of the `tag` used as input (in case of a manual trigger).

This will add one more option to create the release, besides the fully manually approach where the artifacts must be build locally and uploaded afterwards. We can then just start the action with the `tag` by `Use workflow from` and the GitHub sandbox will create all artifacts and attach it to the release. No local resources are needed.

Fixes #3322