### PR TITLE
Implemented `SkipMultiCursorBack` as a counterpart to `SkipMultiCursor`

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -2064,14 +2064,16 @@ func (h *BufPane) MouseMultiCursor(e *tcell.EventMouse) bool {
 	return true
 }
 
-// SkipMultiCursor moves the current multiple cursor to the next available position
-func (h *BufPane) SkipMultiCursor() bool {
+func (h *BufPane) skipMultiCursor(forward bool) bool {
 	lastC := h.Buf.GetCursor(h.Buf.NumCursors() - 1)
 	if !lastC.HasSelection() {
 		return false
 	}
 	sel := lastC.GetSelection()
 	searchStart := lastC.CurSelection[1]
+	if !forward {
+		searchStart = lastC.CurSelection[0]
+	}
 
 	search := string(sel)
 	search = regexp.QuoteMeta(search)
@@ -2079,7 +2081,7 @@ func (h *BufPane) SkipMultiCursor() bool {
 		search = "\\b" + search + "\\b"
 	}
 
-	match, found, err := h.Buf.FindNext(search, h.Buf.Start(), h.Buf.End(), searchStart, true, true)
+	match, found, err := h.Buf.FindNext(search, h.Buf.Start(), h.Buf.End(), searchStart, forward, true)
 	if err != nil {
 		InfoBar.Error(err)
 	}
@@ -2097,6 +2099,16 @@ func (h *BufPane) SkipMultiCursor() bool {
 	}
 	h.Relocate()
 	return true
+}
+
+// SkipMultiCursor moves the current multiple cursor to the next available position
+func (h *BufPane) SkipMultiCursor() bool {
+	return h.skipMultiCursor(true)
+}
+
+// SkipMultiCursorBack moves the current multiple cursor to the previous available position
+func (h *BufPane) SkipMultiCursorBack() bool {
+	return h.skipMultiCursor(false)
 }
 
 // RemoveMultiCursor removes the latest multiple cursor

--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -841,6 +841,7 @@ var BufKeyActions = map[string]BufKeyAction{
 	"RemoveMultiCursor":         (*BufPane).RemoveMultiCursor,
 	"RemoveAllMultiCursors":     (*BufPane).RemoveAllMultiCursors,
 	"SkipMultiCursor":           (*BufPane).SkipMultiCursor,
+	"SkipMultiCursorBack":       (*BufPane).SkipMultiCursorBack,
 	"JumpToMatchingBrace":       (*BufPane).JumpToMatchingBrace,
 	"JumpLine":                  (*BufPane).JumpLine,
 	"Deselect":                  (*BufPane).Deselect,

--- a/runtime/help/keybindings.md
+++ b/runtime/help/keybindings.md
@@ -270,6 +270,7 @@ SpawnMultiCursorSelect
 RemoveMultiCursor
 RemoveAllMultiCursors
 SkipMultiCursor
+SkipMultiCursorBack
 None
 JumpToMatchingBrace
 Autocomplete


### PR DESCRIPTION
This PR adds `SkipMultiCursorBack` as a counterpart to `SkipMultiCursor`.

Since `Undo` does not reverse selections, you are somehow stuck if you have used `SkipMultiCursor` incorrectly one too many times.

The name for this new action is up for debate. Since I didn't want to change the name of `SkipMultiCursor` I could not think of something better than `SkipMultiCursorBack`.

In case changing the name of `SkipMultiCursor` is an option i would throw the following candidates into the ring:
- `SkipNextMultiCursor` and `SkipPreviousMultiCursor`
- `SkipMultiCursorForward` and `SkipMultiCursorBackward`