### PR TITLE
Fix cursor moving to an unexpected location after a redo

### DIFF
--- a/internal/buffer/eventhandler.go
+++ b/internal/buffer/eventhandler.go
@@ -293,7 +293,6 @@ func (eh *EventHandler) UndoOneEvent() {
 	// Set the cursor in the right place
 	teCursor := t.C
 	if teCursor.Num >= 0 && teCursor.Num < len(eh.cursors) {
-		t.C = *eh.cursors[teCursor.Num]
 		eh.cursors[teCursor.Num].Goto(teCursor)
 		eh.cursors[teCursor.Num].NewTrailingWsY = teCursor.NewTrailingWsY
 	} else {
@@ -338,7 +337,6 @@ func (eh *EventHandler) RedoOneEvent() {
 
 	teCursor := t.C
 	if teCursor.Num >= 0 && teCursor.Num < len(eh.cursors) {
-		t.C = *eh.cursors[teCursor.Num]
 		eh.cursors[teCursor.Num].Goto(teCursor)
 		eh.cursors[teCursor.Num].NewTrailingWsY = teCursor.NewTrailingWsY
 	} else {

--- a/internal/buffer/eventhandler.go
+++ b/internal/buffer/eventhandler.go
@@ -291,12 +291,9 @@ func (eh *EventHandler) UndoOneEvent() {
 	eh.UndoTextEvent(t)
 
 	// Set the cursor in the right place
-	teCursor := t.C
-	if teCursor.Num >= 0 && teCursor.Num < len(eh.cursors) {
-		eh.cursors[teCursor.Num].Goto(teCursor)
-		eh.cursors[teCursor.Num].NewTrailingWsY = teCursor.NewTrailingWsY
-	} else {
-		teCursor.Num = -1
+	if t.C.Num >= 0 && t.C.Num < len(eh.cursors) {
+		eh.cursors[t.C.Num].Goto(t.C)
+		eh.cursors[t.C.Num].NewTrailingWsY = t.C.NewTrailingWsY
 	}
 
 	// Push it to the redo stack
@@ -335,12 +332,9 @@ func (eh *EventHandler) RedoOneEvent() {
 		return
 	}
 
-	teCursor := t.C
-	if teCursor.Num >= 0 && teCursor.Num < len(eh.cursors) {
-		eh.cursors[teCursor.Num].Goto(teCursor)
-		eh.cursors[teCursor.Num].NewTrailingWsY = teCursor.NewTrailingWsY
-	} else {
-		teCursor.Num = -1
+	if t.C.Num >= 0 && t.C.Num < len(eh.cursors) {
+		eh.cursors[t.C.Num].Goto(t.C)
+		eh.cursors[t.C.Num].NewTrailingWsY = t.C.NewTrailingWsY
 	}
 
 	// Modifies the text event


### PR DESCRIPTION
Remember the cursor location in `TextEvent` just once - when the original text event happens, so that when we redo after an undo, the cursor is placed at the location where the actual redone modification happens (as
the user would expect), not at the location where the cursor was before the undo (which may be a completely unrelated location and may be far away).

Fixes #3411