### PR TITLE
Fixing comment plugin not using user settings when overriding default setting

### DIFF
--- a/runtime/plugins/comment/comment.lua
+++ b/runtime/plugins/comment/comment.lua
@@ -3,6 +3,7 @@ VERSION = "1.0.0"
 local util = import("micro/util")
 local config = import("micro/config")
 local buffer = import("micro/buffer")
+local micro = import("micro")
 
 local ft = {}
 
@@ -61,17 +62,21 @@ ft["zig"] = "// %s"
 ft["zscript"] = "// %s"
 ft["zsh"] = "# %s"
 
-local last_ft
-
 function updateCommentType(buf)
-    if buf.Settings["commenttype"] == nil or (last_ft ~= buf.Settings["filetype"] and last_ft ~= nil) then
-        if ft[buf.Settings["filetype"]] ~= nil then
-            buf:SetOptionNative("commenttype", ft[buf.Settings["filetype"]])
+    -- NOTE: Using DoSetOptionNative to avoid LocalSettings[option] = true
+    -- so that "comment.type" can be reset by a "filetype" change to default.
+    if (buf.Settings["comment.type"] == "") then
+        -- NOTE: This won't get triggered if a filetype is change via `setlocal filetype`
+        -- since it is not registered with `RegisterGlobalOption()``
+        if buf.Settings["commenttype"] ~= nil then
+            buf:DoSetOptionNative("comment.type", buf.Settings["commenttype"])
         else
-            buf:SetOptionNative("commenttype", "# %s")
+            if (ft[buf.Settings["filetype"]] ~= nil) then
+                buf:DoSetOptionNative("comment.type", ft[buf.Settings["filetype"]])
+            else
+                buf:DoSetOptionNative("comment.type", "# %s")
+            end
         end
-
-        last_ft = buf.Settings["filetype"]
     end
 end
 
@@ -88,7 +93,7 @@ function commentLine(bp, lineN, indentLen)
     updateCommentType(bp.Buf)
 
     local line = bp.Buf:Line(lineN)
-    local commentType = bp.Buf.Settings["commenttype"]
+    local commentType = bp.Buf.Settings["comment.type"]
     local sel = -bp.Cursor.CurSelection
     local curpos = -bp.Cursor.Loc
     local index = string.find(commentType, "%%s") - 1
@@ -114,7 +119,7 @@ function uncommentLine(bp, lineN, commentRegex)
     updateCommentType(bp.Buf)
 
     local line = bp.Buf:Line(lineN)
-    local commentType = bp.Buf.Settings["commenttype"]
+    local commentType = bp.Buf.Settings["comment.type"]
     local sel = -bp.Cursor.CurSelection
     local curpos = -bp.Cursor.Loc
     local index = string.find(commentType, "%%s") - 1
@@ -178,7 +183,7 @@ end
 function comment(bp, args)
     updateCommentType(bp.Buf)
 
-    local commentType = bp.Buf.Settings["commenttype"]
+    local commentType = bp.Buf.Settings["comment.type"]
     local commentRegex = "^%s*" .. commentType:gsub("%%","%%%%"):gsub("%$","%$"):gsub("%)","%)"):gsub("%(","%("):gsub("%?","%?"):gsub("%*", "%*"):gsub("%-", "%-"):gsub("%.", "%."):gsub("%+", "%+"):gsub("%]", "%]"):gsub("%[", "%["):gsub("%%%%s", "(.*)")
 
     if bp.Cursor:HasSelection() then
@@ -202,6 +207,10 @@ end
 
 function string.starts(String,Start)
     return string.sub(String,1,string.len(Start))==Start
+end
+
+function preinit()
+    config.RegisterCommonOption("comment", "type", "")
 end
 
 function init()

--- a/runtime/plugins/comment/help/comment.md
+++ b/runtime/plugins/comment/help/comment.md
@@ -80,10 +80,10 @@ but it is only available for certain filetypes:
 * zsh: `# %s`
 
 If your filetype is not available here, you can simply modify
-the `commenttype` option:
+the `comment.type` option:
 
 ```
-set commenttype "/* %s */"
+set comment.type "/* %s */"
 ```
 
 Or in your `settings.json`:
@@ -91,7 +91,12 @@ Or in your `settings.json`:
 ```json
 {
     "*.c": {
-        "commenttype": "/* %s */"
+        "comment.type": "/* %s */"
     }
 }
 ```
+
+`commenttype` (without the dot) is the legacy option that is
+superseded by `comment.type`. `commenttype` is still supported
+but deprecated.
+**Use `comment.type` instead.**


### PR DESCRIPTION
If you are overriding the default comment format say
(`"//%s"` instead of `"// %s"`)
```json
"*.cpp": {
    "commenttype": "//%s"
}
```

This will get ignored when switching between different file types and the default will be used again.

And also cleaned up unnecessary (and flawed) logic since we should always honor the buffer settings anyway.