### PR TITLE
Fix Ocaml syntax highlighting

### DIFF
--- a/runtime/syntax/ocaml.yaml
+++ b/runtime/syntax/ocaml.yaml
@@ -5,6 +5,7 @@ detect:
 
 rules:
     - identifier: "\\b[A-Z][0-9a-z_]{2,}\\b"
+    - functions: "\\b[A-Z][0-9a-z_]{2,}\\b"
       #declarations
     - statement: "\\b(let|val|method|in|and|rec|private|virtual|constraint)\\b"
       #structure items
@@ -17,6 +18,7 @@ rules:
     - statement: "\\b(if|then|else)\\b"
       #blocs
     - type: "\\b(begin|end|object|struct|sig|for|while|do|done|to|downto)\\b"
+    - type: "'[0-9A-Za-z_]+"
       #constantes
     - constant.bool: "\\b(true|false)\\b"
       #modules/classes
@@ -24,8 +26,8 @@ rules:
       #expr modifiers
     - special: "\\b(new|ref|mutable|lazy|assert|raise)\\b"
     - constant.string:
-        start: "'"
-        end: "'"
+        start: "'(.|\\\\(([0-7]{3}|x[A-Fa-f0-9]{2}|u[A-Fa-f0-9]{4}|U[A-Fa-f0-9]{8})|[abfnrtv'\\\"\\\\]))'"
+        end: ""
         skip: "\\\\."
         rules:
             - constant.specialChar: "%."

--- a/runtime/syntax/ocaml.yaml
+++ b/runtime/syntax/ocaml.yaml
@@ -5,7 +5,6 @@ detect:
 
 rules:
     - identifier: "\\b[A-Z][0-9a-z_]{2,}\\b"
-    - functions: "\\b[A-Z][0-9a-z_]{2,}\\b"
       #declarations
     - statement: "\\b(let|val|method|in|and|rec|private|virtual|constraint)\\b"
       #structure items

--- a/runtime/syntax/ocaml.yaml
+++ b/runtime/syntax/ocaml.yaml
@@ -24,13 +24,11 @@ rules:
     - special: "\\b(include|inherit|initializer)\\b"
       #expr modifiers
     - special: "\\b(new|ref|mutable|lazy|assert|raise)\\b"
-    - constant.string:
-        start: "'(.|\\\\(([0-7]{3}|x[A-Fa-f0-9]{2}|u[A-Fa-f0-9]{4}|U[A-Fa-f0-9]{8})|[abfnrtv'\\\"\\\\]))'"
-        end: ""
-        rules:
-            - constant.specialChar: "%."
-            - constant.specialChar: "\\\\[abfnrtv'\\\"\\\\]"
-            - constant.specialChar: "\\\\([0-7]{3}|x[A-Fa-f0-9]{2}|u[A-Fa-f0-9]{4}|U[A-Fa-f0-9]{8})"
+      #character literal
+    - constant.string: "'(\\\\[0-7]{3}|\\\\x[A-Fa-f0-9]{2}|\\\\u[A-Fa-f0-9]{4}|\\\\U[A-Fa-f0-9]{8}|\\\\[abfnrtv'\\\"\\\\]|.)'"
+    - constant.specialChar: "\\\\[abfnrtv'\\\"\\\\]"
+    - constant.specialChar: "\\\\([0-7]{3}|x[A-Fa-f0-9]{2}|u[A-Fa-f0-9]{4}|U[A-Fa-f0-9]{8})"
+      #string literal
     - constant.string:
         start: "\""
         end: "\""

--- a/runtime/syntax/ocaml.yaml
+++ b/runtime/syntax/ocaml.yaml
@@ -27,7 +27,6 @@ rules:
     - constant.string:
         start: "'(.|\\\\(([0-7]{3}|x[A-Fa-f0-9]{2}|u[A-Fa-f0-9]{4}|U[A-Fa-f0-9]{8})|[abfnrtv'\\\"\\\\]))'"
         end: ""
-        skip: "\\\\."
         rules:
             - constant.specialChar: "%."
             - constant.specialChar: "\\\\[abfnrtv'\\\"\\\\]"


### PR DESCRIPTION
Ocaml uses single-quote mark `'` for character literals, but it also uses it for generics: `'a` is a generic type but `'a'` is a character. This breaks the highlighting: 
![image](https://github.com/user-attachments/assets/60d52150-f907-45b5-b40e-cee8fb34e103)
It is probably impossible to fix properly in Micro since Go regex does not support lookarounds, so i tried my best without them:
![image](https://github.com/user-attachments/assets/918ab51c-c39c-48f4-8898-4f3810d92da2)
It works, except that escape sequences don't get highlighted inside the character literals. But it's better than the highlighting being completely broken.