### PR TITLE
Adding missing deselect when calling RemoveAllMultiCursors

### DIFF
--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -761,6 +761,7 @@ func (h *BufPane) GotoCmd(args []string) {
 	col = util.Clamp(col-1, 0, util.CharacterCount(h.Buf.LineBytes(line)))
 
 	h.RemoveAllMultiCursors()
+	h.Cursor.Deselect(true)
 	h.GotoLoc(buffer.Loc{col, line})
 }
 
@@ -779,6 +780,7 @@ func (h *BufPane) JumpCmd(args []string) {
 	col = util.Clamp(col-1, 0, util.CharacterCount(h.Buf.LineBytes(line)))
 
 	h.RemoveAllMultiCursors()
+	h.Cursor.Deselect(true)
 	h.GotoLoc(buffer.Loc{col, line})
 }
 


### PR DESCRIPTION
This adds missing deselect calls that were present previously for RemoveAllMultiCursors before PR #3352

This fixes when doing `gotocmd` or `jump` not moving the cursor when there's something selected.