### PR TITLE
syntax/json: Add comment support to the syntax highlighting

### DIFF
--- a/runtime/syntax/json.yaml
+++ b/runtime/syntax/json.yaml
@@ -30,10 +30,10 @@ rules:
         start: "//"
         end: "$"
         rules:
-            - todo: "(TODO|XXX|FIXME)"
+            - todo: "(TODO|XXX|FIXME):?"
 
     - comment:
         start: "/\\*"
         end: "\\*/"
         rules:
-            - todo: "(TODO|XXX|FIXME)"
+            - todo: "(TODO|XXX|FIXME):?"

--- a/runtime/syntax/json.yaml
+++ b/runtime/syntax/json.yaml
@@ -25,3 +25,15 @@ rules:
 
     - statement: "\\\"(\\\\\"|[^\"])*\\\"[[:space:]]*:\"  \"'(\\'|[^'])*'[[:space:]]*:"
     - constant: "\\\\u[0-9a-fA-F]{4}|\\\\[bfnrt'\"/\\\\]"
+
+    - comment:
+        start: "//"
+        end: "$"
+        rules:
+            - todo: "(TODO|XXX|FIXME)"
+
+    - comment:
+        start: "/\\*"
+        end: "\\*/"
+        rules:
+            - todo: "(TODO|XXX|FIXME)"


### PR DESCRIPTION
This feature already has a quite long story:

- https://github.com/zyedidia/micro/issues/266
- https://github.com/zyedidia/micro/issues/2701
- https://github.com/zyedidia/micro/issues/2704
- https://github.com/zyedidia/micro/pull/2736
- https://github.com/zyedidia/micro/issues/2995

Since `micro` already uses `json5` to parse his own internal `json` configurations and we changed the default behavior of the `comment` plugin to set `//` as the default comment type within `json` via https://github.com/zyedidia/micro/pull/3388 it's just a logical step to highlight it correctly in `json`'s (reused https://github.com/zyedidia/micro/pull/2736). It was and it will be up to the user if he/she places comments with `micro` in `json`, because he/she should know if the file is parsed with a `json5` parser or not.
Especially since https://github.com/zyedidia/micro/pull/3343 it's much more easy to edit `micro`'s own configurations in `micro` itself by just `reload`ing the changed files. As long as `set`, `reset`, `bind` and `unbind` (hopefully I didn't forget anything) isn't used `micro` doesn't rewrite the settings by his own and the comments are kept.

Additionally we can think about adding `hjson` (https://github.com/zyedidia/micro/pull/2203) and `jsonc` (https://github.com/zyedidia/micro/issues/2704) to the same `json` syntax definition, instead of creating new file types. The latter one is arguable, since via syntax includes it's also easy to extend/override definitions.