### PR TITLE
Allowing plugin to add cursor in custom Loc

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1955,6 +1955,14 @@ func (h *BufPane) SpawnMultiCursor() bool {
 	return true
 }
 
+// SpawnCursorAtLoc spawns a new cursor at a location and merges the cursors
+func (h *BufPane) SpawnCursorAtLoc(loc buffer.Loc) *buffer.Cursor {
+	c := buffer.NewCursor(h.Buf, loc)
+	h.Buf.AddCursor(c)
+	h.Buf.MergeCursors()
+	return c
+}
+
 // SpawnMultiCursorUpN is not an action
 func (h *BufPane) SpawnMultiCursorUpN(n int) bool {
 	lastC := h.Buf.GetCursor(h.Buf.NumCursors() - 1)


### PR DESCRIPTION
It is very difficult to add new cursor from a plugin standpoint since `NewCursor()` is not exposed.
While this can be worked around by manipulating the cursor after calling `SpawnMultiCursorDown()`, it is pretty much impossible to retain selections from previous cursors.

This PR allows the plugin to add new cursor without any limitations