### PR TITLE
tools: Revert `tgz` to `tar.gz` in `cross-compile.sh`

### DIFF
--- a/tools/cross-compile.sh
+++ b/tools/cross-compile.sh
@@ -20,8 +20,8 @@ cp assets/micro-logo-mark.svg micro-$VERSION/micro.svg
 create_artefact_generic()
 {
 	mv micro micro-$VERSION/
-	tar -czf micro-$VERSION-$1.tgz micro-$VERSION
-	sha256sum micro-$VERSION-$1.tgz > micro-$VERSION-$1.tgz.sha
+	tar -czf micro-$VERSION-$1.tar.gz micro-$VERSION
+	sha256sum micro-$VERSION-$1.tar.gz > micro-$VERSION-$1.tar.gz.sha
 	mv micro-$VERSION-$1.* binaries
 	rm micro-$VERSION/micro
 }


### PR DESCRIPTION
This issue came up with #3445 and was fixed/workarounded with benweissmann/getmic.ro#37 resp. https://github.com/benweissmann/getmic.ro/pull/37/commits/84063954d2f8fadc2fd64e7f938f05cf2881b569.
We came to the conclusion, that we should stick to the full qualified file extension `tar.gz`.

@benweissmann:
~Shall I provide the additional PR to revert the change from `tar.gz` to `tgz`?~
PR created: https://github.com/benweissmann/getmic.ro/pull/39