### PR TITLE
Makefile: Fetch tags with `--force`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ install: generate
 install-all: install
 
 fetch-tags:
-	git fetch --tags
+	git fetch --tags --force
 
 generate:
 	GOOS=$(shell go env GOHOSTOS) GOARCH=$(shell go env GOHOSTARCH) go generate ./runtime


### PR DESCRIPTION
Since the `nightly` tag continuously changes it needs to be force fetched.

Fixes #3447