### PR TITLE
Add Swift shebang to syntax

### DIFF
--- a/runtime/syntax/swift.yaml
+++ b/runtime/syntax/swift.yaml
@@ -2,6 +2,7 @@ filetype: swift
 
 detect:
     filename: "\\.swift$"
+    header: "^#!.*bin/(env +)?swift( |$)"
 
 rules:
 


### PR DESCRIPTION
The Swift compiler can be run in "interpreter" mode, so it can run Swift "scripts" if they have a proper shebang and no file extension. This PR adds a shebang detection to the `swift.yaml` syntax file so Micro can highlight Swift scripts as well.