### PR TITLE
Fix rust syntax file to recognize byte strings and c strings.

### DIFF
--- a/runtime/syntax/rust.yaml
+++ b/runtime/syntax/rust.yaml
@@ -22,29 +22,29 @@ rules:
     - type: "\\b(bool|str|isize|usize|((i|u)(8|16|32|64))|f32|f64)\\b"
 
     - constant.string:
-        start: "\""
+        start: "[bc]?\""
         end: "\""
         skip: '\\.'
         rules:
             - constant.specialChar: '\\.'
 
     - constant.string:
-        start: "r#\""
+        start: "[bc]?r#\""
         end: "\"#"
         rules: []
 
     - constant.string:
-        start: "r##\""
+        start: "[bc]?r##\""
         end: "\"##"
         rules: []
 
     - constant.string:
-        start: "r###\""
+        start: "[bc]?r###\""
         end: "\"###"
         rules: []
 
     - constant.string:
-        start: "r####+\""
+        start: "[bc]?r####+\""
         end: "\"####+"
         rules: []
 


### PR DESCRIPTION
In rust, there are some prefixes that may be part of the string literal. String literals of the form b"test" (and br##"test"## etc) are byte strings (as opposed to unicode strings), and similarly, string literals of the form c"test" are C zero-terminated strings.  Hence, added optional prefixes to each of the string regular expressions so the prefix will be recognized as part of the string.

Built and tested after fix.