### PR TITLE
Makefile: Make all builds explicitly fully static (disable CGO)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build-quick:
 	go build -trimpath -ldflags "-s -w $(GOVARS) $(ADDITIONAL_GO_LINKER_FLAGS)" ./cmd/micro
 
 build-dbg:
-	go build -trimpath -ldflags "-s -w $(ADDITIONAL_GO_LINKER_FLAGS) $(DEBUGVAR)" ./cmd/micro
+	go build -trimpath -ldflags "$(ADDITIONAL_GO_LINKER_FLAGS) $(DEBUGVAR)" ./cmd/micro
 
 build-tags: fetch-tags build
 

--- a/Makefile
+++ b/Makefile
@@ -10,16 +10,17 @@ ADDITIONAL_GO_LINKER_FLAGS = $(shell GOOS=$(shell go env GOHOSTOS) \
 	go run tools/info-plist.go "$(shell go env GOOS)" "$(VERSION)")
 GOBIN ?= $(shell go env GOPATH)/bin
 GOVARS = -X github.com/zyedidia/micro/v2/internal/util.Version=$(VERSION) -X github.com/zyedidia/micro/v2/internal/util.CommitHash=$(HASH) -X 'github.com/zyedidia/micro/v2/internal/util.CompileDate=$(DATE)'
+CGO_ENABLED := $(if $(CGO_ENABLED),$(CGO_ENABLED),0)
 DEBUGVAR = -X github.com/zyedidia/micro/v2/internal/util.Debug=ON
 VSCODE_TESTS_BASE_URL = 'https://raw.githubusercontent.com/microsoft/vscode/e6a45f4242ebddb7aa9a229f85555e8a3bd987e2/src/vs/editor/test/common/model/'
 
 build: generate build-quick
 
 build-quick:
-	go build -trimpath -ldflags "-s -w $(GOVARS) $(ADDITIONAL_GO_LINKER_FLAGS)" ./cmd/micro
+	CGO_ENABLED=$(CGO_ENABLED) go build -trimpath -ldflags "-s -w $(GOVARS) $(ADDITIONAL_GO_LINKER_FLAGS)" ./cmd/micro
 
 build-dbg:
-	go build -trimpath -ldflags "$(ADDITIONAL_GO_LINKER_FLAGS) $(DEBUGVAR)" ./cmd/micro
+	CGO_ENABLED=$(CGO_ENABLED) go build -trimpath -ldflags "$(ADDITIONAL_GO_LINKER_FLAGS) $(DEBUGVAR)" ./cmd/micro
 
 build-tags: fetch-tags build
 

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,7 @@ build-quick:
 build-dbg:
 	go build -trimpath -ldflags "-s -w $(ADDITIONAL_GO_LINKER_FLAGS) $(DEBUGVAR)" ./cmd/micro
 
-build-tags: fetch-tags generate
-	go build -trimpath -ldflags "-s -w $(GOVARS) $(ADDITIONAL_GO_LINKER_FLAGS)" ./cmd/micro
+build-tags: fetch-tags build
 
 build-all: build
 

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,21 @@ VERSION = $(shell GOOS=$(shell go env GOHOSTOS) GOARCH=$(shell go env GOHOSTARCH
 HASH = $(shell git rev-parse --short HEAD)
 DATE = $(shell GOOS=$(shell go env GOHOSTOS) GOARCH=$(shell go env GOHOSTARCH) \
 	go run tools/build-date.go)
-ADDITIONAL_GO_LINKER_FLAGS = $(shell GOOS=$(shell go env GOHOSTOS) \
-	GOARCH=$(shell go env GOHOSTARCH) \
-	go run tools/info-plist.go "$(shell go env GOOS)" "$(VERSION)")
 GOBIN ?= $(shell go env GOPATH)/bin
 GOVARS = -X github.com/zyedidia/micro/v2/internal/util.Version=$(VERSION) -X github.com/zyedidia/micro/v2/internal/util.CommitHash=$(HASH) -X 'github.com/zyedidia/micro/v2/internal/util.CompileDate=$(DATE)'
-CGO_ENABLED := $(if $(CGO_ENABLED),$(CGO_ENABLED),0)
 DEBUGVAR = -X github.com/zyedidia/micro/v2/internal/util.Debug=ON
 VSCODE_TESTS_BASE_URL = 'https://raw.githubusercontent.com/microsoft/vscode/e6a45f4242ebddb7aa9a229f85555e8a3bd987e2/src/vs/editor/test/common/model/'
+CGO_ENABLED := $(if $(CGO_ENABLED),$(CGO_ENABLED),0)
+
+ADDITIONAL_GO_LINKER_FLAGS := ""
+GOHOSTOS = $(shell go env GOHOSTOS)
+ifeq ($(GOHOSTOS), darwin)
+	# Native darwin resp. macOS builds need external and dynamic linking
+	ADDITIONAL_GO_LINKER_FLAGS += $(shell GOOS=$(GOHOSTOS) \
+		GOARCH=$(shell go env GOHOSTARCH) \
+		go run tools/info-plist.go "$(shell go env GOOS)" "$(VERSION)")
+	CGO_ENABLED = 1
+endif
 
 build: generate build-quick
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ CGO_ENABLED=1 make build
 
 Afterwards the micro binary will dynamically link with the present core system libraries.
 
+**Note for Mac:**
+Native macOS builds are done with `CGO_ENABLED=1` forced set to support adding the "Information Property List" in the linker step.
+
 ### macOS terminal
 
 If you are using macOS, you should consider using [iTerm2](http://iterm2.com/) instead of the default terminal (Terminal.app). The iTerm2 terminal has much better mouse support as well as better handling of key events. For best keybinding behavior, choose `xterm defaults` under `Preferences->Profiles->Keys->Presets...`, and select `Esc+` for `Left Option Key` in the same menu. The newest versions also support true color.

--- a/README.md
+++ b/README.md
@@ -180,15 +180,16 @@ You can install directly with `go get` (`go get github.com/zyedidia/micro/cmd/mi
 recommended because it doesn't build micro with version information (necessary for the plugin manager),
 and doesn't disable debug mode.
 
-### Fully static binary
+### Fully static or dynamically linked binary
 
-By default, the micro binary will dynamically link with core system libraries (this is generally
-recommended for security and portability). However, there is a fully static prebuilt binary that
-is provided for amd64 as `linux-static.tar.gz`, and to build a fully static binary from source, run
+By default, the micro binary is linked statically to increase the portability of the prebuilt binaries.
+This behavior can simply be overriden by providing `CGO_ENABLED=1` to the build target.
 
 ```
-CGO_ENABLED=0 make build
+CGO_ENABLED=1 make build
 ```
+
+Afterwards the micro binary will dynamically link with the present core system libraries.
 
 ### macOS terminal
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Here is a picture of micro editing its source code.
 ![Screenshot](./assets/micro-solarized.png)
 
 To see more screenshots of micro, showcasing some of the default color schemes, see [here](https://micro-editor.github.io).
- 
+
 You can also check out the website for Micro at https://micro-editor.github.io.
 
 - - -

--- a/tools/cross-compile.sh
+++ b/tools/cross-compile.sh
@@ -54,8 +54,12 @@ if ./tools/package-deb.sh $VERSION; then
 fi
 create_artefact_generic "linux64"
 
-echo "Linux 64 fully static"
-CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make build
+echo "Linux 64 fully static (same as linux64)"
+# It is kept for the next release only to support...
+# https://github.com/benweissmann/getmic.ro/blob/f90870e948afab8be9ec40884050044b59ed5b7c/index.sh#L197-L204
+# ...and allow a fluent switch via:
+# https://github.com/benweissmann/getmic.ro/pull/40
+GOOS=linux GOARCH=amd64 make build
 create_artefact_generic "linux64-static"
 
 echo "Linux 32"


### PR DESCRIPTION
Due to this the "Linux 64 fully static" has been marked deprecated and is only kept for compatibility with:
https://github.com/benweissmann/getmic.ro/blob/f90870e948afab8be9ec40884050044b59ed5b7c/index.sh#L197-L204

Fixes #3463