### PR TITLE
Fix non-working raw escape bindings after restarting the screen

### DIFF
--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -89,7 +89,7 @@ func BindKey(k, v string, bind func(e Event, a string)) {
 	}
 
 	if strings.HasPrefix(k, "\x1b") {
-		screen.Screen.RegisterRawSeq(k)
+		screen.RegisterRawSeq(k)
 	}
 
 	bind(event, v)
@@ -342,7 +342,7 @@ func UnbindKey(k string) error {
 		}
 
 		if strings.HasPrefix(k, "\x1b") {
-			screen.Screen.UnregisterRawSeq(k)
+			screen.UnregisterRawSeq(k)
 		}
 
 		defaults := DefaultBindings("buffer")

--- a/internal/screen/screen.go
+++ b/internal/screen/screen.go
@@ -33,6 +33,12 @@ var lock sync.Mutex
 // written to even if no event user event has occurred
 var drawChan chan bool
 
+// rawSeq is the list of raw escape sequences that are bound to some actions
+// via keybindings and thus should be parsed by tcell. We need to register
+// them in tcell every time we reinitialize the screen, so we need to remember
+// them in a list
+var rawSeq = make([]string, 0)
+
 // Lock locks the screen lock
 func Lock() {
 	lock.Lock()
@@ -121,6 +127,34 @@ func SetContent(x, y int, mainc rune, combc []rune, style tcell.Style) {
 	}
 }
 
+// RegisterRawSeq registers a raw escape sequence that should be parsed by tcell
+func RegisterRawSeq(r string) {
+	for _, seq := range rawSeq {
+		if seq == r {
+			return
+		}
+	}
+	rawSeq = append(rawSeq, r)
+
+	if Screen != nil {
+		Screen.RegisterRawSeq(r)
+	}
+}
+
+// UnregisterRawSeq unregisters a raw escape sequence that should be parsed by tcell
+func UnregisterRawSeq(r string) {
+	for i, seq := range rawSeq {
+		if seq == r {
+			rawSeq[i] = rawSeq[len(rawSeq)-1]
+			rawSeq = rawSeq[:len(rawSeq)-1]
+		}
+	}
+
+	if Screen != nil {
+		Screen.UnregisterRawSeq(r)
+	}
+}
+
 // TempFini shuts the screen down temporarily
 func TempFini() bool {
 	screenWasNil := Screen == nil
@@ -193,6 +227,10 @@ func Init() error {
 
 	if config.GetGlobalOption("mouse").(bool) {
 		Screen.EnableMouse()
+	}
+
+	for _, r := range rawSeq {
+		Screen.RegisterRawSeq(r)
 	}
 
 	return nil


### PR DESCRIPTION
When we temporarily disable the screen (e.g. during `RunInteractiveShell`) and then enable it again, we reinitialize `tcell.Screen` from scratch, so we need to register all previously registered raw escape sequences once again. Otherwise raw escape bindings stop working, since the list of raw escape sequences of this newly create `tcell.Screen` is empty.

Fixes #3392