### PR TITLE
Mark quick install script as third-party

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Pre-built binaries are distributed in [releases](https://github.com/zyedidia/mic
 
 To uninstall micro, simply remove the binary, and the configuration directory at `~/.config/micro`.
 
-#### Quick-install script
+#### Third-party quick-install script
 
 ```bash
 curl https://getmic.ro | bash


### PR DESCRIPTION
Minor update to README that highlights the pipe install script is provided by a third-party.