### PR TITLE
Refactor: move usage string to the constant

### DIFF
--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -29,6 +29,49 @@ import (
 	"github.com/zyedidia/tcell/v2"
 )
 
+const usage = `Usage: micro [OPTIONS] [FILE]...
+-clean
+    	Cleans the configuration directory
+-config-dir dir
+    	Specify a custom location for the configuration directory
+[FILE]:LINE:COL (if the ` + "`parsecursor`" + ` option is enabled)
++LINE:COL
+    	Specify a line and column to start the cursor at when opening a buffer
+-options
+    	Show all option help
+-debug
+    	Enable debug mode (enables logging to ./log.txt)
+-profile
+    	Enable CPU profiling (writes profile info to ./micro.prof
+    	so it can be analyzed later with "go tool pprof micro.prof")
+-version
+    	Show the version number and information
+
+Micro's plugins can be managed at the command line with the following commands.
+-plugin install [PLUGIN]...
+    	Install plugin(s)
+-plugin remove [PLUGIN]...
+    	Remove plugin(s)
+-plugin update [PLUGIN]...
+    	Update plugin(s) (if no argument is given, updates all plugins)
+-plugin search [PLUGIN]...
+    	Search for a plugin
+-plugin list
+    	List installed plugins
+-plugin available
+    	List available plugins
+
+Micro's options can also be set via command line arguments for quick
+adjustments. For real configuration, please use the settings.json
+file (see 'help options').
+
+-option value
+    	Set ` + "`option` to `value`" + ` for this session
+    	For example: ` + "`micro -syntax off file.c`" + `
+
+Use ` + "`micro -options`" + ` to see the full list of configuration options
+`
+
 var (
 	// Command line flags
 	flagVersion   = flag.Bool("version", false, "Show the version number and information")
@@ -46,45 +89,7 @@ var (
 )
 
 func InitFlags() {
-	flag.Usage = func() {
-		fmt.Println("Usage: micro [OPTIONS] [FILE]...")
-		fmt.Println("-clean")
-		fmt.Println("    \tCleans the configuration directory")
-		fmt.Println("-config-dir dir")
-		fmt.Println("    \tSpecify a custom location for the configuration directory")
-		fmt.Println("[FILE]:LINE:COL (if the `parsecursor` option is enabled)")
-		fmt.Println("+LINE:COL")
-		fmt.Println("    \tSpecify a line and column to start the cursor at when opening a buffer")
-		fmt.Println("-options")
-		fmt.Println("    \tShow all option help")
-		fmt.Println("-debug")
-		fmt.Println("    \tEnable debug mode (enables logging to ./log.txt)")
-		fmt.Println("-profile")
-		fmt.Println("    \tEnable CPU profiling (writes profile info to ./micro.prof")
-		fmt.Println("    \tso it can be analyzed later with \"go tool pprof micro.prof\")")
-		fmt.Println("-version")
-		fmt.Println("    \tShow the version number and information")
-
-		fmt.Print("\nMicro's plugins can be managed at the command line with the following commands.\n")
-		fmt.Println("-plugin install [PLUGIN]...")
-		fmt.Println("    \tInstall plugin(s)")
-		fmt.Println("-plugin remove [PLUGIN]...")
-		fmt.Println("    \tRemove plugin(s)")
-		fmt.Println("-plugin update [PLUGIN]...")
-		fmt.Println("    \tUpdate plugin(s) (if no argument is given, updates all plugins)")
-		fmt.Println("-plugin search [PLUGIN]...")
-		fmt.Println("    \tSearch for a plugin")
-		fmt.Println("-plugin list")
-		fmt.Println("    \tList installed plugins")
-		fmt.Println("-plugin available")
-		fmt.Println("    \tList available plugins")
-
-		fmt.Print("\nMicro's options can also be set via command line arguments for quick\nadjustments. For real configuration, please use the settings.json\nfile (see 'help options').\n\n")
-		fmt.Println("-option value")
-		fmt.Println("    \tSet `option` to `value` for this session")
-		fmt.Println("    \tFor example: `micro -syntax off file.c`")
-		fmt.Println("\nUse `micro -options` to see the full list of configuration options")
-	}
+	flag.Usage = func() { fmt.Print(usage) }
 
 	optionFlags = make(map[string]*string)
 


### PR DESCRIPTION
The PR moves usage string to a constant to improve readability and maintainability.

<details>
<summary>The micro's output remains the same</summary>

Before:

```sh
$ ./micro -h > before.txt
```

After this PR:
```sh
./micro -h > after.txt
```

Diff is empty:
```sh
diff before.txt after.txt
```

</details>