### PR TITLE
Remove unused internal or unexported functions

### DIFF
--- a/internal/action/infocomplete.go
+++ b/internal/action/infocomplete.go
@@ -135,15 +135,6 @@ headerLoop:
 	return chosen, suggestions
 }
 
-func contains(s []string, e string) bool {
-	for _, a := range s {
-		if a == e {
-			return true
-		}
-	}
-	return false
-}
-
 // OptionComplete autocompletes options
 func OptionComplete(b *buffer.Buffer) ([]string, []string) {
 	c := b.GetActiveCursor()

--- a/internal/buffer/line_array.go
+++ b/internal/buffer/line_array.go
@@ -285,11 +285,6 @@ func (la *LineArray) deleteLines(y1, y2 int) {
 	la.lines = la.lines[:y1+copy(la.lines[y1:], la.lines[y2+1:])]
 }
 
-// DeleteByte deletes the byte at a position
-func (la *LineArray) deleteByte(pos Loc) {
-	la.lines[pos.Y].data = la.lines[pos.Y].data[:pos.X+copy(la.lines[pos.Y].data[pos.X:], la.lines[pos.Y].data[pos.X+1:])]
-}
-
 // Substr returns the string representation between two locations
 func (la *LineArray) Substr(start, end Loc) []byte {
 	startX := runeToByteIndex(start.X, la.lines[start.Y].data)

--- a/internal/config/plugin.go
+++ b/internal/config/plugin.go
@@ -143,15 +143,3 @@ func FindPlugin(name string) *Plugin {
 	}
 	return pl
 }
-
-// FindAnyPlugin does not require the plugin to be enabled
-func FindAnyPlugin(name string) *Plugin {
-	var pl *Plugin
-	for _, p := range Plugins {
-		if p.Name == name {
-			pl = p
-			break
-		}
-	}
-	return pl
-}

--- a/internal/config/rtfiles.go
+++ b/internal/config/rtfiles.go
@@ -62,12 +62,6 @@ type realFile string
 // some asset file
 type assetFile string
 
-// some file on filesystem but with a different name
-type namedFile struct {
-	realFile
-	name string
-}
-
 // a file with the data stored in memory
 type memoryFile struct {
 	name string
@@ -97,10 +91,6 @@ func (af assetFile) Name() string {
 
 func (af assetFile) Data() ([]byte, error) {
 	return rt.Asset(string(af))
-}
-
-func (nf namedFile) Name() string {
-	return nf.name
 }
 
 // AddRuntimeFile registers a file for the given filetype

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -233,18 +233,6 @@ func IsNonWordChar(r rune) bool {
 	return !IsWordChar(r)
 }
 
-// IsUpperWordChar returns whether or not a rune is an 'upper word character'
-// Upper word characters are defined as numbers, upper-case letters or sub-word delimiters
-func IsUpperWordChar(r rune) bool {
-	return IsUpperAlphanumeric(r) || IsSubwordDelimiter(r)
-}
-
-// IsLowerWordChar returns whether or not a rune is a 'lower word character'
-// Lower word characters are defined as numbers, lower-case letters or sub-word delimiters
-func IsLowerWordChar(r rune) bool {
-	return IsLowerAlphanumeric(r) || IsSubwordDelimiter(r)
-}
-
 // IsSubwordDelimiter returns whether or not a rune is a 'sub-word delimiter character'
 // i.e. is considered a part of the word and is used as a delimiter between sub-words of the word.
 // For now the only sub-word delimiter character is '_'.
@@ -508,11 +496,6 @@ func Clamp(val, min, max int) int {
 // IsAutocomplete returns whether a character should begin an autocompletion.
 func IsAutocomplete(c rune) bool {
 	return c == '.' || IsWordChar(c)
-}
-
-// ParseSpecial replaces escaped ts with '\t'.
-func ParseSpecial(s string) string {
-	return strings.ReplaceAll(s, "\\t", "\t")
 }
 
 // String converts a byte array to a string (for lua plugins)

--- a/pkg/highlight/highlighter.go
+++ b/pkg/highlight/highlighter.go
@@ -51,19 +51,6 @@ func runePos(p int, str []byte) int {
 	return CharacterCount(str[:p])
 }
 
-func combineLineMatch(src, dst LineMatch) LineMatch {
-	for k, v := range src {
-		if g, ok := dst[k]; ok {
-			if g == 0 {
-				dst[k] = v
-			}
-		} else {
-			dst[k] = v
-		}
-	}
-	return dst
-}
-
 // A State represents the region at the end of a line
 type State *region
 


### PR DESCRIPTION
This PR removes unused internal or unexported functions reported by the [deadcode](https://go.dev/blog/deadcode) analyzer.

<details>
<summary>Details</summary>

```
❯ deadcode ./... | grep internal
internal/action/infocomplete.go:138:6: unreachable func: contains
internal/buffer/line_array.go:289:22: unreachable func: LineArray.deleteByte
internal/config/plugin.go:148:6: unreachable func: FindAnyPlugin
internal/config/rtfiles.go:102:21: unreachable func: namedFile.Name
internal/screen/screen.go:240:6: unreachable func: InitSimScreen
internal/util/profile.go:19:6: unreachable func: Tic
internal/util/profile.go:24:6: unreachable func: Toc
internal/util/util.go:238:6: unreachable func: IsUpperWordChar
internal/util/util.go:244:6: unreachable func: IsLowerWordChar
internal/util/util.go:514:6: unreachable func: ParseSpecial
```

</details>