### PR TITLE
Add truecolor option

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -123,6 +123,7 @@ var DefaultGlobalOnlySettings = map[string]interface{}{
 	"tabhighlight":   false,
 	"tabreverse":     true,
 	"xterm":          false,
+	"truecolor":      false,
 }
 
 // a list of settings that should never be globally modified

--- a/internal/screen/screen.go
+++ b/internal/screen/screen.go
@@ -184,7 +184,7 @@ func Init() error {
 	drawChan = make(chan bool, 8)
 
 	// Should we enable true color?
-	truecolor := os.Getenv("MICRO_TRUECOLOR") == "1"
+	truecolor := os.Getenv("MICRO_TRUECOLOR") == "1" || config.GetGlobalOption("truecolor").(bool)
 
 	if !truecolor {
 		os.Setenv("TCELL_TRUECOLOR", "disable")


### PR DESCRIPTION
Added a config option to enable truecolor, while still retaining backwards compatibility with the environment variable method of enabling truecolor.