### PR TITLE
Fix SIGINT killing micro when saving with sudo

### DIFF
--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -48,13 +48,13 @@ func overwriteFile(name string, enc encoding.Encoding, fn func(io.Writer) error,
 		// need to start the process now, otherwise when we flush the file
 		// contents to its stdin it might hang because the kernel's pipe size
 		// is too small to handle the full file contents all at once
-		if e := cmd.Start(); e != nil && err == nil {
+		if err = cmd.Start(); err != nil {
 			screen.TempStart(screenb)
 
 			signal.Notify(util.Sigterm, os.Interrupt)
 			signal.Stop(c)
 
-			return err
+			return
 		}
 	} else if writeCloser, err = os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666); err != nil {
 		return


### PR DESCRIPTION
When we are saving a file with sudo, if we interrupt sudo via `Ctrl-c`, it doesn't just kill sudo, it kills micro itself.

The cause is the same as the similar issue https://github.com/zyedidia/micro/issues/2612 for `RunInteractiveShell()` which was fixed by https://github.com/zyedidia/micro/pull/3357. So fix it the same way as in https://github.com/zyedidia/micro/pull/3357.

Also on top of that, fix the lack of error reporting when saving with sudo fails.