### PR TITLE
action/command: Allow `-vsplit` & `-hsplit` as optional argument for `help`

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1723,7 +1723,8 @@ func (h *BufPane) ToggleHelp() bool {
 	if h.Buf.Type == buffer.BTHelp {
 		h.Quit()
 	} else {
-		h.openHelp("help", true, false)
+		hsplit := config.GlobalSettings["helpsplit"] == "hsplit"
+		h.openHelp("help", hsplit, false)
 	}
 	return true
 }

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1723,7 +1723,7 @@ func (h *BufPane) ToggleHelp() bool {
 	if h.Buf.Type == buffer.BTHelp {
 		h.Quit()
 	} else {
-		h.openHelp("help")
+		h.openHelp("help", true, false)
 	}
 	return true
 }

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -501,7 +501,7 @@ func (h *BufPane) HelpCmd(args []string) {
 	}
 }
 
-// VSplitCmd opens a vertical split with file given in the first argument
+// VSplitCmd opens one or more vertical splits with the files given as arguments
 // If no file is given, it opens an empty buffer in a new split
 func (h *BufPane) VSplitCmd(args []string) {
 	if len(args) == 0 {
@@ -510,16 +510,18 @@ func (h *BufPane) VSplitCmd(args []string) {
 		return
 	}
 
-	buf, err := buffer.NewBufferFromFile(args[0], buffer.BTDefault)
-	if err != nil {
-		InfoBar.Error(err)
-		return
-	}
+	for _, a := range args {
+		buf, err := buffer.NewBufferFromFile(a, buffer.BTDefault)
+		if err != nil {
+			InfoBar.Error(err)
+			return
+		}
 
-	h.VSplitBuf(buf)
+		h.VSplitBuf(buf)
+	}
 }
 
-// HSplitCmd opens a horizontal split with file given in the first argument
+// HSplitCmd opens one or more horizontal splits with the files given as arguments
 // If no file is given, it opens an empty buffer in a new split
 func (h *BufPane) HSplitCmd(args []string) {
 	if len(args) == 0 {
@@ -528,13 +530,15 @@ func (h *BufPane) HSplitCmd(args []string) {
 		return
 	}
 
-	buf, err := buffer.NewBufferFromFile(args[0], buffer.BTDefault)
-	if err != nil {
-		InfoBar.Error(err)
-		return
-	}
+	for _, a := range args {
+		buf, err := buffer.NewBufferFromFile(a, buffer.BTDefault)
+		if err != nil {
+			InfoBar.Error(err)
+			return
+		}
 
-	h.HSplitBuf(buf)
+		h.HSplitBuf(buf)
+	}
 }
 
 // EvalCmd evaluates a lua expression

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -488,13 +488,15 @@ func (h *BufPane) HelpCmd(args []string) {
 			forceSplit = true
 		}
 
-		if config.FindRuntimeFile(config.RTHelp, topics[0]) != nil {
-			err := h.openHelp(topics[0], hsplit, forceSplit)
-			if err != nil {
-				InfoBar.Error(err)
+		for _, topic := range topics {
+			if config.FindRuntimeFile(config.RTHelp, topic) != nil {
+				err := h.openHelp(topic, hsplit, forceSplit)
+				if err != nil {
+					InfoBar.Error(err)
+				}
+			} else {
+				InfoBar.Error("Sorry, no help for ", topic)
 			}
-		} else {
-			InfoBar.Error("Sorry, no help for ", topics[0])
 		}
 	}
 }

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -546,7 +546,8 @@ func (h *BufPane) EvalCmd(args []string) {
 	InfoBar.Error("Eval unsupported")
 }
 
-// NewTabCmd opens the given file in a new tab
+// NewTabCmd opens one or more tabs with the files given as arguments
+// If no file is given, it opens an empty buffer in a new tab
 func (h *BufPane) NewTabCmd(args []string) {
 	width, height := screen.Screen.Size()
 	iOffset := config.GetInfoBarOffset()

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -448,7 +448,10 @@ func (h *BufPane) openHelp(page string, hsplit bool, forceSplit bool) error {
 	return nil
 }
 
-// HelpCmd tries to open the given help page in a horizontal split
+// HelpCmd tries to open the given help page according to the split type
+// configured with the "helpsplit" option. It can be overriden by the optional
+// arguments "-vpslit" or "-hsplit". In case more than one help page is given
+// as argument then it opens all of them with the defined split type.
 func (h *BufPane) HelpCmd(args []string) {
 	hsplit := config.GlobalSettings["helpsplit"] == "hsplit"
 	if len(args) < 1 {

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -450,12 +450,12 @@ func (h *BufPane) openHelp(page string, hsplit bool, forceSplit bool) error {
 
 // HelpCmd tries to open the given help page in a horizontal split
 func (h *BufPane) HelpCmd(args []string) {
+	hsplit := config.GlobalSettings["helpsplit"] == "hsplit"
 	if len(args) < 1 {
 		// Open the default help if the user just typed "> help"
-		h.openHelp("help", true, false)
+		h.openHelp("help", hsplit, false)
 	} else {
 		var topics []string
-		hsplit := true
 		forceSplit := false
 		const errSplit = "hsplit and vsplit are not allowed at the same time"
 		for _, arg := range args {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -29,6 +29,7 @@ var optionValidators = map[string]optionValidator{
 	"detectlimit":     validateNonNegativeValue,
 	"encoding":        validateEncoding,
 	"fileformat":      validateChoice,
+	"helpsplit":       validateChoice,
 	"matchbracestyle": validateChoice,
 	"multiopen":       validateChoice,
 	"reload":          validateChoice,
@@ -41,6 +42,7 @@ var optionValidators = map[string]optionValidator{
 var OptionChoices = map[string][]string{
 	"clipboard":       {"internal", "external", "terminal"},
 	"fileformat":      {"unix", "dos"},
+	"helpsplit":       {"hsplit", "vsplit"},
 	"matchbracestyle": {"underline", "highlight"},
 	"multiopen":       {"tab", "hsplit", "vsplit"},
 	"reload":          {"prompt", "auto", "disabled"},
@@ -109,6 +111,7 @@ var DefaultGlobalOnlySettings = map[string]interface{}{
 	"divchars":       "|-",
 	"divreverse":     true,
 	"fakecursor":     false,
+	"helpsplit":      "hsplit",
 	"infobar":        true,
 	"keymenu":        false,
 	"mouse":          true,

--- a/runtime/help/commands.md
+++ b/runtime/help/commands.md
@@ -82,7 +82,9 @@ quotes here but these are not necessary when entering the command in micro.
 * `hsplit ['filename']`: same as `vsplit` but opens a horizontal split instead
    of a vertical split.
 
-* `tab ['filename']`: opens the given file in a new tab.
+* `tab ['filename']`: opens the given file in a new tab. If no filename
+   is provided, a tab is opened with an empty buffer. If multiple files are
+   provided (separated via ` `) they are opened all as tabs.
 
 * `tabmove '[-+]n'`: Moves the active tab to another slot. `n` is an integer.
    If `n` is prefixed with `-` or `+`, then it represents a relative position

--- a/runtime/help/commands.md
+++ b/runtime/help/commands.md
@@ -21,10 +21,13 @@ quotes here but these are not necessary when entering the command in micro.
    This command will modify `bindings.json` and overwrite any bindings to
    `key` that already exist.
 
-* `help ['topic']`: opens the corresponding help topic. If no topic is provided
-   opens the default help screen. Help topics are stored as `.md` files in the
-   `runtime/help` directory of the source tree, which is embedded in the final
-   binary.
+* `help ['topic'] ['flags']`: opens the corresponding help topic.
+   If no topic is provided opens the default help screen.
+   Help topics are stored as `.md` files in the `runtime/help` directory of
+   the source tree, which is embedded in the final binary.
+   The `flags` are optional.
+   * `-hsplit`: Opens the help topic in a horizontal split (default for initial split)
+   * `-vsplit`: Opens the help topic in a vertical split
 
 * `save ['filename']`: saves the current buffer. If the file is provided it
    will 'save as' the filename.

--- a/runtime/help/commands.md
+++ b/runtime/help/commands.md
@@ -76,7 +76,8 @@ quotes here but these are not necessary when entering the command in micro.
    command's output will be displayed in one line when it finishes running.
 
 * `vsplit ['filename']`: opens a vertical split with `filename`. If no filename
-   is provided, a vertical split is opened with an empty buffer.
+   is provided, a vertical split is opened with an empty buffer. If multiple
+   files are provided (separated via ` `) they are opened all as splits.
 
 * `hsplit ['filename']`: same as `vsplit` but opens a horizontal split instead
    of a vertical split.

--- a/runtime/help/commands.md
+++ b/runtime/help/commands.md
@@ -27,8 +27,10 @@ quotes here but these are not necessary when entering the command in micro.
    Help topics are stored as `.md` files in the `runtime/help` directory of
    the source tree, which is embedded in the final binary.
    The `flags` are optional.
-   * `-hsplit`: Opens the help topic in a horizontal split (default for initial split)
+   * `-hsplit`: Opens the help topic in a horizontal split
    * `-vsplit`: Opens the help topic in a vertical split
+
+   The default split type is defined by the global `helpsplit` option.
 
 * `save ['filename']`: saves the current buffer. If the file is provided it
    will 'save as' the filename.

--- a/runtime/help/commands.md
+++ b/runtime/help/commands.md
@@ -21,8 +21,9 @@ quotes here but these are not necessary when entering the command in micro.
    This command will modify `bindings.json` and overwrite any bindings to
    `key` that already exist.
 
-* `help ['topic'] ['flags']`: opens the corresponding help topic.
-   If no topic is provided opens the default help screen.
+* `help ['topic'] ['flags']`: opens the corresponding help topics.
+   If no topic is provided opens the default help screen. If multiple topics are
+   provided (separated via ` `) they are opened all as splits.
    Help topics are stored as `.md` files in the `runtime/help` directory of
    the source tree, which is embedded in the final binary.
    The `flags` are optional.

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -172,6 +172,13 @@ Here are the available options:
     default value: `unknown`. This will be automatically overridden depending
     on the file you open.
 
+* `helpsplit`: sets the split type to be used by the `help` command.
+   Possible values:
+    * `vsplit`: open help in a vertical split pane
+    * `hsplit`: open help in a horizontal split pane
+
+    default value: `hsplit`
+
 * `hlsearch`: highlight all instances of the searched text after a successful
    search. This highlighting can be temporarily turned off via the
    `UnhighlightSearch` action (triggered by the Esc key by default) or toggled


### PR DESCRIPTION
Additionally the `help`, `vsplit` and `hsplit` command can now open multiple files like the `tab` command.

Closes #3497