### PR TITLE
Revert `SpawnMultiCursor{Up,Down}` honoring softwrap + overhaul `LastVisualX` usage

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -2060,37 +2060,20 @@ func (h *BufPane) SpawnCursorAtLoc(loc buffer.Loc) *buffer.Cursor {
 // SpawnMultiCursorUpN is not an action
 func (h *BufPane) SpawnMultiCursorUpN(n int) bool {
 	lastC := h.Buf.GetCursor(h.Buf.NumCursors() - 1)
-	var c *buffer.Cursor
-	if !h.Buf.Settings["softwrap"].(bool) {
-		if n > 0 && lastC.Y == 0 {
-			return false
-		}
-		if n < 0 && lastC.Y+1 == h.Buf.LinesNum() {
-			return false
-		}
-
-		h.Buf.DeselectCursors()
-
-		c = buffer.NewCursor(h.Buf, buffer.Loc{lastC.X, lastC.Y - n})
-		c.LastVisualX = lastC.LastVisualX
-		c.LastWrappedVisualX = lastC.LastWrappedVisualX
-		c.X = c.GetCharPosInLine(h.Buf.LineBytes(c.Y), c.LastVisualX)
-		c.Relocate()
-	} else {
-		vloc := h.VLocFromLoc(lastC.Loc)
-		sloc := h.Scroll(vloc.SLoc, -n)
-		if sloc == vloc.SLoc {
-			return false
-		}
-
-		h.Buf.DeselectCursors()
-
-		vloc.SLoc = sloc
-		vloc.VisualX = lastC.LastWrappedVisualX
-		c = buffer.NewCursor(h.Buf, h.LocFromVLoc(vloc))
-		c.LastVisualX = lastC.LastVisualX
-		c.LastWrappedVisualX = lastC.LastWrappedVisualX
+	if n > 0 && lastC.Y == 0 {
+		return false
 	}
+	if n < 0 && lastC.Y+1 == h.Buf.LinesNum() {
+		return false
+	}
+
+	h.Buf.DeselectCursors()
+
+	c := buffer.NewCursor(h.Buf, buffer.Loc{lastC.X, lastC.Y - n})
+	c.LastVisualX = lastC.LastVisualX
+	c.LastWrappedVisualX = lastC.LastWrappedVisualX
+	c.X = c.GetCharPosInLine(h.Buf.LineBytes(c.Y), c.LastVisualX)
+	c.Relocate()
 
 	h.Buf.AddCursor(c)
 	h.Buf.SetCurCursor(h.Buf.NumCursors() - 1)

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -657,7 +657,7 @@ func (h *BufPane) InsertNewline() bool {
 			h.Buf.Remove(buffer.Loc{X: 0, Y: h.Cursor.Y - 1}, buffer.Loc{X: util.CharacterCount(line), Y: h.Cursor.Y - 1})
 		}
 	}
-	h.Cursor.LastVisualX = h.Cursor.GetVisualX()
+	h.Cursor.StoreVisualX()
 	h.Relocate()
 	return true
 }
@@ -687,7 +687,7 @@ func (h *BufPane) Backspace() bool {
 			h.Buf.Remove(loc.Move(-1, h.Buf), loc)
 		}
 	}
-	h.Cursor.LastVisualX = h.Cursor.GetVisualX()
+	h.Cursor.StoreVisualX()
 	h.Relocate()
 	return true
 }

--- a/internal/buffer/cursor.go
+++ b/internal/buffer/cursor.go
@@ -67,8 +67,9 @@ func (c *Cursor) Buf() *Buffer {
 // Goto puts the cursor at the given cursor's location and gives
 // the current cursor its selection too
 func (c *Cursor) Goto(b Cursor) {
-	c.X, c.Y, c.LastVisualX, c.LastWrappedVisualX = b.X, b.Y, b.LastVisualX, b.LastWrappedVisualX
+	c.X, c.Y = b.X, b.Y
 	c.OrigSelection, c.CurSelection = b.OrigSelection, b.CurSelection
+	c.StoreVisualX()
 }
 
 // GotoLoc puts the cursor at the given cursor's location and gives

--- a/internal/buffer/cursor.go
+++ b/internal/buffer/cursor.go
@@ -100,7 +100,7 @@ func (c *Cursor) GetCharPosInLine(b []byte, visualPos int) int {
 // Start moves the cursor to the start of the line it is on
 func (c *Cursor) Start() {
 	c.X = 0
-	c.LastVisualX = c.GetVisualX()
+	c.StoreVisualX()
 }
 
 // StartOfText moves the cursor to the first non-whitespace rune of
@@ -131,7 +131,7 @@ func (c *Cursor) IsStartOfText() bool {
 // End moves the cursor to the end of the line it is on
 func (c *Cursor) End() {
 	c.X = util.CharacterCount(c.buf.LineBytes(c.Y))
-	c.LastVisualX = c.GetVisualX()
+	c.StoreVisualX()
 }
 
 // CopySelection copies the user's selection to either "primary"

--- a/internal/buffer/eventhandler.go
+++ b/internal/buffer/eventhandler.go
@@ -104,7 +104,7 @@ func (eh *EventHandler) DoTextEvent(t *TextEvent, useUndo bool) {
 		c.OrigSelection[0] = move(c.OrigSelection[0])
 		c.OrigSelection[1] = move(c.OrigSelection[1])
 		c.Relocate()
-		c.LastVisualX = c.GetVisualX()
+		c.StoreVisualX()
 	}
 
 	if useUndo {

--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -58,7 +58,7 @@ func (w *BufWindow) SetBuffer(b *buffer.Buffer) {
 		if option == "softwrap" || option == "wordwrap" {
 			w.Relocate()
 			for _, c := range w.Buf.GetCursors() {
-				c.LastVisualX = c.GetVisualX()
+				c.LastWrappedVisualX = c.GetVisualX(true)
 			}
 		}
 	}
@@ -160,7 +160,7 @@ func (w *BufWindow) updateDisplayInfo() {
 
 	if w.bufWidth != prevBufWidth && w.Buf.Settings["softwrap"].(bool) {
 		for _, c := range w.Buf.GetCursors() {
-			c.LastVisualX = c.GetVisualX()
+			c.LastWrappedVisualX = c.GetVisualX(true)
 		}
 	}
 }
@@ -238,7 +238,7 @@ func (w *BufWindow) Relocate() bool {
 
 	// horizontal relocation (scrolling)
 	if !b.Settings["softwrap"].(bool) {
-		cx := activeC.GetVisualX()
+		cx := activeC.GetVisualX(false)
 		rw := runewidth.RuneWidth(activeC.RuneUnder(activeC.X))
 		if rw == 0 {
 			rw = 1 // tab or newline

--- a/runtime/plugins/comment/comment.lua
+++ b/runtime/plugins/comment/comment.lua
@@ -107,7 +107,7 @@ function commentLine(bp, lineN, indentLen)
         bp.Cursor.Y = curpos.Y
     end
     bp.Cursor:Relocate()
-    bp.Cursor.LastVisualX = bp.Cursor:GetVisualX()
+    bp.Cursor:StoreVisualX()
 end
 
 function uncommentLine(bp, lineN, commentRegex)
@@ -135,7 +135,7 @@ function uncommentLine(bp, lineN, commentRegex)
         end
     end
     bp.Cursor:Relocate()
-    bp.Cursor.LastVisualX = bp.Cursor:GetVisualX()
+    bp.Cursor:StoreVisualX()
 end
 
 function toggleCommentLine(bp, lineN, commentRegex)

--- a/runtime/plugins/status/status.lua
+++ b/runtime/plugins/status/status.lua
@@ -21,7 +21,7 @@ function lines(b)
 end
 
 function vcol(b)
-    return tostring(b:GetActiveCursor():GetVisualX())
+    return tostring(b:GetActiveCursor():GetVisualX(false))
 end
 
 function bytes(b)


### PR DESCRIPTION
In #3145, namely in https://github.com/zyedidia/micro/pull/3145/commits/9f36c575f4c6352da798c7517545cad831996a43, we changed the behavior of `SpawnMultiCursor{Up,Down}` to spawn cursor in the next visual line within a wrapped line when softwrap is enabled. That was done for "consistency" with cursor movements (`Cursor{Up,Down}` etc). However it seems there are no actual use cases for that. Whereas at least some users (see issue #3499) prefer to spawn cursor in the next logical line, regardless of the softwrap setting.

So restore the old behavior.

In the future we may also consider adding actions like `CursorUpLogical`, `CursorDownLogical` etc, for moving cursor by logical lines even if softwrap is enabled, if there are users that want it. For now let's just fix multicursor spawning.

...That is just a part of the story. Simply reverting https://github.com/zyedidia/micro/pull/3145/commits/9f36c575f4c6352da798c7517545cad831996a43 is not enough, since it would make `SpawnMultiCursor{Up,Down}` broken, due to another change from #3145, namely https://github.com/zyedidia/micro/pull/3145/commits/93b53267c5f747c51efe54c12f8c46b43ab309f9, due to the fact that `LastVisualX` currently assumes visual lines, not logical lines, so mixing logical lines usage with `LastVisualX` usage would cause `SpawnMultiCursor{Up,Down}` spawn cursors at unexpected locations in some cases.

The easy way would be to revert https://github.com/zyedidia/micro/pull/3145/commits/93b53267c5f747c51efe54c12f8c46b43ab309f9 as well, but that means bringing back the issues fixed by https://github.com/zyedidia/micro/pull/3145/commits/93b53267c5f747c51efe54c12f8c46b43ab309f9, which would be unfortunate.

So instead rework `LastVisualX` and `GetVisualX()` usage: restore the original semantics of `LastVisualX` that it used to have long ago, before #2076: last visual x cursor location in a logical line, not in a visual line. And add a separate `LastWrappedVisualX` field for last visual x cursor location in a visual line. So we can track last x position at the same time for both cases when we care about softwrap (e.g. cursor movements) and when we don't care about it (e.g. for spawning multicursors, in order to fix #3499, and possibly in the future for `Cursor{Up,Down}Logical` etc).

Also this fixes a minor bug: in InsertTab(), when `tabstospaces` is enabled and we insert a tab, the amount of inserted spaces depends on the visual line wrapping (i.e. on the window width), which is probably not a good idea.

Fixes #3499