### PR TITLE
Add target for Windows ARM64 in cross-compile.sh

### DIFF
--- a/tools/cross-compile.sh
+++ b/tools/cross-compile.sh
@@ -106,7 +106,7 @@ echo "Windows 64"
 GOOS=windows GOARCH=amd64 make build
 create_artefact_windows "win64"
 
-echo "Windows ARM64"
+echo "Windows ARM 64"
 GOOS=windows GOARCH=arm64 make build
 create_artefact_windows "win-arm64"
 

--- a/tools/cross-compile.sh
+++ b/tools/cross-compile.sh
@@ -106,6 +106,10 @@ echo "Windows 64"
 GOOS=windows GOARCH=amd64 make build
 create_artefact_windows "win64"
 
+echo "Windows ARM64"
+GOOS=windows GOARCH=arm64 make build
+create_artefact_windows "win-arm64"
+
 echo "Windows 32"
 GOOS=windows GOARCH=386 make build
 create_artefact_windows "win32"


### PR DESCRIPTION
It seems other scripts in `tools` folder isn't being used by GitHub Workflow, hence, leaving them alone.
You can check my builds using GitHub Workflow and building natively in my [repo](https://github.com/creeperlv/micro-woa). They work on my Windows on Arm computers.