### PR TITLE
Fix regression in CopyLine, CutLine, DeleteLine for last line

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1300,7 +1300,13 @@ func (h *BufPane) selectLines() int {
 	} else {
 		h.Cursor.SelectLine()
 	}
-	return h.Cursor.CurSelection[1].Y - h.Cursor.CurSelection[0].Y
+
+	nlines := h.Cursor.CurSelection[1].Y - h.Cursor.CurSelection[0].Y
+	if nlines == 0 && h.Cursor.HasSelection() {
+		// selected last line and it is not empty
+		nlines++
+	}
+	return nlines
 }
 
 // Copy the selection to the system clipboard


### PR DESCRIPTION
Fix regression introduced in commit fdacb289624a ("CopyLine, CutLine, DeleteLine: respect selection"): when `CopyLine`, `CutLine` or `DeleteLine` is done in the last line of the buffer and this line is not empty, this line gets selected but does not get copied/cut/deleted (and worse, it remains selected).

Reported by @niten94 in https://github.com/zyedidia/micro/pull/3335#issuecomment-2434328231