### PR TITLE
Added support for the 'var' keyword in Java

### DIFF
--- a/runtime/syntax/java.yaml
+++ b/runtime/syntax/java.yaml
@@ -4,7 +4,7 @@ detect:
     filename: "\\.java$"
 
 rules:
-    - type: "\\b(boolean|byte|char|double|float|int|long|new|short|this|transient|void)\\b"
+    - type: "\\b(boolean|byte|char|double|float|int|long|new|var|short|this|transient|void)\\b"
     - statement: "\\b(break|case|catch|continue|default|do|else|finally|for|if|return|switch|throw|try|while)\\b"
     - type: "\\b(abstract|class|extends|final|implements|import|instanceof|interface|native|package|private|protected|public|static|strictfp|super|synchronized|throws|volatile)\\b"
     - constant: "\\b(true|false|null)\\b"


### PR DESCRIPTION
The var keyword was unsupported, but should now be supported through updates in the YAML file.