### PR TITLE
Add .cjs (common javascript) to javascript syntax definition

### DIFF
--- a/runtime/syntax/javascript.yaml
+++ b/runtime/syntax/javascript.yaml
@@ -1,7 +1,7 @@
 filetype: javascript
 
 detect:
-    filename: "(\\.js$|\\.es[5678]?$|\\.mjs$)"
+    filename: "(\\.(m|c)?js$|\\.es[5678]?$)"
     header: "^#!.*/(env +)?node( |$)"
 
 rules:


### PR DESCRIPTION
Closes #3521