### PR TITLE
actions: Perform `Cursor(Page)Down` with selection like GUI editors do

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -256,9 +256,10 @@ func (h *BufPane) CursorUp() bool {
 func (h *BufPane) CursorDown() bool {
 	selectionEndNewline := h.Cursor.HasSelection() && h.Cursor.CurSelection[1].X == 0
 	h.Cursor.Deselect(false)
-	h.MoveCursorDown(1)
 	if selectionEndNewline {
 		h.Cursor.Start()
+	} else {
+		h.MoveCursorDown(1)
 	}
 	h.Relocate()
 	return true
@@ -1739,6 +1740,9 @@ func (h *BufPane) CursorPageDown() bool {
 	h.Cursor.Deselect(false)
 	pageOverlap := int(h.Buf.Settings["pageoverlap"].(float64))
 	scrollAmount := h.BufView().Height - pageOverlap
+	if selectionEndNewline {
+		scrollAmount--
+	}
 	h.MoveCursorDown(scrollAmount)
 	if h.Cursor.Num == 0 {
 		h.ScrollDown(scrollAmount)

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -254,8 +254,12 @@ func (h *BufPane) CursorUp() bool {
 
 // CursorDown moves the cursor down
 func (h *BufPane) CursorDown() bool {
+	selectionEndNewline := h.Cursor.HasSelection() && h.Cursor.CurSelection[1].X == 0
 	h.Cursor.Deselect(false)
 	h.MoveCursorDown(1)
+	if selectionEndNewline {
+		h.Cursor.Start()
+	}
 	h.Relocate()
 	return true
 }
@@ -1732,6 +1736,7 @@ func (h *BufPane) CursorPageUp() bool {
 // CursorPageDown places the cursor a page down,
 // moving the view to keep cursor at the same relative position in the view
 func (h *BufPane) CursorPageDown() bool {
+	selectionEndNewline := h.Cursor.HasSelection() && h.Cursor.CurSelection[1].X == 0
 	h.Cursor.Deselect(false)
 	pageOverlap := int(h.Buf.Settings["pageoverlap"].(float64))
 	scrollAmount := h.BufView().Height - pageOverlap
@@ -1739,6 +1744,9 @@ func (h *BufPane) CursorPageDown() bool {
 	if h.Cursor.Num == 0 {
 		h.ScrollDown(scrollAmount)
 		h.ScrollAdjust()
+	}
+	if selectionEndNewline {
+		h.Cursor.Start()
 	}
 	h.Relocate()
 	return true

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -293,7 +293,6 @@ func (h *BufPane) CursorLeft() bool {
 func (h *BufPane) CursorRight() bool {
 	if h.Cursor.HasSelection() {
 		h.Cursor.Deselect(false)
-		h.Cursor.Right()
 	} else {
 		tabstospaces := h.Buf.Settings["tabstospaces"].(bool)
 		tabmovement := h.Buf.Settings["tabmovement"].(bool)

--- a/internal/buffer/cursor.go
+++ b/internal/buffer/cursor.go
@@ -193,7 +193,7 @@ func (c *Cursor) Deselect(start bool) {
 		if start {
 			c.Loc = c.CurSelection[0]
 		} else {
-			c.Loc = c.CurSelection[1].Move(-1, c.buf)
+			c.Loc = c.CurSelection[1]
 		}
 		c.ResetSelection()
 		c.StoreVisualX()

--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -449,7 +449,7 @@ func (w *BufWindow) displayBuffer() {
 
 		currentLine := false
 		for _, c := range cursors {
-			if bloc.Y == c.Y && w.active {
+			if !c.HasSelection() && bloc.Y == c.Y && w.active {
 				currentLine = true
 				break
 			}


### PR DESCRIPTION
#3091 introduced a small regression in case the actual selection included the new line character, which was ignored on `CursorDown`.
This PR shall fix this by moving the cursor to the start of the line.

Fixes #3476