### PR TITLE
Add KDL syntax highlighting

### DIFF
--- a/runtime/kdl.yaml
+++ b/runtime/kdl.yaml
@@ -1,0 +1,64 @@
+filetype: 'kdl'
+
+detect:
+  filename: "\\.kdl"
+
+rules:
+  # Punctuation
+  - symbol.operator: '='
+  - symbol.brackets: '[{}]'
+  # Strings
+  - constant.string:
+      start: '"'
+      end: '"'
+      skip: '(\\\\\|\\")'
+      rules:
+        - constant.specialChar: '\\u[[:xdigit:]]{1,6}'
+        - constant.specialChar: '\\[btnfr"\\]'
+  # Raw Strings
+  # These definitions are not correct, ideally `#` should be same count for both begin and end, but it should be programmable as captured \1
+  # In my understanding, this is a micro editor restriction. See https://github.com/zyedidia/micro/blob/21bb61c5ff3cd4cd11adbd521657df90d50f54c7/runtime/syntax/jsonnet.yaml#L61-L78
+  # So, I defined some typical cases here, supporting only for 0-3 "#"
+  - constant.string:
+      start: '\br"'
+      end: '"'
+      rules: []
+  - constant.string:
+      start: '\br#"'
+      end: '"#'
+      rules: []
+  - constant.string:
+      start: '\br##"'
+      end: '"##'
+      rules: []
+  - constant.string:
+      start: '\br###"'
+      end: '"###'
+      rules: []
+  # Integer
+  - constant.number: '[-+]?(\d+)'
+  # Float
+  - constant.number: '[-+]?(\d+)\.\d*'
+  # Boolean and inf, nan without sign
+  - constant.bool.true: '\btrue\b'
+  - constant.bool.false: '\bfalse\b'
+  # Comments
+  - comment:
+      start: '//'
+      end: '$'
+      rules:
+        - todo: '(TODO|FIXME|XXX|NOTE)'
+  # Slashdash comments
+  # https://github.com/kdl-org/kdl/blob/de1dbd2c330c9193b836499db241787484627c3b/SPEC.md#L77-L79
+  # vscode extension realizes this with lookahead and lookbehind, the regex feature cannot be used in micro
+  # https://github.com/kdl-org/vscode-kdl/blob/646d7b819d72b2f0d9dd05102a305506bafa3cf6/syntaxes/kdl.tmLanguage.json#L182-L199
+  # https://github.com/zyedidia/micro/issues/901#issuecomment-354931928
+  # So simplified it, it means this is inaccurate
+  - comment.block:
+      start: '^\s*/-'
+      end: '\s'
+      rules: []
+  - comment.block:
+      start: '/-{'
+      end: '}'
+      rules: []


### PR DESCRIPTION
[zellij](https://github.com/zellij-org/zellij) is using [KDL](https://github.com/kdl-org/kdl) for the config file.

How about adding the definition here?
I've been using this file these days, and it seems to be working at least in my use.
This PR is just based on https://github.com/kachick/micro-kdl, intentionally keeping the comments.
I can remove or revise them if necessary.

Should I send a PR to https://github.com/micro-editor/plugin-channel first?