### PR TITLE
avoid creating `nil` callback for `JobSpawn`

### DIFF
--- a/internal/shell/job.go
+++ b/internal/shell/job.go
@@ -78,8 +78,10 @@ func JobSpawn(cmdName string, cmdArgs []string, onStdout, onStderr, onExit func(
 	go func() {
 		// Run the process in the background and create the onExit callback
 		proc.Run()
-		jobFunc := JobFunction{onExit, outbuf.String(), userargs}
-		Jobs <- jobFunc
+		if onExit != nil {
+			jobFunc := JobFunction{onExit, outbuf.String(), userargs}
+			Jobs <- jobFunc
+		}
 	}()
 
 	return &Job{proc, stdin}


### PR DESCRIPTION
If a program started with `shell.JobSpawn` terminates and no callback is set, then micro crashes. For example, if I call the Lua function
```
function jobspawn(bp)
    shell.JobSpawn("xclock", {}, nil, nil, nil)
end
```
and close the `xclock` window, then I get ((on Ubuntu, with master) :
```
Micro encountered an error: runtime.errorString runtime error: invalid memory address or nil pointer dereference
runtime/panic.go:220 (0x44af36)
runtime/panic.go:219 (0x44af06)
github.com/zyedidia/micro/v2/cmd/micro/micro.go:423 (0x8de2b5)
github.com/zyedidia/micro/v2/cmd/micro/micro.go:400 (0x8dde97)
runtime/proc.go:250 (0x4373d2)
runtime/asm_amd64.s:1571 (0x465f21)
 
If you can reproduce this error, please report it at https://github.com/zyedidia/micro/issues
```
This PR fixes this bug.