### PR TITLE
Replace deprecated ioutil with io and os

### DIFF
--- a/cmd/micro/clean.go
+++ b/cmd/micro/clean.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/gob"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -85,7 +84,7 @@ func CleanConfig() {
 	}
 
 	// detect incorrectly formatted buffer/ files
-	files, err := ioutil.ReadDir(filepath.Join(config.ConfigDir, "buffers"))
+	files, err := os.ReadDir(filepath.Join(config.ConfigDir, "buffers"))
 	if err == nil {
 		var badFiles []string
 		var buffer buffer.SerializedBuffer

--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/signal"
@@ -209,7 +208,7 @@ func LoadInput(args []string) []*buffer.Buffer {
 		// Option 2
 		// The input is not a terminal, so something is being piped in
 		// and we should read from stdin
-		input, err = ioutil.ReadAll(os.Stdin)
+		input, err = io.ReadAll(os.Stdin)
 		if err != nil {
 			screen.TermMessage("Error reading from stdin: ", err)
 			input = []byte{}

--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -25,7 +24,7 @@ var Binder = map[string]func(e Event, action string){
 
 func createBindingsIfNotExist(fname string) {
 	if _, e := os.Stat(fname); os.IsNotExist(e) {
-		ioutil.WriteFile(fname, []byte("{}"), 0644)
+		os.WriteFile(fname, []byte("{}"), 0644)
 	}
 }
 
@@ -37,7 +36,7 @@ func InitBindings() {
 	createBindingsIfNotExist(filename)
 
 	if _, e := os.Stat(filename); e == nil {
-		input, err := ioutil.ReadFile(filename)
+		input, err := os.ReadFile(filename)
 		if err != nil {
 			screen.TermMessage("Error reading bindings.json file: " + err.Error())
 			return
@@ -265,7 +264,7 @@ func TryBindKey(k, v string, overwrite bool) (bool, error) {
 	filename := filepath.Join(config.ConfigDir, "bindings.json")
 	createBindingsIfNotExist(filename)
 	if _, e = os.Stat(filename); e == nil {
-		input, err := ioutil.ReadFile(filename)
+		input, err := os.ReadFile(filename)
 		if err != nil {
 			return false, errors.New("Error reading bindings.json file: " + err.Error())
 		}
@@ -304,7 +303,7 @@ func TryBindKey(k, v string, overwrite bool) (bool, error) {
 		BindKey(k, v, Binder["buffer"])
 
 		txt, _ := json.MarshalIndent(parsed, "", "    ")
-		return true, ioutil.WriteFile(filename, append(txt, '\n'), 0644)
+		return true, os.WriteFile(filename, append(txt, '\n'), 0644)
 	}
 	return false, e
 }
@@ -317,7 +316,7 @@ func UnbindKey(k string) error {
 	filename := filepath.Join(config.ConfigDir, "bindings.json")
 	createBindingsIfNotExist(filename)
 	if _, e = os.Stat(filename); e == nil {
-		input, err := ioutil.ReadFile(filename)
+		input, err := os.ReadFile(filename)
 		if err != nil {
 			return errors.New("Error reading bindings.json file: " + err.Error())
 		}
@@ -354,7 +353,7 @@ func UnbindKey(k string) error {
 		}
 
 		txt, _ := json.MarshalIndent(parsed, "", "    ")
-		return ioutil.WriteFile(filename, append(txt, '\n'), 0644)
+		return os.WriteFile(filename, append(txt, '\n'), 0644)
 	}
 	return e
 }

--- a/internal/buffer/autocomplete.go
+++ b/internal/buffer/autocomplete.go
@@ -2,7 +2,6 @@ package buffer
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -109,15 +108,15 @@ func FileComplete(b *Buffer) ([]string, []string) {
 	sep := string(os.PathSeparator)
 	dirs := strings.Split(input, sep)
 
-	var files []os.FileInfo
+	var files []os.DirEntry
 	var err error
 	if len(dirs) > 1 {
 		directories := strings.Join(dirs[:len(dirs)-1], sep) + sep
 
 		directories, _ = util.ReplaceHome(directories)
-		files, err = ioutil.ReadDir(directories)
+		files, err = os.ReadDir(directories)
 	} else {
-		files, err = ioutil.ReadDir(".")
+		files, err = os.ReadDir(".")
 	}
 
 	if err != nil {

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -546,7 +545,7 @@ func (b *Buffer) ReOpen() error {
 	}
 
 	reader := bufio.NewReader(transform.NewReader(file, enc.NewDecoder()))
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	txt := string(data)
 
 	if err != nil {

--- a/internal/config/plugin_installer.go
+++ b/internal/config/plugin_installer.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -396,7 +395,7 @@ func (pv *PluginVersion) DownloadAndInstall(out io.Writer) error {
 		return err
 	}
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/internal/config/rtfiles.go
+++ b/internal/config/rtfiles.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"errors"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
@@ -81,7 +80,7 @@ func (rf realFile) Name() string {
 }
 
 func (rf realFile) Data() ([]byte, error) {
-	return ioutil.ReadFile(string(rf))
+	return os.ReadFile(string(rf))
 }
 
 func (af assetFile) Name() string {
@@ -107,7 +106,7 @@ func AddRealRuntimeFile(fileType RTFiletype, file RuntimeFile) {
 // AddRuntimeFilesFromDirectory registers each file from the given directory for
 // the filetype which matches the file-pattern
 func AddRuntimeFilesFromDirectory(fileType RTFiletype, directory, pattern string) {
-	files, _ := ioutil.ReadDir(directory)
+	files, _ := os.ReadDir(directory)
 	for _, f := range files {
 		if ok, _ := filepath.Match(pattern, f.Name()); !f.IsDir() && ok {
 			fullPath := filepath.Join(directory, f.Name())
@@ -194,14 +193,14 @@ func InitPlugins() {
 
 	// Search ConfigDir for plugin-scripts
 	plugdir := filepath.Join(ConfigDir, "plug")
-	files, _ := ioutil.ReadDir(plugdir)
+	files, _ := os.ReadDir(plugdir)
 
 	isID := regexp.MustCompile(`^[_A-Za-z0-9]+$`).MatchString
 
 	for _, d := range files {
 		plugpath := filepath.Join(plugdir, d.Name())
 		if stat, err := os.Stat(plugpath); err == nil && stat.IsDir() {
-			srcs, _ := ioutil.ReadDir(plugpath)
+			srcs, _ := os.ReadDir(plugpath)
 			p := new(Plugin)
 			p.Name = d.Name()
 			p.DirName = d.Name()
@@ -209,7 +208,7 @@ func InitPlugins() {
 				if strings.HasSuffix(f.Name(), ".lua") {
 					p.Srcs = append(p.Srcs, realFile(filepath.Join(plugdir, d.Name(), f.Name())))
 				} else if strings.HasSuffix(f.Name(), ".json") {
-					data, err := ioutil.ReadFile(filepath.Join(plugdir, d.Name(), f.Name()))
+					data, err := os.ReadFile(filepath.Join(plugdir, d.Name(), f.Name()))
 					if err != nil {
 						continue
 					}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -222,7 +221,7 @@ func ReadSettings() error {
 	parsedSettings = make(map[string]interface{})
 	filename := filepath.Join(ConfigDir, "settings.json")
 	if _, e := os.Stat(filename); e == nil {
-		input, err := ioutil.ReadFile(filename)
+		input, err := os.ReadFile(filename)
 		if err != nil {
 			settingsParseError = true
 			return errors.New("Error reading settings.json file: " + err.Error())
@@ -347,7 +346,7 @@ func WriteSettings(filename string) error {
 		}
 
 		txt, _ := json.MarshalIndent(parsedSettings, "", "    ")
-		err = ioutil.WriteFile(filename, append(txt, '\n'), 0644)
+		err = os.WriteFile(filename, append(txt, '\n'), 0644)
 	}
 	return err
 }
@@ -369,7 +368,7 @@ func OverwriteSettings(filename string) error {
 		}
 
 		txt, _ := json.MarshalIndent(settings, "", "    ")
-		err = ioutil.WriteFile(filename, append(txt, '\n'), 0644)
+		err = os.WriteFile(filename, append(txt, '\n'), 0644)
 	}
 	return err
 }

--- a/internal/lua/lua.go
+++ b/internal/lua/lua.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"math/rand"
 	"net"
@@ -137,10 +136,10 @@ func importIo() *lua.LTable {
 func importIoUtil() *lua.LTable {
 	pkg := L.NewTable()
 
-	L.SetField(pkg, "ReadAll", luar.New(L, ioutil.ReadAll))
-	L.SetField(pkg, "ReadDir", luar.New(L, ioutil.ReadDir))
-	L.SetField(pkg, "ReadFile", luar.New(L, ioutil.ReadFile))
-	L.SetField(pkg, "WriteFile", luar.New(L, ioutil.WriteFile))
+	L.SetField(pkg, "ReadAll", luar.New(L, io.ReadAll))
+	L.SetField(pkg, "ReadDir", luar.New(L, os.ReadDir))
+	L.SetField(pkg, "ReadFile", luar.New(L, os.ReadFile))
+	L.SetField(pkg, "WriteFile", luar.New(L, os.WriteFile))
 
 	return pkg
 }

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -397,11 +397,11 @@ standard library.
 Simply import the package you'd like, and then you can use it. For example:
 
 ```lua
-local ioutil = import("io/ioutil")
+local os = import("os")
 local fmt = import("fmt")
 local micro = import("micro")
 
-local data, err = ioutil.ReadFile("SomeFile.txt")
+local data, err = os.ReadFile("SomeFile.txt")
 
 if err ~= nil then
     micro.InfoBar():Error("Error reading file: SomeFile.txt")
@@ -422,7 +422,6 @@ list of functions that are supported, you can look through `lua.go`
 
 * [fmt](https://pkg.go.dev/fmt)
 * [io](https://pkg.go.dev/io)
-* [io/ioutil](https://pkg.go.dev/io/ioutil)
 * [net](https://pkg.go.dev/net)
 * [math](https://pkg.go.dev/math)
 * [math/rand](https://pkg.go.dev/math/rand)

--- a/runtime/syntax/make_headers.go
+++ b/runtime/syntax/make_headers.go
@@ -6,7 +6,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"time"
@@ -34,7 +33,7 @@ func main() {
 	if len(os.Args) > 1 {
 		os.Chdir(os.Args[1])
 	}
-	files, _ := ioutil.ReadDir(".")
+	files, _ := os.ReadDir(".")
 	for _, f := range files {
 		fname := f.Name()
 		if strings.HasSuffix(fname, ".yaml") {
@@ -46,7 +45,7 @@ func main() {
 func convert(name string) {
 	filename := name + ".yaml"
 	var hdr HeaderYaml
-	source, err := ioutil.ReadFile(filename)
+	source, err := os.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}
@@ -68,7 +67,7 @@ func encode(name string, c HeaderYaml) {
 
 func decode(name string) Header {
 	start := time.Now()
-	data, _ := ioutil.ReadFile(name + ".hdr")
+	data, _ := os.ReadFile(name + ".hdr")
 	strs := bytes.Split(data, []byte{'\n'})
 	var hdr Header
 	hdr.FileType = string(strs[0])

--- a/runtime/syntax/syntax_converter.go
+++ b/runtime/syntax/syntax_converter.go
@@ -1,10 +1,10 @@
-//+build ignore
+//go:build ignore
+// +build ignore
 
 package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strings"
@@ -161,6 +161,6 @@ func main() {
 		return
 	}
 
-	data, _ := ioutil.ReadFile(os.Args[1])
+	data, _ := os.ReadFile(os.Args[1])
 	fmt.Print(generateFile(parseFile(string(data), os.Args[1])))
 }

--- a/tools/remove-nightly-assets.go
+++ b/tools/remove-nightly-assets.go
@@ -1,10 +1,10 @@
-//+build ignore
+//go:build ignore
+// +build ignore
 
 package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os/exec"
 	"strings"
@@ -19,7 +19,7 @@ func main() {
 		return
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 
 	var data interface{}
 

--- a/tools/testgen.go
+++ b/tools/testgen.go
@@ -1,10 +1,10 @@
-//+build ignore
+//go:build ignore
+// +build ignore
 
 package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"regexp"
@@ -210,7 +210,7 @@ func main() {
 	var tests []test
 
 	for _, filename := range os.Args[1:] {
-		source, err := ioutil.ReadFile(filename)
+		source, err := os.ReadFile(filename)
 		if err != nil {
 			log.Fatalln(err)
 		}


### PR DESCRIPTION
This PR removes usages of io/ioutil.

The package [io/ioutil](https://pkg.go.dev/io/ioutil) is deprecated since Go 1.16:

Deprecated: As of Go 1.16, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details.

Changes

    Replace ioutil.ReadAll with io.ReadAll
    Replace ioutil.ReadFile, ioutil.WriteFile, ioutil.ReadDir with os.ReadFile, os.WriteFile, os.ReadDir.
