### PR TITLE
skip save dialog on quit if buffer is shared

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1894,6 +1894,13 @@ func (h *BufPane) ForceQuit() bool {
 // Quit this will close the current tab or view that is open
 func (h *BufPane) Quit() bool {
 	if h.Buf.Modified() {
+		for _, b := range buffer.OpenBuffers {
+			if b != h.Buf && b.SharedBuffer == h.Buf.SharedBuffer {
+				h.ForceQuit()
+				return true
+			}
+		}
+
 		if config.GlobalSettings["autosave"].(float64) > 0 {
 			// autosave on means we automatically save when quitting
 			h.SaveCB("Quit", func() {


### PR DESCRIPTION
Currently, when a modified buffer is closed, the user is asked if the buffer should be saved. This happens even if the same file is opened in another buffer. With this PR, the save dialog is skipped in this case. I personally like to open a file in a second buffers when I made modifications that affect two locations. Then this issue pops up.