### PR TITLE
avoid HTML escaping in JSON files

### DIFF
--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -1,7 +1,6 @@
 package action
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -303,8 +302,7 @@ func TryBindKey(k, v string, overwrite bool) (bool, error) {
 
 		BindKey(k, v, Binder["buffer"])
 
-		txt, _ := json.MarshalIndent(parsed, "", "    ")
-		return true, ioutil.WriteFile(filename, append(txt, '\n'), 0644)
+		return true, config.WriteJson(filename, parsed)
 	}
 	return false, e
 }
@@ -353,8 +351,7 @@ func UnbindKey(k string) error {
 			delete(config.Bindings["buffer"], k)
 		}
 
-		txt, _ := json.MarshalIndent(parsed, "", "    ")
-		return ioutil.WriteFile(filename, append(txt, '\n'), 0644)
+		return config.WriteJson(filename, parsed)
 	}
 	return e
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -312,6 +312,19 @@ func InitLocalSettings(settings map[string]interface{}, path string) {
 	}
 }
 
+func WriteJson(filename string, v interface{}) error {
+		file, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+		file.Truncate(0)
+		enc := json.NewEncoder(file)
+		enc.SetEscapeHTML(false)
+		enc.SetIndent("", "    ")
+		return enc.Encode(v)
+}
+
 // WriteSettings writes the settings to the specified filename as JSON
 func WriteSettings(filename string) error {
 	if settingsParseError {
@@ -346,8 +359,7 @@ func WriteSettings(filename string) error {
 			}
 		}
 
-		txt, _ := json.MarshalIndent(parsedSettings, "", "    ")
-		err = ioutil.WriteFile(filename, append(txt, '\n'), 0644)
+		err = WriteJson(filename, parsedSettings)
 	}
 	return err
 }
@@ -368,8 +380,7 @@ func OverwriteSettings(filename string) error {
 			}
 		}
 
-		txt, _ := json.MarshalIndent(settings, "", "    ")
-		err = ioutil.WriteFile(filename, append(txt, '\n'), 0644)
+		err = WriteJson(filename, settings)
 	}
 	return err
 }


### PR DESCRIPTION
Currently the HTML characters "<" and ">" are escaped in the JSON file micro writes, see [here](https://pkg.go.dev/encoding/json#Marshal). This makes the `bindings.json` file hard to read: Instead of
```
{
    "<F5><a>": "command:log",
}
```
one gets
```
{
    "\u003cF5\u003e\u003ca\u003e": "command:log",
}
```
This PR changes this. I'm assuming that the HTML security concern behind the escaping doesn't apply here. For `settings.json` I don't have a strong use case. I just thought it's best to use the same code for both files.