### PR TITLE
turn `autoclosePairs` and `autoNewlinePairs` into buffer-local options

### DIFF
--- a/runtime/plugins/autoclose/autoclose.lua
+++ b/runtime/plugins/autoclose/autoclose.lua
@@ -1,9 +1,11 @@
 VERSION = "1.0.0"
 
+local config = import("micro/config")
 local uutil = import("micro/util")
 local utf8 = import("utf8")
-local autoclosePairs = {"\"\"", "''", "``", "()", "{}", "[]"}
-local autoNewlinePairs = {"()", "{}", "[]"}
+
+config.RegisterCommonOption("autoclose", "pairs", {"\"\"", "''", "``", "()", "{}", "[]"})
+config.RegisterCommonOption("autoclose", "newlinePairs", {"()", "{}", "[]"})
 
 function charAt(str, i)
     -- lua indexing is one off from go
@@ -11,6 +13,7 @@ function charAt(str, i)
 end
 
 function onRune(bp, r)
+    local autoclosePairs = bp.Buf.Settings["autoclose.pairs"]
     for i = 1, #autoclosePairs do
         if r == charAt(autoclosePairs[i], 2) then
             local curLine = bp.Buf:Line(bp.Cursor.Y)
@@ -42,6 +45,7 @@ function onRune(bp, r)
 end
 
 function preInsertNewline(bp)
+    local autoNewlinePairs = bp.Buf.Settings["autoclose.newlinePairs"]
     local curLine = bp.Buf:Line(bp.Cursor.Y)
     local curRune = charAt(curLine, bp.Cursor.X)
     local nextRune = charAt(curLine, bp.Cursor.X+1)
@@ -64,6 +68,7 @@ function preInsertNewline(bp)
 end
 
 function preBackspace(bp)
+    local autoclosePairs = bp.Buf.Settings["autoclose.pairs"]
     for i = 1, #autoclosePairs do
         local curLine = bp.Buf:Line(bp.Cursor.Y)
         if charAt(curLine, bp.Cursor.X+1) == charAt(autoclosePairs[i], 2) and charAt(curLine, bp.Cursor.X) == charAt(autoclosePairs[i], 1) then


### PR DESCRIPTION
This way one can configure different brackets for different buffers. This seems to me the natural way to do.

At present, the new options are called `pairs` and `newlinePairs`. Should the latter one be renamed, for example to `newline_pairs`?