### PR TITLE
make `FindNext` and `FindPrevious` work with empty matches

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1211,6 +1211,14 @@ func (h *BufPane) FindNext() bool {
 	match, found, err := h.Buf.FindNext(h.Buf.LastSearch, h.Buf.Start(), h.Buf.End(), searchLoc, true, h.Buf.LastSearchRegex)
 	if err != nil {
 		InfoBar.Error(err)
+	} else if found && searchLoc == match[0] && match[0] == match[1] {
+		// skip empty match at present cursor location
+		if searchLoc == h.Buf.End() {
+			searchLoc = h.Buf.Start()
+		} else {
+			searchLoc = searchLoc.Move(1, h.Buf)
+		}
+		match, found, _ = h.Buf.FindNext(h.Buf.LastSearch, h.Buf.Start(), h.Buf.End(), searchLoc, true, h.Buf.LastSearchRegex)
 	}
 	if found {
 		h.Cursor.SetSelectionStart(match[0])
@@ -1240,6 +1248,14 @@ func (h *BufPane) FindPrevious() bool {
 	match, found, err := h.Buf.FindNext(h.Buf.LastSearch, h.Buf.Start(), h.Buf.End(), searchLoc, false, h.Buf.LastSearchRegex)
 	if err != nil {
 		InfoBar.Error(err)
+	} else if found && searchLoc == match[0] && match[0] == match[1] {
+		// skip empty match at present cursor location
+		if searchLoc == h.Buf.Start() {
+			searchLoc = h.Buf.End()
+		} else {
+			searchLoc = searchLoc.Move(-1, h.Buf)
+		}
+		match, found, _ = h.Buf.FindNext(h.Buf.LastSearch, h.Buf.Start(), h.Buf.End(), searchLoc, false, h.Buf.LastSearchRegex)
 	}
 	if found {
 		h.Cursor.SetSelectionStart(match[0])


### PR DESCRIPTION
This is a companion to #3566, as suggested by @dmaluka in [this comment](https://github.com/zyedidia/micro/pull/3566#discussion_r1881046670). If there is an empty match, then `FindNext` will move one rune to the right before starting the search and `Findprevious` will move one rune to the left.

The new field `LastMatch` of `Buffer` keeps track of the last match. I only initialize it after a search (that is, when `LastSearch` is non-empty).

When testing the PR, keep in mind that currently `^` always matches the current position when searching downwards and `$` does the same when searching upwards. That should be addressed in a different PR.
