### PR TITLE
Add, sort options in list, default JSON in `options.md`

### DIFF
--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -79,21 +79,15 @@ Here are the available options:
 
     default value: `0`
 
-* `colorscheme`: loads the colorscheme stored in
-   $(configDir)/colorschemes/`option`.micro, This setting is `global only`.
+* `colorscheme`: loads the colorscheme stored in `(option).micro`.
+   The colorscheme can be selected from all the files in the
+   `~/.config/micro/colorschemes/` directory. This setting is `global only`.
+   Note: The colorschemes that micro comes with by default are not located in
+   `colorschemes/`, because they are embedded in the micro binary. You can see
+   the list of default colorschemes and read more about micro's colorschemes in
+   the `colors` help topic (`help colors`).
 
     default value: `default`
-
-   Note that the default colorschemes (default, solarized, and solarized-tc)
-   are not located in configDir, because they are embedded in the micro
-   binary.
-
-   The colorscheme can be selected from all the files in the
-   `~/.config/micro/colorschemes/` directory. Micro comes by default with
-   three colorschemes:
-
-   You can read more about micro's colorschemes in the `colors` help topic
-   (`help colors`).
 
 * `cursorline`: highlight the line that the cursor is on in a different color
    (the color is defined by the colorscheme you are using).

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -89,7 +89,7 @@ Here are the available options:
    binary.
 
    The colorscheme can be selected from all the files in the
-   ~/.config/micro/colorschemes/ directory. Micro comes by default with
+   `~/.config/micro/colorschemes/` directory. Micro comes by default with
    three colorschemes:
 
    You can read more about micro's colorschemes in the `colors` help topic
@@ -293,7 +293,7 @@ Here are the available options:
     default value: `2`
 
 * `parsecursor`: if enabled, this will cause micro to parse filenames such as
-   file.txt:10:5 as requesting to open `file.txt` with the cursor at line 10
+   `file.txt:10:5` as requesting to open `file.txt` with the cursor at line 10
    and column 5. The column number can also be dropped to open the file at a
    given line and column 0. Note that with this option enabled it is not possible
    to open a file such as `file.txt:10:5`, where `:10:5` is part of the filename.
@@ -444,7 +444,7 @@ Here are the available options:
 * `tabhighlight`: inverts the tab characters' (filename, save indicator, etc)
    colors with respect to the tab bar.
 
-    default value: false
+    default value: `false`
 
 * `tabmovement`: navigate spaces at the beginning of lines as if they are tabs
    (e.g. move over 4 spaces at once). This option only does anything if
@@ -454,7 +454,7 @@ Here are the available options:
 
 * `tabreverse`: reverses the tab bar colors when active.
 
-    default value: true
+    default value: `true`
 
 * `tabsize`: the size in spaces that a tab character should be displayed with.
 
@@ -507,13 +507,13 @@ or disable them:
    recent Git commit rather than the diff since opening the file.
 
 Any option you set in the editor will be saved to the file
-~/.config/micro/settings.json so, in effect, your configuration file will be
+`~/.config/micro/settings.json` so, in effect, your configuration file will be
 created for you. If you'd like to take your configuration with you to another
-machine, simply copy the settings.json to the other machine.
+machine, simply copy `settings.json` to the other machine.
 
 ## Settings.json file
 
-The settings.json file should go in your configuration directory (by default
+The `settings.json` file should go in your configuration directory (by default
 at `~/.config/micro`), and should contain only options which have been modified
 from their default setting. Here is the full list of options in json format,
 so that you can see what the formatting should look like.

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -201,11 +201,11 @@ Here are the available options:
 
     default value: `false`
 
-* `incsearch`: enable incremental search in "Find" prompt (matching as you type).
+* `ignorecase`: perform case-insensitive searches.
 
     default value: `true`
 
-* `ignorecase`: perform case-insensitive searches.
+* `incsearch`: enable incremental search in "Find" prompt (matching as you type).
 
     default value: `true`
 
@@ -292,15 +292,6 @@ Here are the available options:
 
     default value: `2`
 
-* `paste`: treat characters sent from the terminal in a single chunk as a paste
-   event rather than a series of manual key presses. If you are pasting using
-   the terminal keybinding (not `Ctrl-v`, which is micro's default paste
-   keybinding) then it is a good idea to enable this option during the paste
-   and disable once the paste is over. See `> help copypaste` for details about
-   copying and pasting in a terminal environment.
-
-    default value: `false`
-
 * `parsecursor`: if enabled, this will cause micro to parse filenames such as
    file.txt:10:5 as requesting to open `file.txt` with the cursor at line 10
    and column 5. The column number can also be dropped to open the file at a
@@ -308,6 +299,15 @@ Here are the available options:
    to open a file such as `file.txt:10:5`, where `:10:5` is part of the filename.
    It is also possible to open a file with a certain cursor location by using the
    `+LINE:COL` flag syntax. See `micro -help` for the command line options.
+
+    default value: `false`
+
+* `paste`: treat characters sent from the terminal in a single chunk as a paste
+   event rather than a series of manual key presses. If you are pasting using
+   the terminal keybinding (not `Ctrl-v`, which is micro's default paste
+   keybinding) then it is a good idea to enable this option during the paste
+   and disable once the paste is over. See `> help copypaste` for details about
+   copying and pasting in a terminal environment.
 
     default value: `false`
 
@@ -335,6 +335,12 @@ Here are the available options:
 
     default value: `false`
 
+* `relativeruler`: make line numbers display relatively. If set to true, all
+   lines except for the line that the cursor is located will display the distance
+   from the cursor's line.
+
+    default value: `false`
+
 * `reload`: controls the reload behavior of the current buffer in case the file
    has changed. The available options are `prompt`, `auto` & `disabled`.
 
@@ -351,12 +357,6 @@ Here are the available options:
 * `ruler`: display line numbers.
 
     default value: `true`
-
-* `relativeruler`: make line numbers display relatively. If set to true, all
-   lines except for the line that the cursor is located will display the distance
-   from the cursor's line.
-
-    default value: `false`
 
 * `savecursor`: remember where the cursor was last time the file was opened and
    put it there when you open the file again. Information is saved to
@@ -441,16 +441,16 @@ Here are the available options:
 
     default value: `true`
 
+* `tabhighlight`: inverts the tab characters' (filename, save indicator, etc)
+   colors with respect to the tab bar.
+
+    default value: false
+
 * `tabmovement`: navigate spaces at the beginning of lines as if they are tabs
    (e.g. move over 4 spaces at once). This option only does anything if
    `tabstospaces` is on.
 
     default value: `false`
-
-* `tabhighlight`: inverts the tab characters' (filename, save indicator, etc)
-   colors with respect to the tab bar.
-
-    default value: false
 
 * `tabreverse`: reverses the tab bar colors when active.
 
@@ -532,18 +532,24 @@ so that you can see what the formatting should look like.
     "colorscheme": "default",
     "comment": true,
     "cursorline": true,
+    "detectlimit": 100,
     "diff": true,
     "diffgutter": false,
     "divchars": "|-",
     "divreverse": true,
     "encoding": "utf-8",
     "eofnewline": true,
+    "fakecursor": false,
     "fastdirty": false,
     "fileformat": "unix",
     "filetype": "unknown",
-    "incsearch": true,
     "ftoptions": true,
+    "helpsplit": "hsplit",
+    "hlsearch": false,
+    "hltaberrors": false,
+    "hltrailingws": false,
     "ignorecase": true,
+    "incsearch": true,
     "indentchar": " ",
     "infobar": true,
     "initlua": true,
@@ -556,6 +562,8 @@ so that you can see what the formatting should look like.
     "matchbracestyle": "underline",
     "mkparents": false,
     "mouse": true,
+    "multiopen": "tab",
+    "pageoverlap": 2,
     "parsecursor": false,
     "paste": false,
     "permbackup": false,
@@ -565,12 +573,14 @@ so that you can see what the formatting should look like.
     "pluginrepos": [],
     "readonly": false,
     "relativeruler": false,
+    "reload": "prompt",
     "rmtrailingws": false,
     "ruler": true,
     "savecursor": false,
     "savehistory": true,
     "saveundo": false,
     "scrollbar": false,
+    "scrollbarchar": "|",
     "scrollmargin": 3,
     "scrollspeed": 2,
     "smartpaste": true,
@@ -583,12 +593,13 @@ so that you can see what the formatting should look like.
     "statusline": true,
     "sucmd": "sudo",
     "syntax": true,
-    "tabmovement": false,
     "tabhighlight": true,
+    "tabmovement": false,
     "tabreverse": false,
     "tabsize": 4,
     "tabstospaces": false,
     "useprimary": true,
+    "wordwrap": false,
     "xterm": false
 }
 ```


### PR DESCRIPTION
The changes below are done to `options.md` in this pull request:
- Sorting option entries
- Adding, sorting options in JSON code block with default values
- Inserting few parts like paths and values in backticks
- Adjusting `colorscheme` option description to update content and use formatting like in other options