### PR TITLE
Added syntax highlighting for kanata config files.

### DIFF
--- a/runtime/syntax/kanata-config.yaml
+++ b/runtime/syntax/kanata-config.yaml
@@ -4,7 +4,6 @@ detect:
     filename: "\\.kbd$"
 
 rules:
-    - default: "\\([a-z-]+"
     - symbol.operator: "@|\\$"
     - symbol.brackets: "[()]"
     - constant.number: "\\b[0-9]+\\b"

--- a/runtime/syntax/kanata-config.yaml
+++ b/runtime/syntax/kanata-config.yaml
@@ -1,0 +1,33 @@
+filetype: kanata
+
+detect:
+    filename: "\\.kbd$"
+
+rules:
+    - default: "\\([a-z-]+"
+    - symbol.operator: "@|\\$"
+    - symbol.brackets: "[()]"
+    - constant.number: "\\b[0-9]+\\b"
+    
+    - constant.string:
+        start: "\""
+        end: "\""
+        skip: "\\\\."
+        rules: []
+
+    - constant.string:
+        start: "r#\""
+        end: "\"#"
+        rules: []
+    
+    - comment:
+        start: "#[|]"
+        end: "[|]#"
+        rules:
+            - todo: "(TODO|XXX|FIXME):?"
+    
+    - comment:
+        start: ";;"
+        end: "$"
+        rules:
+            - todo: "(TODO|XXX|FIXME):?"


### PR DESCRIPTION
I was editing a [kanata](https://github.com/jtroo/kanata) config file, for a custom keyboard layout, and got tired of the uncolored text on my screen pretty fast. So, as one does, I quickly put together a syntax file for it.

It supports every type of token present in the [official feature showcase  config file](https://github.com/jtroo/kanata/blob/main/cfg_samples/kanata.kbd).

This highlighting is applied to *.kbd files only. As far as I'm aware, there are no conflicts with this file extension. Which is important to note, given the niche application of this file type.