### PR TITLE
call `onSetActive` consistently whenever a bufpane receives focus

### DIFF
--- a/cmd/micro/micro_test.go
+++ b/cmd/micro/micro_test.go
@@ -83,8 +83,8 @@ func startup(args []string) (tcell.SimulationScreen, error) {
 		return nil, errors.New("No buffers opened")
 	}
 
-	action.InitTabs(b)
 	action.InitGlobals()
+	action.InitTabs(b)
 
 	err = config.RunPluginFn("init")
 	if err != nil {

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1899,6 +1899,9 @@ func (h *BufPane) ForceQuit() bool {
 		h.Unsplit()
 	} else if len(Tabs.List) > 1 {
 		Tabs.RemoveTab(h.splitID)
+		if e := MainTab().CurPane(); e != nil { // e == nil for 'raw' tab
+			e.SetActive(true)
+		}
 	} else {
 		screen.Screen.Fini()
 		InfoBar.Close()

--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -666,7 +666,6 @@ func (h *BufPane) VSplitIndex(buf *buffer.Buffer, right bool) *BufPane {
 	}
 	MainTab().AddPane(e, currentPaneIdx)
 	MainTab().Resize()
-	MainTab().SetActive(currentPaneIdx)
 	return e
 }
 
@@ -680,18 +679,23 @@ func (h *BufPane) HSplitIndex(buf *buffer.Buffer, bottom bool) *BufPane {
 	}
 	MainTab().AddPane(e, currentPaneIdx)
 	MainTab().Resize()
-	MainTab().SetActive(currentPaneIdx)
 	return e
 }
 
 // VSplitBuf opens the given buffer in a new vertical split.
 func (h *BufPane) VSplitBuf(buf *buffer.Buffer) *BufPane {
-	return h.VSplitIndex(buf, h.Buf.Settings["splitright"].(bool))
+	e := h.VSplitIndex(buf, h.Buf.Settings["splitright"].(bool))
+	MainTab().SetActive(MainTab().GetPane(e.ID()))
+	e.SetActive(true)
+	return e
 }
 
 // HSplitBuf opens the given buffer in a new horizontal split.
 func (h *BufPane) HSplitBuf(buf *buffer.Buffer) *BufPane {
-	return h.HSplitIndex(buf, h.Buf.Settings["splitbottom"].(bool))
+	e := h.HSplitIndex(buf, h.Buf.Settings["splitbottom"].(bool))
+	MainTab().SetActive(MainTab().GetPane(e.ID()))
+	e.SetActive(true)
+	return e
 }
 
 // Close this pane.

--- a/internal/action/tab.go
+++ b/internal/action/tab.go
@@ -1,12 +1,9 @@
 package action
 
 import (
-	luar "layeh.com/gopher-luar"
-
 	"github.com/zyedidia/micro/v2/internal/buffer"
 	"github.com/zyedidia/micro/v2/internal/config"
 	"github.com/zyedidia/micro/v2/internal/display"
-	ulua "github.com/zyedidia/micro/v2/internal/lua"
 	"github.com/zyedidia/micro/v2/internal/screen"
 	"github.com/zyedidia/micro/v2/internal/views"
 	"github.com/zyedidia/tcell/v2"
@@ -153,17 +150,9 @@ func (t *TabList) SetActive(a int) {
 	t.TabWindow.SetActive(a)
 
 	for i, p := range t.List {
-		if i == a {
-			if !p.isActive {
-				p.isActive = true
-
-				err := config.RunPluginFn("onSetActive", luar.New(ulua.L, p.CurPane()))
-				if err != nil {
-					screen.TermMessage(err)
-				}
-			}
-		} else {
-			p.isActive = false
+		p.isActive = i == a
+		if h := p.CurPane(); h != nil { // h == nil for 'raw' tab
+			h.SetActive(i == a)
 		}
 	}
 }
@@ -210,12 +199,13 @@ func InitTabs(bufs []*buffer.Buffer) {
 		Tabs = NewTabList(bufs[:1])
 		for _, b := range bufs[1:] {
 			if multiopen == "vsplit" {
-				MainTab().CurPane().VSplitBuf(b)
+				MainTab().CurPane().VSplitIndex(b, true)
 			} else {  // default hsplit
-				MainTab().CurPane().HSplitBuf(b)
+				MainTab().CurPane().HSplitIndex(b, true)
 			}
 		}
 	}
+	MainTab().CurPane().SetActive(true)
 
 	screen.RestartCallback = Tabs.ResetMouse
 }

--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -36,7 +36,6 @@ func NewBufWindow(x, y, width, height int, buf *buffer.Buffer) *BufWindow {
 	w.View = new(View)
 	w.X, w.Y, w.Width, w.Height = x, y, width, height
 	w.SetBuffer(buf)
-	w.active = true
 
 	w.sline = NewStatusLine(w)
 

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -57,15 +57,13 @@ that micro defines:
 
 * `deinit()`: cleanup function called when your plugin is unloaded or reloaded.
 
-* `onSetActive(bufpane)`: runs when changing the currently active panel.
-
 * `onBufferOpen(buf)`: runs when a buffer is opened. The input contains
    the buffer object.
 
 * `onBufPaneOpen(bufpane)`: runs when a bufpane is opened. The input
    contains the bufpane object.
 
-* `onSetActive(bufpane)`: runs when changing the currently active bufpane.
+* `onSetActive(bufpane)`: runs when a bufpane becomes active.
 
 * `onAction(bufpane)`: runs when `Action` is triggered by the user, where
    `Action` is a bindable action (see `> help keybindings`). A bufpane


### PR DESCRIPTION
I find the current behavior of `onSetActive` quite strange (as remarked in #3563 already):

- When you start micro, `onSetActive` is not called. This also applies if you list one or more files on the command line that are opened in separate tabs or splits.
- When you open a new tab or switch between tabs, `onSetActive` is called. When you close a tab (that is not the only tab), then most of the time `onSetActive` is called. However, if you open several files on startup and then close one tab after the other, `onSetActive` is never called.
- When you open a new split, `onSetActive` is not called. When you switch between splits or close a split, `onSetActive` is called.
- On top of that, if you open a "raw" buffer, then `onSetActive` is called with `nil` as argument.

This PR changes the behavior as follows: "active" is interpreted as the bufpane that can receive user input. Hence there is exactly one active bufpane at any time (or none if the "raw" buffer is open). Whenever a bufpane becomes active, `onSetActive` is called. This may happen through opening, switching or closing tabs or splits and also at startup. Th call for a "raw" buffer is eliminated, and the double mentioning of `onSetActive` in the documentation is corrected.

I've used this patch for some time now and it seems to work well. Nevertheless, please have a look at the changes. Maybe there are better ways to achieve the goal. Or maybe you want `onSetActive` to behave differently. I myself find if difficult at present to use `onSetActive` in a meaningful way.