### PR TITLE
Autocompletion of file paths in editor.

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -925,7 +925,7 @@ func (h *BufPane) Autocomplete() bool {
 		b.CycleAutocomplete(true)
 		return true
 	}
-	return b.Autocomplete(buffer.BufferComplete)
+	return b.Autocomplete(buffer.Complete)
 }
 
 // CycleAutocompleteBack cycles back in the autocomplete suggestion list

--- a/internal/buffer/autocomplete.go
+++ b/internal/buffer/autocomplete.go
@@ -101,13 +101,28 @@ func (b *Buffer) GetArg() (string, int) {
 	return input, argstart
 }
 
+// Complete filenames or buffer words
+func Complete(b *Buffer) ([]string, []string) {
+	completions, suggestions := FileComplete(b)
+	if len(completions) != 0 || len(suggestions) != 0 {
+		return completions, suggestions
+	}
+	return BufferComplete(b)
+}
+
+func IsQuoteOrBraceStart(r rune) bool {
+	return r == '"' || r == '\'' || r == '(' || r == '[' || r == '{'
+}
+
 // FileComplete autocompletes filenames
 func FileComplete(b *Buffer) ([]string, []string) {
 	c := b.GetActiveCursor()
 	input, argstart := b.GetArg()
+	// Allow completion of paths inside quotes and braces
+	path_start := strings.LastIndexFunc(input, IsQuoteOrBraceStart) + 1
 
 	sep := string(os.PathSeparator)
-	dirs := strings.Split(input, sep)
+	dirs := strings.Split(input[path_start:], sep)
 
 	var files []os.FileInfo
 	var err error
@@ -144,7 +159,7 @@ func FileComplete(b *Buffer) ([]string, []string) {
 		} else {
 			complete = suggestions[i]
 		}
-		completions[i] = util.SliceEndStr(complete, c.X-argstart)
+		completions[i] = util.SliceEndStr(complete, c.X-argstart-path_start)
 	}
 
 	return completions, suggestions

--- a/internal/buffer/autocomplete_test.go
+++ b/internal/buffer/autocomplete_test.go
@@ -1,0 +1,116 @@
+package buffer
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/zyedidia/micro/v2/internal/config"
+)
+
+func setupTestDir() (string, error) {
+	dir, err := ioutil.TempDir("", "testdir")
+	if err != nil {
+		return "", err
+	}
+
+	subdirs := []string{"subdir1", "subdir2"}
+	files := []string{"file1.txt", "file2.txt"}
+
+	for _, subdir := range subdirs {
+		if err := os.Mkdir(dir+string(os.PathSeparator)+subdir, 0755); err != nil {
+			return "", err
+		}
+	}
+
+	for _, file := range files {
+		if _, err := os.Create(dir + string(os.PathSeparator) + file); err != nil {
+			return "", err
+		}
+	}
+	return dir, nil
+}
+
+func init() {
+	config.InitRuntimeFiles(false)
+	config.InitGlobalSettings()
+	config.GlobalSettings["backup"] = false
+	config.GlobalSettings["fastdirty"] = true
+}
+
+func teardownTestDir(dir string) {
+	os.RemoveAll(dir)
+}
+
+func TestFileComplete(t *testing.T) {
+	dir, err := setupTestDir()
+	if err != nil {
+		t.Fatalf("Failed to set up test directory: %v", err)
+	}
+	defer teardownTestDir(dir)
+
+	tests := []struct {
+		name         string
+		input        string
+		expectedComp []string
+		expectedSugg []string
+		expectedErr  bool
+	}{
+		{
+			name:         "Complete subdir",
+			input:        dir + string(os.PathSeparator) + "sub",
+			expectedComp: []string{"dir1" + string(os.PathSeparator), "dir2" + string(os.PathSeparator)},
+			expectedSugg: []string{"subdir1" + string(os.PathSeparator), "subdir2" + string(os.PathSeparator)},
+		},
+		{
+			name:         "Complete file",
+			input:        dir + string(os.PathSeparator) + "f",
+			expectedComp: []string{"ile1.txt", "ile2.txt"},
+			expectedSugg: []string{"file1.txt", "file2.txt"},
+		},
+		{
+			name:         "No match",
+			input:        dir + string(os.PathSeparator) + "nomatch",
+			expectedComp: []string{},
+			expectedSugg: []string{},
+		},
+		{
+			name:         "Complete subdir inside quotes",
+			input:        "\"" + dir + string(os.PathSeparator) + "sub",
+			expectedComp: []string{"dir1" + string(os.PathSeparator), "dir2" + string(os.PathSeparator)},
+			expectedSugg: []string{"subdir1" + string(os.PathSeparator), "subdir2" + string(os.PathSeparator)},
+		},
+		{
+			name:         "Complete inside function and quotes",
+			input:        "funtion(\"" + dir + string(os.PathSeparator) + "sub",
+			expectedComp: []string{"dir1" + string(os.PathSeparator), "dir2" + string(os.PathSeparator)},
+			expectedSugg: []string{"subdir1" + string(os.PathSeparator), "subdir2" + string(os.PathSeparator)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBufferFromString(tt.input, "", BTDefault)
+			c := b.GetActiveCursor()
+			c.End()
+
+			completions, suggestions := FileComplete(b)
+			if len(completions) != len(tt.expectedComp) {
+				t.Errorf("expected %d completions, got %d", len(tt.expectedComp), len(completions))
+			}
+			for i, exp := range tt.expectedComp {
+				if completions[i] != exp {
+					t.Errorf("expected completion %s, got %s", exp, completions[i])
+				}
+			}
+			if len(suggestions) != len(tt.expectedSugg) {
+				t.Errorf("expected %d suggestions, got %d", len(tt.expectedSugg), len(suggestions))
+			}
+			for i, exp := range tt.expectedSugg {
+				if suggestions[i] != exp {
+					t.Errorf("expected suggestion %s, got %s", exp, suggestions[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -495,7 +495,7 @@ func Clamp(val, min, max int) int {
 
 // IsAutocomplete returns whether a character should begin an autocompletion.
 func IsAutocomplete(c rune) bool {
-	return c == '.' || IsWordChar(c)
+	return c == '.' || c == os.PathSeparator || IsWordChar(c)
 }
 
 // String converts a byte array to a string (for lua plugins)


### PR DESCRIPTION
Change:
Add file completion as a default autocomplete option in edit mode (beside buffer complete).

Rationale:
Simple text editor like micro is great for editing bash scripts and config files. In such scenarios file path completion is very handy. Micro already has code for file completion but only in command mode.