### PR TITLE
define message methods for `SharedBuffer` instead of `Buffer`

### DIFF
--- a/internal/buffer/message.go
+++ b/internal/buffer/message.go
@@ -61,17 +61,17 @@ func (m *Message) Style() tcell.Style {
 	return config.DefStyle
 }
 
-func (b *Buffer) AddMessage(m *Message) {
+func (b *SharedBuffer) AddMessage(m *Message) {
 	b.Messages = append(b.Messages, m)
 }
 
-func (b *Buffer) removeMsg(i int) {
+func (b *SharedBuffer) removeMsg(i int) {
 	copy(b.Messages[i:], b.Messages[i+1:])
 	b.Messages[len(b.Messages)-1] = nil
 	b.Messages = b.Messages[:len(b.Messages)-1]
 }
 
-func (b *Buffer) ClearMessages(owner string) {
+func (b *SharedBuffer) ClearMessages(owner string) {
 	for i := len(b.Messages) - 1; i >= 0; i-- {
 		if b.Messages[i].Owner == owner {
 			b.removeMsg(i)
@@ -79,7 +79,7 @@ func (b *Buffer) ClearMessages(owner string) {
 	}
 }
 
-func (b *Buffer) ClearAllMessages() {
+func (b *SharedBuffer) ClearAllMessages() {
 	b.Messages = make([]*Message, 0)
 }
 


### PR DESCRIPTION
`AddMessage` and the like are defined for `Buffer` although they only use the `SharedBuffer` part. This PR defines them for `SharedBuffer`. As a consequence, these methods can now be used from within the `onBeforeTextEvent` callback, which receives a `SharedBuffer` as argument.