### PR TITLE
run `onBeforeTextEvent` also for undo and redo events

### DIFF
--- a/internal/buffer/eventhandler.go
+++ b/internal/buffer/eventhandler.go
@@ -114,6 +114,15 @@ func (eh *EventHandler) DoTextEvent(t *TextEvent, useUndo bool) {
 
 // ExecuteTextEvent runs a text event
 func ExecuteTextEvent(t *TextEvent, buf *SharedBuffer) {
+	b, err := config.RunPluginFnBool(nil, "onBeforeTextEvent", luar.New(ulua.L, buf), luar.New(ulua.L, t))
+	if err != nil {
+		screen.TermMessage(err)
+	}
+
+	if !b {
+		return
+	}
+
 	if t.EventType == TextEventInsert {
 		for _, d := range t.Deltas {
 			buf.insert(d.Start, d.Text)
@@ -240,15 +249,6 @@ func (eh *EventHandler) Execute(t *TextEvent) {
 		eh.RedoStack = new(TEStack)
 	}
 	eh.UndoStack.Push(t)
-
-	b, err := config.RunPluginFnBool(nil, "onBeforeTextEvent", luar.New(ulua.L, eh.buf), luar.New(ulua.L, t))
-	if err != nil {
-		screen.TermMessage(err)
-	}
-
-	if !b {
-		return
-	}
 
 	ExecuteTextEvent(t, eh.buf)
 }


### PR DESCRIPTION
The `onBeforeTextEvent` is not documented, but it has been discussed [here](https://github.com/zyedidia/micro/issues/2686#issuecomment-2155698633), for example. Currently this callback is only called for "new" events, but not for those coming from undo or redo events. This means that these latter events are missed if one uses `onBeforeTextEvent` to monitor how a buffer changes. This PR fixes this by moving the invocation of the callback to a function that is also called for undo and redo events.