### PR TITLE
Expanded Python syntax file

### DIFF
--- a/runtime/colorschemes/catppuccin-mocha_py.micro
+++ b/runtime/colorschemes/catppuccin-mocha_py.micro
@@ -1,0 +1,54 @@
+# Custom color scheme inspired by Catppuccin - Mocha from "https://catppuccin.com/"
+# Language related syntax
+color-link default "#cdd6f4,#1e1e2e"
+color-link comment "italic #777777"
+color-link constant "bold #fab387,#1e1e2e"        # None, self, Ellipse, cls, default for True and False*
+color-link constant.bool "bold #f9e2af,#1e1e2e"   # True && False
+color-link constant.number "bold #fab387"         # New: Float and int
+color-link constant.specialChar "italic #f5c2e7"  # New: Escape characters and {} inside string
+color-link constant.string "#a6e3a1,#1e1e2e"      # Single or double quotes, and docstring
+color-link constant.string.char "#6A8759,#1e1e2e" # unknown
+color-link constant.string.url "italic #777777"   # New: does not work*
+color-link identifier "italic #f38ba8,#1e1e2e"    # built in functions, def functions and function calls with or without dot
+color-link identifier.var "bold #cdd6f4"          # New: Variables, attributes, placeholders*
+color-link identifier.class "bold #f9e2af"        # New: As stated and few more*
+color-link message "bold #f38ba8,#181825"        # As intended both for errors and some others
+color-link preproc "italic #89b4fa,#1e1e2e"       # Statement preceded by an @
+color-link statement "#cba6f7,#1e1e2e"            # Several keywords*
+color-link symbol "bold #CCCCCC,#1e1e2e"          # Default color
+color-link type "#f9e2af,#1e1e2e"                 # Type hint in both inside and outisde of functions
+color-link type.keyword "#f9e2af,#1e1e2e"         # Built-in types*
+color-link symbol "bold #f38ba8"                  # New*
+color-link symbol.brackets "bold #9399b2"         # New*
+color-link symbol.operator "bold #89dceb"         # New*
+color-link special "#74c7ec,#1e1e2e"              # unknown
+color-link underlined "#D33682,#1e1e2e"           # unknown
+color-link error "bold #CB4B16,#1e1e2e"           # unknown
+color-link todo "bold #8aadf4,#1e1e2e"            # NOTE TODO*
+
+# Micro appearance
+color-link hlsearch "#11111b,#89dceb"
+color-link statusline "#89dceb,#313244"
+color-link tabbar "#242424,#CCCCCC"
+color-link indent-char "#4F4F4F,#1e1e2e"
+color-link line-number "#7f849c,#313244"
+color-link current-line-number "#b4befe,#1e1e2e"
+# 37, 38, 39 affected if "diffgutter" is set to true in "settings.json"
+color-link diff-added "#a6e3a1"
+color-link diff-modified "#89b4fa"
+color-link diff-deleted "#f38ba8"
+color-link gutter-error "#f38ba8,#1e1e2e"         # >> language error
+color-link gutter-warning "#f9e2af,#1e1e2e"       # >> i.e. spell checking
+color-link cursor-line "#45475a"
+color-link color-column "#45475a"
+color-link divider "#777777"                      # New
+color-link selection "#2C2C2C,#777777"            # New
+
+# No extended types; Plain brackets.
+color-link type.extended "default"
+color-link symbol.tag "#AE381FF,#1e1e2e"
+color-link match-brace "#1e1e2e,#7A9EC2"
+color-link tab-error "#D75F5F"
+color-link trailingws "#bac2de"
+
+# *NOTE* review the python3.yaml for more detail

--- a/runtime/colorschemes/darcula_py.micro
+++ b/runtime/colorschemes/darcula_py.micro
@@ -1,0 +1,52 @@
+# Language related syntax
+color-link default "#A5B09E,#242424"
+color-link comment "italic #777777"
+color-link constant "bold #007364,#242424"        # None, self, Ellipse, cls, default for True and False*
+color-link constant.bool "bold #CB4B16,#242424"   # True && False
+color-link constant.number "bold #005A89"         # New: Float and int
+color-link constant.specialChar "italic #BF723F"  # New: Escape characters and {} inside string
+color-link constant.string "#6A8759,#242424"      # Single or double quotes, and docstring
+color-link constant.string.char "#6A8759,#242424" # unknown
+color-link constant.string.url "italic #777777"   # New: does not work*
+color-link identifier "italic #FFC66D,#242424"    # built in functions, def functions and function calls with or without dot
+color-link identifier.var "bold #A5B09E"          # New: Variables, attributes, placeholders*
+color-link identifier.class "bold #007364"        # New: As stated and few more*
+color-link message "bold #D33682,#C242424"        # As intended both for errors and some others
+color-link preproc "italic #3F8CBF,#242424"       # Statement preceded by an @
+color-link statement "#915010,#242424"            # Several keywords*
+color-link symbol "bold #CCCCCC,#242424"          # Default color
+color-link type "#817CCF,#242424"                 # Type hint in both inside and outisde of functions
+color-link type.keyword "#817CCF,#242424"         # Built-in types*
+color-link symbol.brackets "bold #AF7B27"         # New*
+color-link symbol.operator "bold #BF723F"         # New*
+color-link special "#CC8242,#242424"              # unknown
+color-link underlined "#D33682,#242424"           # unknown
+color-link error "bold #CB4B16,#242424"           # unknown
+color-link todo "bold #D33682,#242424"            # NOTE TODO*
+
+# Micro appearance
+color-link hlsearch "#CCCCCC,#32593D"
+color-link statusline "#FFC66D,#2C2C2C"
+color-link tabbar "#242424,#CCCCCC"
+color-link indent-char "#4F4F4F,#242424"
+color-link line-number "#977000,#2C2C2C"
+color-link current-line-number "#FFC66D,#242424"
+# 36, 37, 38 affected if "diffgutter" is set to true in "settings.json"
+color-link diff-added "#00AF00"
+color-link diff-modified "#FFAF00"
+color-link diff-deleted "#D70000"
+color-link gutter-error "#D33682,#242424"         # >> language error
+color-link gutter-warning "#36D387,#242424"       # >> i.e. spell checking
+color-link cursor-line "#2C2C2C"
+color-link color-column "#2C2C2C"
+color-link divider "#777777"                      # New
+color-link selection "#2C2C2C,#777777"            # New
+
+# No extended types; Plain brackets.
+color-link type.extended "default"
+color-link symbol.tag "#AE81FF,#242424"
+color-link match-brace "#242424,#7A9EC2"
+color-link tab-error "#D75F5F"
+color-link trailingws "#777777"
+
+# *NOTE* review the python3.yaml for more detail

--- a/runtime/colorschemes/monokai_py.micro
+++ b/runtime/colorschemes/monokai_py.micro
@@ -1,0 +1,52 @@
+# Language related syntax
+color-link default "#FF9366,#333333"
+color-link comment "#756F52,#333333"
+color-link constant "bold #7D7075,#333333"
+color-link constant.bool "bold #005A89,#333333"   # True && False
+color-link constant.number "bold #817CCF"
+color-link constant.specialChar "italic #747FE6"  # New: Escape characters and {} inside string
+color-link constant.string "#FFCA7A,#333333"
+color-link constant.string.char "#BDE6AD,#333333"
+color-link constant.string.url "italic #777777"   # New: does not work*
+color-link identifier "#FF9366,#333333"
+color-link identifier.var "bold #66D9EF"          # New: Variables, attributes, placeholders*
+color-link identifier.class "bold #AE81FF"        # New: As stated and few more*
+color-link message "bold #00C799,#C242424"        # As intended both for errors and some others
+color-link preproc "italic #FFB5FA,#333333"       # Statement preceded by an @
+color-link statement "#F92672,#333333"
+color-link symbol "bold #CCCCCC,#333333"          # Default color
+color-link type "#007364,#333333"                 # Type hint in both inside and outisde of functions
+color-link type.keyword "#007364,#333333"         # Built-in types*
+color-link symbol.brackets "bold #B8009A"         # New*
+color-link symbol.operator "bold #F92672,#333333"
+color-link special "#A6E22E,#333333"
+color-link underlined "#D33682,#333333"
+color-link error "bold #CB4B16,#333333"
+color-link todo "bold #D33682,#333333"
+
+# Micro appearance
+color-link hlsearch "#777777,#FFCA7A"
+color-link statusline "#FFC66D,#3E3E3E"
+color-link tabbar "#242424,#CCCCCC"
+color-link indent-char "#4F4F4F,#333333"
+color-link line-number "#977000,#2C2C2C"
+color-link current-line-number "#00C799,#333333"
+# 36, 37, 38 affected if "diffgutter" is set to true in "settings.json"
+color-link diff-added "#00AF00"
+color-link diff-modified "#FFAF00"
+color-link diff-deleted "#D70000"
+color-link gutter-error "#66D2FF,#333333"         # >> language error
+color-link gutter-warning "#A5B09E,#333333"       # >> i.e. spell checking
+color-link cursor-line "#3E3E3E"
+color-link color-column "#3E3E3E"
+color-link divider "#777777"                      # New
+color-link selection "#2C2C2C,#777777"            # New
+
+# No extended types; Plain brackets.
+color-link type.extended "default"
+color-link symbol.tag "#AE81FF,#333333"
+color-link match-brace "#333333,#AE81FF"
+color-link tab-error "#D75F5F"
+color-link trailingws "#777777"
+
+# *NOTE* review the python3.yaml for more detail

--- a/runtime/syntax/python3.yaml
+++ b/runtime/syntax/python3.yaml
@@ -5,22 +5,50 @@ detect:
     header: "^#!.*/(env +)?python(3)?$"
 
 rules:
-    # built-in objects
-    - constant: "\\b(Ellipsis|None|self|cls|True|False)\\b"
       # built-in attributes
     - constant: "\\b(__bases__|__builtin__|__class__|__debug__|__dict__|__doc__|__file__|__members__|__methods__|__name__|__self__)\\b"
       # built-in functions
     - identifier: "\\b(abs|all|any|ascii|bin|bool|breakpoint|bytearray|bytes|callable|chr|classmethod|compile|complex|delattr|dir|divmod|eval|exec|format|getattr|globals|hasattr|hash|help|hex|id|input|isinstance|issubclass|iter|len|locals|max|min|next|nonlocal|oct|open|ord|pow|print|repr|round|setattr|sorted|sum|vars|__import__)\\b"
+    - identifier: "\\b(classmethod|enumerate|filter|map|object|property|reversed|slice|staticmethod|super|type|zip)\\b" # New one, previously "type"
       # special method names
     - identifier: "\\b__(abs|add|and|call|cmp|coerce|complex|concat|contains|delattr|delitem|delslice|del|dict|divmod|div|float|getattr|getitem|getslice|hash|hex|iadd|iand|iconcat|ifloordiv|ilshift|imatmul|imod|imul|init|int|invert|inv|ior|ipow|irshift|isub|iter|itruediv|ixor|len|long|lshift|mod|mul|neg|next|nonzero|oct|or|pos|pow|radd|rand|rcmp|rdivmod|rdiv|repeat|repr|rlshift|rmod|rmul|ror|rpow|rrshift|rshift|rsub|rxor|setattr|setitem|setslice|str|sub|xor)__\\b"
-      # types
-    - type: "\\b(bool|bytearray|bytes|classmethod|complex|dict|enumerate|filter|float|frozenset|int|list|map|memoryview|object|property|range|reversed|set|slice|staticmethod|str|super|tuple|type|zip)\\b"
       # definitions
     - identifier: "def [a-zA-Z_0-9]+"
+      # Basic variable assign
+    - identifier.var: "((^|\\s+|\\()[\\w]+(\\s|,)?)+=" # New one
+      # Variable assignment to another variable
+    - identifier.var: "=\\s?[\\w]+" # New one
+      # Variables followed by ':' (for typing), '.' operand (call a function i.e. dict.items()) and as placeholders inside 'for' loop
+    - identifier.var: "[\\w]+((\\.|\\s)\\b|: )" # New one
+      # Variables stated after specific keywords
+    - identifier.var: "(return|while|for|if|and|or|in)\\s[a-zA-Z_0-9]+\\s?" # New one
+      # Variables followed or preceded by comparative operands.
+    - identifier.var: "[a-zA-Z0-9_]+\\s(<|>|<=|>=|!=|==)\\s([a-zA-Z0-9_]+)?:?$" # New one
+      # Variables followed/preceded by normal or compound assignment
+    - identifier.var: "(\\+|\\-|\\/|\\*)\\s\\w+" # New one
+    - identifier.var: "(^|\\s+|\\()\\w+\\s(\\+|\\-|\\/|\\*)?=?" # New one
+      # Variables inside any type of brackets. NOTE: variables with anything but integers or float, won't work.
+      # Dictionaries highlight variables as 'types' (because of the ':') instead of a regular variable
+    - identifier.var: "(\\(|\\[|{)([\\w]+|[\\d_]+(\\.[\\d_])*)((,|:)\\s([\\w]+|[\\d_]+(\\.[\\d_])*)?){0,},?(\\)|\\]|})\\s?(:|=)?" # New one
+      # Iterator slicing and key assignment
+    - identifier.var: "\\b[\\w]+(\\[[\\w:.\\(\\)\\s/*-+]+\\])" # New one
+      # Custom function call
+    - identifier: "[\\w]+\\("  # New one
+      # Functions called with dot operand
+    - identifier: "\\.[a-z]+\\(?"  # New one
+      # Import, class and error statements
+    - identifier.class: "(import|from|as|class|except)\\s[\\w]+((,\\s[\\w]+)+|:)?" # New one
       # keywords
     - statement: "\\b(and|as|assert|async|await|break|case|class|continue|def|del|elif|else|except|finally|for|from|global|if|import|in|is|lambda|match|nonlocal|not|or|pass|raise|return|try|while|with|yield)\\b"
       # decorators
     - preproc: "^\\s*@[^(]*"
+      # From `typing` module and other modules
+    - type: "(:|->)\\s[a-zA-Z]+(\\[[a-zA-Z]+(,\\s[a-zA-Z]+)?\\])?\\s?:?"  # New one
+      # Types in basic library (no modules imported)
+    - type.keyword: "\\b(str|int|float|complex|list|tuple|range|dict|set|frozenset|bool|bytes|bytearray|memoryview|NoneType)\\b" # New one
+      # built-in objects. NOTE: Changed to this location to take precedence
+    - constant: "\\b(Ellipsis|None|self|cls|True|False)\\b"
+    - constant.bool: "\\b(True|False)\\b"  # New one
       # operators
     - symbol.operator: "([~^.:;,+*|=!\\%@]|<|>|/|-|&)"
       # parentheses
@@ -45,6 +73,8 @@ rules:
         skip: "\\\\."
         rules:
             - constant.specialChar: "\\\\."
+            # f-string format
+            - constant.specialChar: "\\{[\\w\\d/*-+.\\s\\(\\)]*?\\}" # New one
 
     - constant.string:
         start: "'"
@@ -52,6 +82,11 @@ rules:
         skip: "\\\\."
         rules:
             - constant.specialChar: "\\\\."
+            # f-string format
+            - constant.specialChar: "\\{[\\w\\d/*-+.\\s\\(\\)]*?\\}" # New one
+
+      # NOTE: Requires unique symbols %&#... Currently not working presumably missing specific rules
+    - constant.string.url: "(http(s)?:\\/\\/w{3}\\.)?[\\w]+(\\.[a-z]{,3})+((\\/[\\w]+){1,})?" # New one
 
     - comment:
         start: "#"


### PR DESCRIPTION
Greetings,
I recently discovered Micro and it's an amazing editor. I managed to customize it to my needs and while doing so I stumble with the color schemes. I couldn't edit it to my hearts content so I gave it a try with the syntax file method and now I want to share it. After some trial and error I added some missing basic cases when coding in Python:

- Static typing
- Dot operand followed by a function call and so on.
- Built in and custom function calls
- Variable assignments
- Placeholders in loops
- Import, class and error handling
- Relocate/modify previous statements
-  *f-strings*
 
New statements (and modified ones) come with a comment explaining the new highlighted cases. Sadly I wasn't capable to address all of them as I wanted. For instance the __identifier.var__ at line 32, won't work in a dictionary because of the colon (overruled by the __type__ statement at 46 which was relocated in order to take precedence): also it only properly works if, say a list, only contains variables and numbers (both floats and integers) if there's a string then the variable won't be highlighted as intended, it will use the default color stated in the *.micro* color scheme file.
Finally I wasn't able to use the __color-link__ related to URL's. Although is a fairly generic regexp the editor just won't highlight it, I can only assume it needs a set of specific rules to properly work but to be honest I'm not really sure how to do so.
Even if you can target every possible scenario with the current groups and subgroups, by using better regexp and/or relocating some to take precedence, I would suggest to expand them overall for instance __identifier.var.attr__ when calling and defining functions.

Because of this small endeavor I also rework a couple of the color schemes complying with this new syntax file which is meant to work specifically with Python files (unless the file content from other languages shares keywords and such with Python).
This "new" color schemes (three at the moment, two are expanded from yours, the third is an adapted version) are divided by syntax related highlight and the editor appearance with some comments to improve readability. Some of them I let them unchanged mainly because I didn't found the case they're supposed to highlight.
I believe a deeper explanation of every group and subgroup may facilitate expanding/creating both syntax files and color schemes to a higher degree.