### PR TITLE
ignore quoted characters when splitting keybindings into actions

### DIFF
--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -100,9 +100,7 @@ func BufMapEvent(k Event, action string) {
 			break
 		}
 
-		// TODO: fix problem when complex bindings have these
-		// characters (escape them?)
-		idx := strings.IndexAny(action, "&|,")
+		idx := util.IndexAnyUnquoted(action, "&|,")
 		a := action
 		if idx >= 0 {
 			a = action[:idx]

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -320,6 +320,28 @@ func RunePos(b []byte, i int) int {
 	return CharacterCount(b[:i])
 }
 
+// IndexAnyUnquoted returns the first position in s of a character from chars.
+// Escaped (with backslash) and quoted (with single or double quotes) characters
+// are ignored. Returns -1 if not successful
+func IndexAnyUnquoted(s, chars string) int {
+	var e bool
+	var q rune
+	for i, r := range s {
+		if e {
+			e = false
+		} else if (q == 0 || q == '"') && r == '\\' {
+			e = true
+		} else if r == q {
+			q = 0
+		} else if q == 0 && (r == '\'' || r == '"') {
+			q = r
+		} else if q == 0 && strings.IndexRune(chars, r) >= 0 {
+			return i
+		}
+	}
+	return -1
+}
+
 // MakeRelative will attempt to make a relative path between path and base
 func MakeRelative(path, base string) (string, error) {
 	if len(path) > 0 {

--- a/runtime/help/keybindings.md
+++ b/runtime/help/keybindings.md
@@ -66,7 +66,9 @@ bindings, tab is bound as
 
 This means that if the `Autocomplete` action is successful, the chain will
 abort. Otherwise, it will try `IndentSelection`, and if that fails too, it
-will execute `InsertTab`.
+will execute `InsertTab`. To use `,`, `|` or `&` in an action (as an argument
+to a command, for example), escape it with `\` or wrap it in single or double
+quotes.
 
 ## Binding commands
 


### PR DESCRIPTION
Currently a keybinding of the form
```
"F3": "command:run sh -c 'ls | wc -l'"
```
does not work because micro interprets `&`, `|` and `,` as separators between actions:
https://github.com/zyedidia/micro/blob/f49487dc3adf82ec5e63bf1b6c0ffaed268aa747/internal/action/bufpane.go#L103-L105
This PR fixes this by ignoring escaped and quoted characters when splitting a keybinding into actions.