### PR TITLE
Fix 2 small formatting error of default value in options.md

### DIFF
--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -450,11 +450,11 @@ Here are the available options:
 * `tabhighlight`: inverts the tab characters' (filename, save indicator, etc)
    colors with respect to the tab bar.
 
-    default value: false
+    default value: `false`
 
 * `tabreverse`: reverses the tab bar colors when active.
 
-    default value: true
+    default value: `true`
 
 * `tabsize`: the size in spaces that a tab character should be displayed with.
 


### PR DESCRIPTION
There are 2 default values that don't have the proper formatting. This fixes those 2 small formatting error of default value in options.md.

Regards, Antoine