### PR TITLE
Add the ability lock settings.json and bindings.json for plugins

### DIFF
--- a/cmd/micro/initlua.go
+++ b/cmd/micro/initlua.go
@@ -73,7 +73,7 @@ func luaImportMicroConfig() *lua.LTable {
 	ulua.L.SetField(pkg, "OptionComplete", luar.New(ulua.L, action.OptionComplete))
 	ulua.L.SetField(pkg, "OptionValueComplete", luar.New(ulua.L, action.OptionValueComplete))
 	ulua.L.SetField(pkg, "NoComplete", luar.New(ulua.L, nil))
-	ulua.L.SetField(pkg, "TryBindKey", luar.New(ulua.L, action.TryBindKey))
+	ulua.L.SetField(pkg, "TryBindKey", luar.New(ulua.L, action.TryBindKeyPlug))
 	ulua.L.SetField(pkg, "Reload", luar.New(ulua.L, action.ReloadConfig))
 	ulua.L.SetField(pkg, "AddRuntimeFileFromMemory", luar.New(ulua.L, config.PluginAddRuntimeFileFromMemory))
 	ulua.L.SetField(pkg, "AddRuntimeFilesFromDirectory", luar.New(ulua.L, config.PluginAddRuntimeFilesFromDirectory))
@@ -88,8 +88,8 @@ func luaImportMicroConfig() *lua.LTable {
 	ulua.L.SetField(pkg, "RegisterCommonOption", luar.New(ulua.L, config.RegisterCommonOptionPlug))
 	ulua.L.SetField(pkg, "RegisterGlobalOption", luar.New(ulua.L, config.RegisterGlobalOptionPlug))
 	ulua.L.SetField(pkg, "GetGlobalOption", luar.New(ulua.L, config.GetGlobalOption))
-	ulua.L.SetField(pkg, "SetGlobalOption", luar.New(ulua.L, action.SetGlobalOption))
-	ulua.L.SetField(pkg, "SetGlobalOptionNative", luar.New(ulua.L, action.SetGlobalOptionNative))
+	ulua.L.SetField(pkg, "SetGlobalOption", luar.New(ulua.L, action.SetGlobalOptionPlug))
+	ulua.L.SetField(pkg, "SetGlobalOptionNative", luar.New(ulua.L, action.SetGlobalOptionNativePlug))
 	ulua.L.SetField(pkg, "ConfigDir", luar.New(ulua.L, config.ConfigDir))
 
 	return pkg

--- a/internal/action/bindings.go
+++ b/internal/action/bindings.go
@@ -256,6 +256,13 @@ func eventsEqual(e1 Event, e2 Event) bool {
 	return e1 == e2
 }
 
+func TryBindKeyPlug(k, v string, overwrite bool) (bool, error) {
+	if l, ok := config.GlobalSettings["lockbindings"]; ok && l.(bool) {
+		return false, errors.New("bindings.json file locked by user for all plugins")
+	}
+	return TryBindKey(k, v, overwrite)
+}
+
 // TryBindKey tries to bind a key by writing to config.ConfigDir/bindings.json
 // Returns true if the keybinding already existed and a possible error
 func TryBindKey(k, v string, overwrite bool) (bool, error) {

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -634,6 +634,13 @@ func doSetGlobalOptionNative(option string, nativeValue interface{}) error {
 	return nil
 }
 
+func SetGlobalOptionNativePlug(option string, nativeValue interface{}) error {
+	if l, ok := config.GlobalSettings["locksettings"]; ok && l.(bool) {
+		return errors.New("settings.json file locked by user for all plugins")
+	}
+	return SetGlobalOptionNative(option, nativeValue)
+}
+
 func SetGlobalOptionNative(option string, nativeValue interface{}) error {
 	if err := config.OptionIsValid(option, nativeValue); err != nil {
 		return err
@@ -658,6 +665,13 @@ func SetGlobalOptionNative(option string, nativeValue interface{}) error {
 	}
 
 	return config.WriteSettings(filepath.Join(config.ConfigDir, "settings.json"))
+}
+
+func SetGlobalOptionPlug(option, value string) error {
+	if l, ok := config.GlobalSettings["locksettings"]; ok && l.(bool) {
+		return errors.New("settings.json file locked by user for all plugins")
+	}
+	return SetGlobalOption(option, value)
 }
 
 func SetGlobalOption(option, value string) error {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -116,6 +116,8 @@ var DefaultGlobalOnlySettings = map[string]interface{}{
 	"helpsplit":      "hsplit",
 	"infobar":        true,
 	"keymenu":        false,
+	"lockbindings":   false,
+	"locksettings":   false,
 	"mouse":          true,
 	"multiopen":      "tab",
 	"parsecursor":    false,

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -237,6 +237,16 @@ Here are the available options:
 
     default value: `false`
 
+* `lockbindings`: Disable plugins to modify the `bindings.json` in your config
+   directory.
+
+    default value: `false`
+
+* `locksettings`: Disable plugins to modify the `settings.json` in your config
+   directory.
+
+    default value: `false`
+
 * `matchbrace`: show matching braces for '()', '{}', '[]' when the cursor
    is on a brace character or (if `matchbraceleft` is enabled) next to it.
 


### PR DESCRIPTION
If you have comments in either `settings.json` or `bindings.json`, it is possible for plugins to overwrite the json, and erases all the formatting done by the user.

Adding an option to lock these files to avoid losing formatting.

Related to #3385 (Which we should close), #3302 , #2194 