### PR TITLE
Add missing resize in TabMove

### DIFF
--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -205,6 +205,7 @@ func (h *BufPane) TabMoveCmd(args []string) {
 	Tabs.List = append(Tabs.List, nil)
 	copy(Tabs.List[idxTo+1:], Tabs.List[idxTo:])
 	Tabs.List[idxTo] = activeTab
+	Tabs.Resize()
 	Tabs.UpdateNames()
 	Tabs.SetActive(idxTo)
 	// InfoBar.Message(fmt.Sprintf("Moved tab from slot %d to %d", idxFrom+1, idxTo+1))


### PR DESCRIPTION
If you create 2 scratched buffers tabs (just new tabs), do `tabswitch 2`, then perform a `tabmove 1` (or `tabmove 2`, doesn't matter), and then go to the next/prev tab, the tab bar will disappear when selecting one of the tabs. 

I didn't fully figure out why it happens but it seems like it is missing a Resize to update the tab sizes. This patch fixes that.