### PR TITLE
statusline: Provide `overwrite` mode indicator

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1864,7 +1864,7 @@ func (h *BufPane) CommandMode() bool {
 
 // ToggleOverwriteMode lets the user toggle the text overwrite mode
 func (h *BufPane) ToggleOverwriteMode() bool {
-	h.isOverwriteMode = !h.isOverwriteMode
+	h.Buf.OverwriteMode = !h.Buf.OverwriteMode
 	return true
 }
 

--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -224,8 +224,6 @@ type BufPane struct {
 	// (possibly multiple) buttons were pressed previously.
 	mousePressed map[MouseEvent]bool
 
-	// We need to keep track of insert key press toggle
-	isOverwriteMode bool
 	// This stores when the last click was
 	// This is useful for detecting double and triple clicks
 	lastClickTime time.Time
@@ -358,9 +356,6 @@ func (h *BufPane) OpenBuffer(b *buffer.Buffer) {
 	// Set mouseReleased to true because we assume the mouse is not being
 	// pressed when the editor is opened
 	h.resetMouse()
-	// Set isOverwriteMode to false, because we assume we are in the default
-	// mode when editor is opened
-	h.isOverwriteMode = false
 	h.lastClickTime = time.Time{}
 }
 
@@ -639,7 +634,7 @@ func (h *BufPane) DoRuneInsert(r rune) {
 			c.ResetSelection()
 		}
 
-		if h.isOverwriteMode {
+		if h.Buf.OverwriteMode {
 			next := c.Loc
 			next.X++
 			h.Buf.Replace(c.Loc, next, string(r))

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -209,6 +209,11 @@ type Buffer struct {
 	LastSearchRegex bool
 	// HighlightSearch enables highlighting all instances of the last successful search
 	HighlightSearch bool
+
+	// OverwriteMode indicates that we are in overwrite mode (toggled by
+	// Insert key by default) i.e. that typing a character shall replace the
+	// character under the cursor instead of inserting a character before it.
+	OverwriteMode bool
 }
 
 // NewBufferFromFileAtLoc opens a new buffer with a given cursor location

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -93,7 +93,7 @@ var defaultCommonSettings = map[string]interface{}{
 	"softwrap":        false,
 	"splitbottom":     true,
 	"splitright":      true,
-	"statusformatl":   "$(filename) $(modified)($(line),$(col)) $(status.paste)| ft:$(opt:filetype) | $(opt:fileformat) | $(opt:encoding)",
+	"statusformatl":   "$(filename) $(modified)$(overwrite)($(line),$(col)) $(status.paste)| ft:$(opt:filetype) | $(opt:fileformat) | $(opt:encoding)",
 	"statusformatr":   "$(bind:ToggleKeyMenu): bindings, $(bind:ToggleHelp): help",
 	"statusline":      true,
 	"syntax":          true,

--- a/internal/display/statusline.go
+++ b/internal/display/statusline.go
@@ -47,6 +47,12 @@ var statusInfo = map[string]func(*buffer.Buffer) string{
 		}
 		return ""
 	},
+	"overwrite": func(b *buffer.Buffer) string {
+		if b.OverwriteMode && !b.Type.Readonly {
+			return "[ovwr] "
+		}
+		return ""
+	},
 	"lines": func(b *buffer.Buffer) string {
 		return strconv.Itoa(b.LinesNum())
 	},

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -415,11 +415,11 @@ Here are the available options:
 * `statusformatl`: format string definition for the left-justified part of the
    statusline. Special directives should be placed inside `$()`. Special
    directives include: `filename`, `modified`, `line`, `col`, `lines`,
-   `percentage`, `opt`, `bind`.
+   `percentage`, `opt`, `overwrite`, `bind`.
    The `opt` and `bind` directives take either an option or an action afterward
    and fill in the value of the option or the key bound to the action.
 
-    default value: `$(filename) $(modified)($(line),$(col)) $(status.paste)|
+    default value: `$(filename) $(modified)$(overwrite)($(line),$(col)) $(status.paste)|
                     ft:$(opt:filetype) | $(opt:fileformat) | $(opt:encoding)`
 
 * `statusformatr`: format string definition for the right-justified part of the
@@ -578,7 +578,7 @@ so that you can see what the formatting should look like.
     "splitbottom": true,
     "splitright": true,
     "status": true,
-    "statusformatl": "$(filename) $(modified)($(line),$(col)) $(status.paste)| ft:$(opt:filetype) | $(opt:fileformat) | $(opt:encoding)",
+    "statusformatl": "$(filename) $(modified)$(overwrite)($(line),$(col)) $(status.paste)| ft:$(opt:filetype) | $(opt:fileformat) | $(opt:encoding)",
     "statusformatr": "$(bind:ToggleKeyMenu): bindings, $(bind:ToggleHelp): help",
     "statusline": true,
     "sucmd": "sudo",


### PR DESCRIPTION
We can store the `overwrite` state in the `Buffer` instead of the `BufPane`, which makes it easier to be accessed from the `statusline` via the `statusformatl` option.

Closes #3155