### PR TITLE
Fixing settings not being applied when saving as a new file

### DIFF
--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -232,6 +232,6 @@ func (b *Buffer) saveToFile(filename string, withSudo bool, autoSave bool) error
 	absPath, _ := filepath.Abs(filename)
 	b.AbsPath = absPath
 	b.isModified = false
-	b.UpdateRules()
+	b.ReloadSettings(true)
 	return err
 }


### PR DESCRIPTION
When you have file type-specific settings, it won't get applied when you are saving to a new file.

So if you have something like:
```json
    "ft:c": {
        "colorcolumn": 50
    }
```

Creating a new buffer and saving to a c file won't apply the `colorcolumn` settings. This is just for demonstration. Opening an existing file will however apply the settings as intended. 

This patch fixes that.
