### PR TITLE
Prompt to save or discard new files even with autosave enabled

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1917,7 +1917,7 @@ func (h *BufPane) Quit() bool {
 			}
 		}
 
-		if config.GlobalSettings["autosave"].(float64) > 0 {
+		if config.GlobalSettings["autosave"].(float64) > 0 && h.Buf.Path != "" {
 			// autosave on means we automatically save when quitting
 			h.SaveCB("Quit", func() {
 				h.ForceQuit()


### PR DESCRIPTION
Fix for #3624 (thanks @JoeKar).

Autosave should only apply to existing or named files. For unnamed ("No name") files, Micro should still prompt you to save or discard before exiting.

Fixes #3624