### PR TITLE
Plugin dir name clarification

### DIFF
--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -7,7 +7,8 @@ enable or disable a plugin, look for `Plugin options` in `help options`.
 Micro supports creating plugins with a simple Lua system. Plugins are
 folders containing Lua files and possibly other source files placed
 in `~/.config/micro/plug`. The plugin directory (within `plug`) should
-contain at least one Lua file and a `repo.json` file. The `repo.json` file
+contain at least one Lua file and a `repo.json` file, and should be named 
+using only alphanumeric characters and underscore. The `repo.json` file
 provides additional information such as the name of the plugin, the
 plugin's website, dependencies, etc.
 [Here is an example `repo.json` file](https://github.com/micro-editor/updated-plugins/blob/master/go-plugin/repo.json)


### PR DESCRIPTION
Micro rejects the plugin if the dir-name does not match the regex `^[_A-Za-z0-9]+$`.