### PR TITLE
fix cycling through completion suggestions ending in non-word character

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -911,6 +911,11 @@ func (h *BufPane) Autocomplete() bool {
 		return false
 	}
 
+	if b.HasSuggestions {
+		b.CycleAutocomplete(true)
+		return true
+	}
+
 	if h.Cursor.X == 0 {
 		return false
 	}
@@ -921,10 +926,6 @@ func (h *BufPane) Autocomplete() bool {
 		return false
 	}
 
-	if b.HasSuggestions {
-		b.CycleAutocomplete(true)
-		return true
-	}
 	return b.Autocomplete(buffer.BufferComplete)
 }
 


### PR DESCRIPTION
The fix is only relevant for certain plugins, but I think this is more correct behavior anyway.

fixes #3649