### PR TITLE
buffer: Fix `ReloadSettings(true)` for volatile `filetype`

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1794,12 +1794,12 @@ func (h *BufPane) HalfPageDown() bool {
 
 // ToggleDiffGutter turns the diff gutter off and on
 func (h *BufPane) ToggleDiffGutter() bool {
-	if !h.Buf.Settings["diffgutter"].(bool) {
-		h.Buf.Settings["diffgutter"] = true
+	diffgutter := !h.Buf.Settings["diffgutter"].(bool)
+	h.Buf.SetOptionNative("diffgutter", diffgutter)
+	if diffgutter {
 		h.Buf.UpdateDiff()
 		InfoBar.Message("Enabled diff gutter")
 	} else {
-		h.Buf.Settings["diffgutter"] = false
 		InfoBar.Message("Disabled diff gutter")
 	}
 	return true
@@ -1807,11 +1807,11 @@ func (h *BufPane) ToggleDiffGutter() bool {
 
 // ToggleRuler turns line numbers off and on
 func (h *BufPane) ToggleRuler() bool {
-	if !h.Buf.Settings["ruler"].(bool) {
-		h.Buf.Settings["ruler"] = true
+	ruler := !h.Buf.Settings["ruler"].(bool)
+	h.Buf.SetOptionNative("ruler", ruler)
+	if ruler {
 		InfoBar.Message("Enabled ruler")
 	} else {
-		h.Buf.Settings["ruler"] = false
 		InfoBar.Message("Disabled ruler")
 	}
 	return true

--- a/internal/buffer/settings.go
+++ b/internal/buffer/settings.go
@@ -12,6 +12,7 @@ import (
 
 func (b *Buffer) ReloadSettings(reloadFiletype bool) {
 	settings := config.ParsedSettings()
+	config.UpdatePathGlobLocals(settings, b.AbsPath)
 
 	_, local := b.LocalSettings["filetype"]
 	_, volatile := config.VolatileSettings["filetype"]
@@ -26,7 +27,6 @@ func (b *Buffer) ReloadSettings(reloadFiletype bool) {
 	// update syntax rules, which will also update filetype if needed
 	b.UpdateRules()
 
-	config.UpdatePathGlobLocals(settings, b.AbsPath)
 	config.UpdateFileTypeLocals(settings, b.Settings["filetype"].(string))
 	for k, v := range config.DefaultCommonSettings() {
 		if k == "filetype" {

--- a/internal/buffer/settings.go
+++ b/internal/buffer/settings.go
@@ -25,9 +25,9 @@ func (b *Buffer) ReloadSettings(reloadFiletype bool) {
 
 	// update syntax rules, which will also update filetype if needed
 	b.UpdateRules()
-	settings["filetype"] = b.Settings["filetype"]
 
-	config.InitLocalSettings(settings, b.Path)
+	config.UpdatePathGlobLocals(settings, b.AbsPath)
+	config.UpdateFileTypeLocals(settings, b.Settings["filetype"].(string))
 	for k, v := range config.DefaultCommonSettings() {
 		if k == "filetype" {
 			// prevent recursion

--- a/internal/buffer/settings.go
+++ b/internal/buffer/settings.go
@@ -13,7 +13,9 @@ import (
 func (b *Buffer) ReloadSettings(reloadFiletype bool) {
 	settings := config.ParsedSettings()
 
-	if _, ok := b.LocalSettings["filetype"]; !ok && reloadFiletype {
+	_, local := b.LocalSettings["filetype"]
+	_, volatile := config.VolatileSettings["filetype"]
+	if reloadFiletype && !local && !volatile {
 		// need to update filetype before updating other settings based on it
 		b.Settings["filetype"] = "unknown"
 		if v, ok := settings["filetype"]; ok {

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -288,24 +288,31 @@ func InitGlobalSettings() error {
 	return err
 }
 
-// InitLocalSettings scans the json in settings.json and sets the options locally based
-// on whether the filetype or path matches ft or glob local settings
+// UpdatePathGlobLocals scans the already parsed settings and sets the options locally
+// based on whether the path matches a glob
 // Must be called after ReadSettings
-func InitLocalSettings(settings map[string]interface{}, path string) {
+func UpdatePathGlobLocals(settings map[string]interface{}, path string) {
 	for k, v := range parsedSettings {
-		if strings.HasPrefix(reflect.TypeOf(v).String(), "map") {
-			if strings.HasPrefix(k, "ft:") {
-				if settings["filetype"].(string) == k[3:] {
-					for k1, v1 := range v.(map[string]interface{}) {
-						settings[k1] = v1
-					}
+		if strings.HasPrefix(reflect.TypeOf(v).String(), "map") && !strings.HasPrefix(k, "ft:") {
+			g, _ := glob.Compile(k)
+			if g.MatchString(path) {
+				for k1, v1 := range v.(map[string]interface{}) {
+					settings[k1] = v1
 				}
-			} else {
-				g, _ := glob.Compile(k)
-				if g.MatchString(path) {
-					for k1, v1 := range v.(map[string]interface{}) {
-						settings[k1] = v1
-					}
+			}
+		}
+	}
+}
+
+// UpdateFileTypeLocals scans the already parsed settings and sets the options locally
+// based on whether the filetype matches to "ft:"
+// Must be called after ReadSettings
+func UpdateFileTypeLocals(settings map[string]interface{}, filetype string) {
+	for k, v := range parsedSettings {
+		if strings.HasPrefix(reflect.TypeOf(v).String(), "map") && strings.HasPrefix(k, "ft:") {
+			if filetype == k[3:] {
+				for k1, v1 := range v.(map[string]interface{}) {
+					settings[k1] = v1
 				}
 			}
 		}

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -312,7 +312,9 @@ func UpdateFileTypeLocals(settings map[string]interface{}, filetype string) {
 		if strings.HasPrefix(reflect.TypeOf(v).String(), "map") && strings.HasPrefix(k, "ft:") {
 			if filetype == k[3:] {
 				for k1, v1 := range v.(map[string]interface{}) {
-					settings[k1] = v1
+					if k1 != "filetype" {
+						settings[k1] = v1
+					}
 				}
 			}
 		}


### PR DESCRIPTION
As found out by @niten94 we didn't perform the callbacks in case we reload the `filetype`.

Fixes #3659