### PR TITLE
`sh.yaml`: Match valid parameter expansions without braces

### DIFF
--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -42,7 +42,7 @@ rules:
     - statement: "\\s+(-[A-Za-z]+|--[a-z]+)"
 
     - identifier: "\\$\\{[0-9A-Za-z_:!%&=+#~@*^$?, .\\-\\/\\[\\]]+\\}"
-    - identifier: "\\$[0-9A-Za-z_:!%&=+#~@*^$?,\\-\\[\\]]+"
+    - identifier: "\\$([0-9_!#@*$?-]|[A-Za-z_]\\w*)"
 
     - constant.string:
         start: "\""

--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -41,7 +41,7 @@ rules:
       # Conditional flags
     - statement: "\\s+(-[A-Za-z]+|--[a-z]+)"
 
-    - identifier: "\\$\\{[0-9A-Za-z_:!%&=+#~@*^$?, .\\-\\/\\[\\]]+\\}"
+    - identifier: "\\$\\{[\\w:!%&=+#~@*^$?, .\\-\\/\\[\\]]+\\}"
     - identifier: "\\$([0-9_!#@*$?-]|[A-Za-z_]\\w*)"
 
     - constant.string:


### PR DESCRIPTION
In this pull request, text not parsed in `sh` as part of a name in parameter expansions without braces are changed to not be highlighted together.

In `sh`, there is no expansion format other than `$parameter` when there are no braces. Names cannot begin with a digit but positional parameters with one digit can be specified.

Fixes #3660