### PR TITLE
ReloadSettings only when we need to when saving a file

### DIFF
--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -322,11 +322,16 @@ func (b *Buffer) saveToFile(filename string, withSudo bool, autoSave bool) error
 		}
 	}
 
+	newPath := b.Path != filename
 	b.Path = filename
 	b.AbsPath = absFilename
 	b.isModified = false
 	b.UpdateModTime()
-	b.ReloadSettings(true)
+
+	if newPath {
+		// need to update glob-based and filetype-based settings
+		b.ReloadSettings(true)
+	}
 
 	err = b.Serialize()
 	return err


### PR DESCRIPTION
ReloadSettings only when we need to when saving a file instead of doing it every time when we save, which will also have the benefit of allowing old plugins to work.

Fixes #3687