### PR TITLE
Updating SaveCmd to use saveBufToFile instead

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1042,7 +1042,6 @@ func (h *BufPane) saveBufToFile(filename string, action string, callback func())
 				if err != nil {
 					InfoBar.Error(err)
 				} else {
-					h.Buf.SetName(filename)
 					InfoBar.Message("Saved " + filename)
 					if callback != nil {
 						callback()
@@ -1067,7 +1066,6 @@ func (h *BufPane) saveBufToFile(filename string, action string, callback func())
 			InfoBar.Error(err)
 		}
 	} else {
-		h.Buf.SetName(filename)
 		InfoBar.Message("Saved " + filename)
 		if callback != nil {
 			callback()

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -907,10 +907,7 @@ func (h *BufPane) SaveCmd(args []string) {
 	if len(args) == 0 {
 		h.Save()
 	} else {
-		err := h.Buf.SaveAs(args[0])
-		if err != nil {
-			InfoBar.Error(err)
-		}
+		h.saveBufToFile(args[0], "SaveAs", nil)
 	}
 }
 


### PR DESCRIPTION
Using `saveBufToFile()` to allow sudo prompt instead of just failing.

Also, this fixes the bug where the name is not updated when newly saved buffer is saved again as a different file.
So for example if you create a new buffer (`AddTab` for example) and save as `a.txt`. Then save again as `b.txt`, the title is not updated since it is calling the buffer `SaveAs()` method directly.

I have no idea how the name gets updated in other situations (for example open an existing file and saving it as another file) despite it calling the buffer `SaveAs()` method directly. 