### PR TITLE
Adding error screen for lua functions running in status line

### DIFF
--- a/internal/display/statusline.go
+++ b/internal/display/statusline.go
@@ -83,6 +83,8 @@ func SetStatusInfoFnLua(fn string) {
 			} else {
 				return string(v)
 			}
+		} else {
+			screen.TermMessage(plFn, "failed with error\n"+err.Error())
 		}
 		return ""
 	}


### PR DESCRIPTION
Any Lua plugin error in the status line is hidden since we are not exposing the error, making it impossible to debug. Adding error screen for that.