### PR TITLE
Adding lua function to use result of updated RunBackgroundShell

### DIFF
--- a/cmd/micro/initlua.go
+++ b/cmd/micro/initlua.go
@@ -101,6 +101,14 @@ func luaImportMicroShell() *lua.LTable {
 	ulua.L.SetField(pkg, "ExecCommand", luar.New(ulua.L, shell.ExecCommand))
 	ulua.L.SetField(pkg, "RunCommand", luar.New(ulua.L, shell.RunCommand))
 	ulua.L.SetField(pkg, "RunBackgroundShell", luar.New(ulua.L, shell.RunBackgroundShell))
+	ulua.L.SetField(pkg, "LaunchBackgroundShellFunc", luar.New(ulua.L, func(f func() (string, error), cb func(string, error)) {
+		go func() {
+			output, runErr := f()
+			if cb != nil {
+				cb(output, runErr)
+			}
+		}()
+	}))
 	ulua.L.SetField(pkg, "RunInteractiveShell", luar.New(ulua.L, shell.RunInteractiveShell))
 	ulua.L.SetField(pkg, "JobStart", luar.New(ulua.L, shell.JobStart))
 	ulua.L.SetField(pkg, "JobSpawn", luar.New(ulua.L, shell.JobSpawn))

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -819,12 +819,17 @@ func (h *BufPane) UnbindCmd(args []string) {
 
 // RunCmd runs a shell command in the background
 func (h *BufPane) RunCmd(args []string) {
-	runf, err := shell.RunBackgroundShell(shellquote.Join(args...))
+	runCmd := shellquote.Join(args...)
+	runf, err := shell.RunBackgroundShell(runCmd)
 	if err != nil {
 		InfoBar.Error(err)
 	} else {
 		go func() {
-			InfoBar.Message(runf())
+			output, runErr := runf()
+			if runErr != nil {
+				output = fmt.Sprint(runCmd, " exited with error: ", err)
+			}
+			InfoBar.Message(output)
 			screen.Redraw()
 		}()
 	}

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -3,7 +3,6 @@ package shell
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
@@ -48,7 +47,7 @@ func RunCommand(input string) (string, error) {
 // RunBackgroundShell runs a shell command in the background
 // It returns a function which will run the command and returns a string
 // message result
-func RunBackgroundShell(input string) (func() string, error) {
+func RunBackgroundShell(input string) (func() (string, error), error) {
 	args, err := shellquote.Split(input)
 	if err != nil {
 		return nil, err
@@ -56,15 +55,8 @@ func RunBackgroundShell(input string) (func() string, error) {
 	if len(args) == 0 {
 		return nil, errors.New("No arguments")
 	}
-	inputCmd := args[0]
-	return func() string {
-		output, err := RunCommand(input)
-
-		str := output
-		if err != nil {
-			str = fmt.Sprint(inputCmd, " exited with error: ", err, ": ", output)
-		}
-		return str
+	return func() (string, error) {
+		return RunCommand(input)
 	}, nil
 }
 

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -249,8 +249,12 @@ The packages and their contents are listed below (in Go type signatures):
        two arguments in the `ExecCommand` argument list (quoting arguments
        will preserve spaces).
 
-    - `RunBackgroundShell(input string) (func() string, error)`: returns a
+    - `RunBackgroundShell(input string) (func() (string, error), error)`: returns a
        function that will run the given shell command and return its output.
+
+    - `LaunchBackgroundShellFunc(f func() (string, error), cb func(string, error))`: Runs
+       the returned function from `RunBackgroundShell` in the background. The output and
+       erorr of such function will be passed to the callback.
 
     - `RunInteractiveShell(input string, wait bool, getOutput bool)
                           (string, error)`:


### PR DESCRIPTION
Currently, `RunBackgroundShell()` returns a function and an error. I don't think there's a way to run that function asynchronously from lua plugin. 

Adding a helper lua function for that. 

Although there's an additional error to the return of the returned function from `RunBackgroundShell()`, this has no impact the lua plugins that are currently using it since it first return var is the same.  I have tested this with a lua plugin.