### PR TITLE
plugins/comment: Add `commenttype` for the filetype `asm`

### DIFF
--- a/runtime/plugins/comment/comment.lua
+++ b/runtime/plugins/comment/comment.lua
@@ -7,6 +7,7 @@ local buffer = import("micro/buffer")
 local ft = {}
 
 ft["apacheconf"] = "# %s"
+ft["asm"] = "; %s"
 ft["batch"] = ":: %s"
 ft["c"] = "// %s"
 ft["c++"] = "// %s"


### PR DESCRIPTION
Fixes #3693