### PR TITLE
syntax: asm: highlight C-like comments

### DIFF
--- a/runtime/syntax/asm.yaml
+++ b/runtime/syntax/asm.yaml
@@ -4,7 +4,7 @@ detect:
     filename: "\\.(S|s|asm)$"
 
 rules:
-    # This file is made for NASM assembly
+    # This file is made mainly for NASM assembly
 
     ## Instructions
     # x86
@@ -108,3 +108,16 @@ rules:
         rules:
             - todo: "(TODO|XXX|FIXME):?"
 
+    ## C-like comments (supported by some assemblers)
+
+    - comment:
+        start: "//"
+        end: "$"
+        rules:
+            - todo: "(TODO|XXX|FIXME):?"
+
+    - comment:
+        start: "/\\*"
+        end: "\\*/"
+        rules:
+            - todo: "(TODO|XXX|FIXME):?"


### PR DESCRIPTION
Different assemblers have different syntaxes for comments: `;`, `#`, `!`, `|`, `@`, `*` and finally C-like comments `//` and `/* ... */`.

Micro currently highlights only `;`. This is causing various problems with broken highlighting with other types of comments (i.e. those not recognized by micro as comments), when the text in those comments contains special characters, causing wrong highlighting of text after them.

On the other hand, highlighting comments like `#`, `|` etc would cause conflicts with other syntax elements, e.g. constants in ARM assembly, preprocessor directives, arithmetic expressions etc.

So let's highlight at least C-like comments. They are quite commonly used and they are not so likely to cause conflicts with other syntax elements.

See also discussion in #3694.