### PR TITLE
Fix unable to perform proportional resize caused by chained parents after quiting a nested VSplit inside a HSplit

### DIFF
--- a/internal/views/splits.go
+++ b/internal/views/splits.go
@@ -439,11 +439,12 @@ func (n *Node) VSplit(right bool) uint64 {
 }
 
 // unsplits the child of a split
-func (n *Node) unsplit(i int, h bool) {
+func (n *Node) unsplit(i int) {
 	copy(n.children[i:], n.children[i+1:])
 	n.children[len(n.children)-1] = nil
 	n.children = n.children[:len(n.children)-1]
 
+	h := n.Kind == STVert
 	nonrs, numr := n.getResizeInfo(h)
 	if numr == 0 {
 		// This means that this was the last child
@@ -470,12 +471,7 @@ func (n *Node) Unsplit() bool {
 			ind = i
 		}
 	}
-	if n.parent.Kind == STVert {
-		n.parent.unsplit(ind, true)
-	} else {
-		n.parent.unsplit(ind, false)
-	}
-
+	n.parent.unsplit(ind)
 	if n.parent.IsLeaf() {
 		return n.parent.Unsplit()
 	}


### PR DESCRIPTION
When you do a HSplit, follow by a VSplit, then quit the last pane and do a HSplit again, the proportional resize won't work as expected.

Currently you will get a 50%, 25%, 25% HSplits.
Instead it should be 33%, 33%, 33%.

This problem is caused by failing to resolve chained parents and the resize is called on the "wrong" parent.

The patch fixes chained parents by simplifying the tree when unsplittng.

This problem can be visualized by calling the `String()` on the current tab. In lua, it will look something like this:

```lua
function MyFunction(bp)
    micro.Log("Node Tree:", bp:Tab():String())
end
```

So if you have something like this

```text
-------------------------------------------------------------
|                                  |                        |
|                                  |             2          |
|              1                   |----------------------- |
|                                  |                        |
|                                  |             3          |
-------------------------------------------------------------
```

the tree looks like this:
```text
-{0 0 211 46} 1
     |{0 0 105 46} 1🍁
     |{105 0 106 46} 2
         -{105 0 106 23} 2🍁
         -{105 23 106 23} 3🍁
```

If you quit the 3rd pane, the tree will look like this:

```text
-{0 0 211 46} 1
    |{0 0 105 46} 1🍁
    |{105 0 106 46} 
        -{105 0 106 46} 2🍁
```

Then if you do a VSplit, the tree will look like
```text
-{0 0 211 46} 1
    |{0 0 105 46} 1🍁
    |{105 0 106 46} 2
        -{105 0 106 46} 2
            |{105 0 53 46} 2🍁
            |{158 0 53 46} 4🍁
```

Which fails the resize since it is calling on a chained parent


After applying the patch, it will "simplify" the tree after quitting the 3rd pane

```text
-{0 0 211 46} 1
    |{0 0 105 46} 1🍁
    |{105 0 106 46} 2🍁
```

Then when you do another VSplit, it will look like this:
```text
-{0 0 211 46} 1
    |{0 0 70 46} 1🍁
    |{70 0 70 46} 2🍁
    |{140 0 71 46} 3🍁
```

 and the resize will work as expected since it will be called on the correct parent.







