### PR TITLE
Skip save on `open` or `term` command if buffer is shared

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1909,14 +1909,7 @@ func (h *BufPane) ForceQuit() bool {
 
 // Quit this will close the current tab or view that is open
 func (h *BufPane) Quit() bool {
-	if h.Buf.Modified() {
-		for _, b := range buffer.OpenBuffers {
-			if b != h.Buf && b.SharedBuffer == h.Buf.SharedBuffer {
-				h.ForceQuit()
-				return true
-			}
-		}
-
+	if h.Buf.Modified() && !h.Buf.Shared() {
 		if config.GlobalSettings["autosave"].(float64) > 0 && h.Buf.Path != "" {
 			// autosave on means we automatically save when quitting
 			h.SaveCB("Quit", func() {

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1907,6 +1907,18 @@ func (h *BufPane) ForceQuit() bool {
 	return true
 }
 
+// closePrompt displays a prompt to save the buffer before closing it to proceed
+// with a different action or command
+func (h *BufPane) closePrompt(action string, callback func()) {
+	InfoBar.YNPrompt("Save changes to "+h.Buf.GetName()+" before closing? (y,n,esc)", func(yes, canceled bool) {
+		if !canceled && !yes {
+			callback()
+		} else if !canceled && yes {
+			h.SaveCB(action, callback)
+		}
+	})
+}
+
 // Quit this will close the current tab or view that is open
 func (h *BufPane) Quit() bool {
 	if h.Buf.Modified() && !h.Buf.Shared() {
@@ -1916,14 +1928,8 @@ func (h *BufPane) Quit() bool {
 				h.ForceQuit()
 			})
 		} else {
-			InfoBar.YNPrompt("Save changes to "+h.Buf.GetName()+" before closing? (y,n,esc)", func(yes, canceled bool) {
-				if !canceled && !yes {
-					h.ForceQuit()
-				} else if !canceled && yes {
-					h.SaveCB("Quit", func() {
-						h.ForceQuit()
-					})
-				}
+			h.closePrompt("Quit", func() {
+				h.ForceQuit()
 			})
 		}
 	} else {

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -308,7 +308,7 @@ func (h *BufPane) OpenCmd(args []string) {
 			}
 			h.OpenBuffer(b)
 		}
-		if h.Buf.Modified() {
+		if h.Buf.Modified() && !h.Buf.Shared() {
 			InfoBar.YNPrompt("Save changes to "+h.Buf.GetName()+" before closing? (y,n,esc)", func(yes, canceled bool) {
 				if !canceled && !yes {
 					open()
@@ -1121,7 +1121,7 @@ func (h *BufPane) TermCmd(args []string) {
 
 	for i, p := range ps {
 		if p.ID() == h.ID() {
-			if h.Buf.Modified() {
+			if h.Buf.Modified() && !h.Buf.Shared() {
 				InfoBar.YNPrompt("Save changes to "+h.Buf.GetName()+" before closing? (y,n,esc)", func(yes, canceled bool) {
 					if !canceled && !yes {
 						term(i, false)

--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -309,14 +309,7 @@ func (h *BufPane) OpenCmd(args []string) {
 			h.OpenBuffer(b)
 		}
 		if h.Buf.Modified() && !h.Buf.Shared() {
-			InfoBar.YNPrompt("Save changes to "+h.Buf.GetName()+" before closing? (y,n,esc)", func(yes, canceled bool) {
-				if !canceled && !yes {
-					open()
-				} else if !canceled && yes {
-					h.Save()
-					open()
-				}
-			})
+			h.closePrompt("Save", open)
 		} else {
 			open()
 		}
@@ -1122,13 +1115,8 @@ func (h *BufPane) TermCmd(args []string) {
 	for i, p := range ps {
 		if p.ID() == h.ID() {
 			if h.Buf.Modified() && !h.Buf.Shared() {
-				InfoBar.YNPrompt("Save changes to "+h.Buf.GetName()+" before closing? (y,n,esc)", func(yes, canceled bool) {
-					if !canceled && !yes {
-						term(i, false)
-					} else if !canceled && yes {
-						h.Save()
-						term(i, false)
-					}
+				h.closePrompt("Save", func() {
+					term(i, false)
 				})
 			} else {
 				term(i, false)

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -620,6 +620,16 @@ func (b *Buffer) WordAt(loc Loc) []byte {
 	return b.Substr(start, end)
 }
 
+// Shared returns if there are other buffers with the same file as this buffer
+func (b *Buffer) Shared() bool {
+	for _, buf := range OpenBuffers {
+		if buf != b && buf.SharedBuffer == b.SharedBuffer {
+			return true
+		}
+	}
+	return false
+}
+
 // Modified returns if this buffer has been modified since
 // being opened
 func (b *Buffer) Modified() bool {


### PR DESCRIPTION
This pull request modifies the `open` and `term` command to skip the save prompt if a file is opened in multiple buffers, in the same way with #3559. The buffer or pane is also replaced when all prompts are completed like the `Quit` action, since the prompt code is generalized into a method.

The names and comments of added methods and parameters could be improved, but I wasn't able to come up with a way to do so.