### PR TITLE
Convert leftover usages of `path` to `filepath`

### DIFF
--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -479,7 +478,7 @@ func (b *Buffer) GetName() string {
 		name = b.Path
 	}
 	if b.Settings["basename"].(bool) {
-		return path.Base(name)
+		return filepath.Base(name)
 	}
 	return name
 }

--- a/internal/config/rtfiles.go
+++ b/internal/config/rtfiles.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -84,8 +83,8 @@ func (rf realFile) Data() ([]byte, error) {
 }
 
 func (af assetFile) Name() string {
-	fn := path.Base(string(af))
-	return fn[:len(fn)-len(path.Ext(fn))]
+	fn := filepath.Base(string(af))
+	return fn[:len(fn)-len(filepath.Ext(fn))]
 }
 
 func (af assetFile) Data() ([]byte, error) {
@@ -125,8 +124,8 @@ func AddRuntimeFilesFromAssets(fileType RTFiletype, directory, pattern string) {
 
 assetLoop:
 	for _, f := range files {
-		if ok, _ := path.Match(pattern, f); ok {
-			af := assetFile(path.Join(directory, f))
+		if ok, _ := filepath.Match(pattern, f); ok {
+			af := assetFile(filepath.Join(directory, f))
 			for _, rf := range realFiles[fileType] {
 				if af.Name() == rf.Name() {
 					continue assetLoop
@@ -167,7 +166,7 @@ func InitRuntimeFiles(user bool) {
 		if user {
 			AddRuntimeFilesFromDirectory(fileType, filepath.Join(ConfigDir, dir), pattern)
 		}
-		AddRuntimeFilesFromAssets(fileType, path.Join("runtime", dir), pattern)
+		AddRuntimeFilesFromAssets(fileType, filepath.Join("runtime", dir), pattern)
 	}
 
 	initRuntimeVars()
@@ -300,7 +299,7 @@ func PluginAddRuntimeFile(plugin string, filetype RTFiletype, filePath string) e
 	if _, err := os.Stat(fullpath); err == nil {
 		AddRealRuntimeFile(filetype, realFile(fullpath))
 	} else {
-		fullpath = path.Join("runtime", "plugins", pldir, filePath)
+		fullpath = filepath.Join("runtime", "plugins", pldir, filePath)
 		AddRuntimeFile(filetype, assetFile(fullpath))
 	}
 	return nil
@@ -317,7 +316,7 @@ func PluginAddRuntimeFilesFromDirectory(plugin string, filetype RTFiletype, dire
 	if _, err := os.Stat(fullpath); err == nil {
 		AddRuntimeFilesFromDirectory(filetype, fullpath, pattern)
 	} else {
-		fullpath = path.Join("runtime", "plugins", pldir, directory)
+		fullpath = filepath.Join("runtime", "plugins", pldir, directory)
 		AddRuntimeFilesFromAssets(filetype, fullpath, pattern)
 	}
 	return nil

--- a/internal/lua/lua.go
+++ b/internal/lua/lua.go
@@ -427,7 +427,6 @@ func importPath() *lua.LTable {
 func importFilePath() *lua.LTable {
 	pkg := L.NewTable()
 
-	L.SetField(pkg, "Join", luar.New(L, filepath.Join))
 	L.SetField(pkg, "Abs", luar.New(L, filepath.Abs))
 	L.SetField(pkg, "Base", luar.New(L, filepath.Base))
 	L.SetField(pkg, "Clean", luar.New(L, filepath.Clean))


### PR DESCRIPTION
Fixes #3726