### PR TITLE
Relocate buffer view after setting options that affect it

### DIFF
--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -61,6 +61,12 @@ func (w *BufWindow) SetBuffer(b *buffer.Buffer) {
 				c.LastWrappedVisualX = c.GetVisualX(true)
 			}
 		}
+
+		if option == "diffgutter" || option == "ruler" || option == "scrollbar" ||
+			option == "statusline" {
+			w.updateDisplayInfo()
+			w.Relocate()
+		}
 	}
 	b.GetVisualX = func(loc buffer.Loc) int {
 		return w.VLocFromLoc(loc).VisualX


### PR DESCRIPTION
Whenever the user changes the value of an option that affects the calculation of display params in `updateDisplayInfo()`, we should immediately recalculate those params and relocate the buffer view accordingly.

For example: after enabling ruler via `set ruler on`, if the cursor is currently at the rightmost edge of the bufpane and softwrap is disabled, then the cursor becomes invisible (since it is now outside the view, since the buffer view width is decreased as a result of adding the ruler but `StartCol` is not updated accordingly), it only becomes visible again after the user types a character (or performs some other action that triggers `updateDisplayInfo()` + relocate). Fix it.

Somewhat related to #3741