### PR TITLE
Change MainTab calls

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1891,11 +1891,11 @@ func (h *BufPane) ClearInfo() bool {
 	return true
 }
 
-// ForceQuit closes the current tab or view even if there are unsaved changes
+// ForceQuit closes the tab or view even if there are unsaved changes
 // (no prompt)
 func (h *BufPane) ForceQuit() bool {
 	h.Buf.Close()
-	if len(MainTab().Panes) > 1 {
+	if len(h.tab.Panes) > 1 {
 		h.Unsplit()
 	} else if len(Tabs.List) > 1 {
 		Tabs.RemoveTab(h.splitID)

--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -652,28 +652,28 @@ func (h *BufPane) DoRuneInsert(r rune) {
 // VSplitIndex opens the given buffer in a vertical split on the given side.
 func (h *BufPane) VSplitIndex(buf *buffer.Buffer, right bool) *BufPane {
 	e := NewBufPaneFromBuf(buf, h.tab)
-	e.splitID = MainTab().GetNode(h.splitID).VSplit(right)
-	currentPaneIdx := MainTab().GetPane(h.splitID)
+	e.splitID = h.tab.GetNode(h.splitID).VSplit(right)
+	currentPaneIdx := h.tab.GetPane(h.splitID)
 	if right {
 		currentPaneIdx++
 	}
-	MainTab().AddPane(e, currentPaneIdx)
-	MainTab().Resize()
-	MainTab().SetActive(currentPaneIdx)
+	h.tab.AddPane(e, currentPaneIdx)
+	h.tab.Resize()
+	h.tab.SetActive(currentPaneIdx)
 	return e
 }
 
 // HSplitIndex opens the given buffer in a horizontal split on the given side.
 func (h *BufPane) HSplitIndex(buf *buffer.Buffer, bottom bool) *BufPane {
 	e := NewBufPaneFromBuf(buf, h.tab)
-	e.splitID = MainTab().GetNode(h.splitID).HSplit(bottom)
-	currentPaneIdx := MainTab().GetPane(h.splitID)
+	e.splitID = h.tab.GetNode(h.splitID).HSplit(bottom)
+	currentPaneIdx := h.tab.GetPane(h.splitID)
 	if bottom {
 		currentPaneIdx++
 	}
-	MainTab().AddPane(e, currentPaneIdx)
-	MainTab().Resize()
-	MainTab().SetActive(currentPaneIdx)
+	h.tab.AddPane(e, currentPaneIdx)
+	h.tab.Resize()
+	h.tab.SetActive(currentPaneIdx)
 	return e
 }
 


### PR DESCRIPTION
Swaping `MainTab` calls to `h.tab` will not change the normal micro behaviour.
This changes will make possible (in plugins), to call`ForceQuit`, `VSplitIndex` and `HSplitIndex` for tabs that aren't main one.