### PR TITLE
Adding indenttabchar, indentspacechar and spacechar options

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -70,7 +70,7 @@ var defaultCommonSettings = map[string]interface{}{
 	"hltrailingws":    false,
 	"ignorecase":      true,
 	"incsearch":       true,
-	"indentchar":      " ",
+	"indentchar":      " ", // Deprecated
 	"keepautoindent":  false,
 	"matchbrace":      true,
 	"matchbraceleft":  true,
@@ -88,6 +88,7 @@ var defaultCommonSettings = map[string]interface{}{
 	"scrollbar":       false,
 	"scrollmargin":    float64(3),
 	"scrollspeed":     float64(2),
+	"showchars":       "",
 	"smartpaste":      true,
 	"softwrap":        false,
 	"splitbottom":     true,
@@ -210,6 +211,7 @@ func validateParsedSettings() error {
 			}
 			continue
 		}
+
 		if _, ok := defaults[k]; ok {
 			if e := verifySetting(k, v, defaults[k]); e != nil {
 				err = e

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -203,12 +203,8 @@ Here are the available options:
 
     default value: `true`
 
-* `indentchar`: sets the indentation character. This will not be inserted into
-   files; it is only a visual indicator that whitespace is present. If set to a
-   printing character, it functions as a subset of the "show invisibles"
-   setting available in many other text editors. The color of this character is
-   determined by the `indent-char` field in the current theme rather than the
-   default text color.
+* `indentchar`: sets the character to be shown to display tab characters.
+   This option is **deprecated**, use the `tab` key in `showchars` option instead.
 
     default value: ` ` (space)
 
@@ -385,6 +381,25 @@ Here are the available options:
 * `scrollspeed`: amount of lines to scroll for one scroll event.
 
     default value: `2`
+
+* `showchars`: sets what characters to be shown to display various invisible
+   characters in the file. The characters shown will not be inserted into files.
+   This option is specified in the form of `key1=value1,key2=value2,...`.
+
+   Here are the list of keys:
+   - `space`: space characters
+   - `tab`: tab characters. If set, overrides the `indentchar` option.
+   - `ispace`: space characters at indent position before the first visible
+               character in a line. If this is not set, `space` will be shown
+               instead.
+   - `itab`: tab characters before the first visible character in a line.
+             If this is not set, `tab` will be shown instead.
+   An example of this option value could be `tab=>,space=.,itab=|>,ispace=|`
+
+   The color of the shown character is determined by the `indent-char`
+   field in the current theme rather than the default text color.
+
+    default value: ``
 
 * `smartpaste`: add leading whitespace when pasting multiple lines.
    This will attempt to preserve the current indentation level when pasting an
@@ -577,6 +592,7 @@ so that you can see what the formatting should look like.
     "scrollbarchar": "|",
     "scrollmargin": 3,
     "scrollspeed": 2,
+    "showchars": "",
     "smartpaste": true,
     "softwrap": false,
     "splitbottom": true,


### PR DESCRIPTION
This PR added the options of `indentspacechar` and `spacechar` and moved `indentchar` to `indenttabchar` to avoid confusion.

`indenttabchar` will display the specified character when `\t` is encountered.

`indentspacechar` will display the specified character when `' '` is encountered at `tabsize` locations

`spacechar` will display the specified character when `' '` is encountered, but `indentspacechar` takes precedence.

Created this PR because I wanted the feature to view files with deeply nested blocks. 
Gonna merge it to my own fork https://github.com/Neko-Box-Coder/micro-dev for whoever needs it while waiting for this to be merged.

This should address long-standing requests of #2539 , #2707 and #431 

I am happy to revert the prompt message of telling user `indentchar` is deprecated, if people/maintainer finds it controversial. 