### PR TITLE
Fix non-working colorscheme plugins

### DIFF
--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -374,11 +374,6 @@ func main() {
 	action.InitBindings()
 	action.InitCommands()
 
-	err = config.InitColorscheme()
-	if err != nil {
-		screen.TermMessage(err)
-	}
-
 	err = config.RunPluginFn("preinit")
 	if err != nil {
 		screen.TermMessage(err)
@@ -403,6 +398,11 @@ func main() {
 	}
 
 	err = config.RunPluginFn("postinit")
+	if err != nil {
+		screen.TermMessage(err)
+	}
+
+	err = config.InitColorscheme()
 	if err != nil {
 		screen.TermMessage(err)
 	}

--- a/internal/config/colorscheme.go
+++ b/internal/config/colorscheme.go
@@ -55,6 +55,14 @@ func InitColorscheme() error {
 	c, err := LoadDefaultColorscheme()
 	if err == nil {
 		Colorscheme = c
+	} else {
+		// The colorscheme setting seems broken (maybe because we have not validated
+		// it earlier, see comment in verifySetting()). So reset it to the default
+		// colorscheme and try again.
+		GlobalSettings["colorscheme"] = DefaultGlobalOnlySettings["colorscheme"]
+		if c, err2 := LoadDefaultColorscheme(); err2 == nil {
+			Colorscheme = c
+		}
 	}
 
 	return err

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -270,6 +270,12 @@ func verifySetting(option string, value interface{}, def interface{}) error {
 		return fmt.Errorf("Error: setting '%s' has incorrect type (%s), using default value: %v (%s)", option, valType, def, defType)
 	}
 
+	if option == "colorscheme" {
+		// Plugins are not initialized yet, so do not verify if the colorscheme
+		// exists yet, since the colorscheme may be added by a plugin later.
+		return nil
+	}
+
 	if err := OptionIsValid(option, value); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #3455

Micro "allows" plugins to register colorschemes via `config.AddRuntimeFile()`. However, that has never really worked, since `InitColorscheme()` is called earlier than plugins `init()` or even `preinit()` callbacks are called.

To work around that, colorscheme plugins (e.g. https://github.com/KiranWells/micro-nord-tc-colors) are using a tricky hack: call `config.AddRuntimeFile()` not in `init()` or `preinit()` but directly in Lua's global scope, so that it is called even earlier, when the plugin's Lua code is loaded. This hack is not guaranteed to work, and works by chance. Furthermore, it only works when starting micro, and doesn't work after the `reload` command. (The reason it doesn't work is that `PluginAddRuntimeFile()` calls `FindPlugin()` which calls `IsLoaded()` which returns false, since, well, the plugin is not loaded, it is only being loaded. And the reason why it works when starting micro is that in that case `IsLoaded()` confusingly returns true, since `GlobalSettings[p.Name]` has not been set yet.)

Moreover, after PR #3343 even this hack stopped working, since we added validation of option values (including the `colorscheme` option) when reading them from settings.json, which happens even earlier than loading plugins. So validation checks if the colorscheme exists, and it doesn't exist yet, since it has not been registered by the plugin yet.

So, this PR does 2 things:

1. Fix the regression caused by [#3343](https://github.com/zyedidia/micro/pull/3343) by disabling early validation for the `colorscheme` option only (treating this option as a special case). We "validate" it later: when we try to load this colorscheme and fail, we reset it to the default colorscheme.

This fix is quite ad-doc and a bit hacky, so any better suggestions are welcome.

2. Fix the original issue: postpone loading colorschemes after fully initializing plugins (i.e. after executing `init()`, `preinit()` and `postinit()` callbacks), so that plugins can finally successfully register colorschemes in those callbacks, instead of using the above tricky hack which is not guaranteed to work.