### PR TITLE
Added fenced code block syntax highlighting in markdown 

### DIFF
--- a/runtime/syntax/markdown.yaml
+++ b/runtime/syntax/markdown.yaml
@@ -1,48 +1,965 @@
 filetype: markdown
-
 detect:
-    filename: "\\.(livemd|md|mkd|mkdn|markdown)$"
-
+  filename: \.(livemd|md|mkd|mkdn|markdown)$
 rules:
-    # Tables (Github extension)
-    - type: ".*[ :]\\|[ :].*"
+  # Tables (Github extension)
+  - type: ".*[ :]\\|[ :].*"
 
-      # quotes
-    - statement:  "^>.*"
+  # quotes
+  - statement: "^>.*"
 
-      # Emphasis
-    - type: "(^|[[:space:]])(_[^ ][^_]*_|\\*[^ ][^*]*\\*)"
+  # Emphasis
+  - type: "(^|[[:space:]])(_[^ ][^_]*_|\\*[^ ][^*]*\\*)"
 
-      # Strong emphasis
-    - type: "(^|[[:space:]])(__[^ ][^_]*__|\\*\\*[^ ][^*]*\\*\\*)"
+  # Strong emphasis
+  - type: "(^|[[:space:]])(__[^ ][^_]*__|\\*\\*[^ ][^*]*\\*\\*)"
 
-      # strike-through
-    - type: "(^|[[:space:]])~~[^ ][^~]*~~"
+  # strike-through
+  - type: "(^|[[:space:]])~~[^ ][^~]*~~"
 
-      # horizontal rules
-    - special: "^(---+|===+|___+|\\*\\*\\*+)\\s*$"
+  # horizontal rules
+  - special: "^(---+|===+|___+|\\*\\*\\*+)\\s*$"
 
-      # headlines
-    - special:  "^#{1,6}.*"
+  # headlines
+  - special: "^#{1,6}.*"
 
-      # lists
-    - identifier:   "^[[:space:]]*[\\*+-] |^[[:space:]]*[0-9]+\\. "
+  # lists
+  - identifier: "^[[:space:]]*[\\*+-] |^[[:space:]]*[0-9]+\\. "
 
-      # misc
-    - preproc:   "(\\(([CcRr]|[Tt][Mm])\\)|\\.{3}|(^|[[:space:]])\\-\\-($|[[:space:]]))"
+  # misc
+  - preproc: "(\\(([CcRr]|[Tt][Mm])\\)|\\.{3}|(^|[[:space:]])\\-\\-($|[[:space:]]))"
 
-      # links
-    - constant: "\\[[^]]+\\]"
-    - constant: "\\[([^][]|\\[[^]]*\\])*\\]\\([^)]+\\)"
+  # links
+  - constant: "\\[[^]]+\\]"
+  - constant: "\\[([^][]|\\[[^]]*\\])*\\]\\([^)]+\\)"
 
-      # images
-    - underlined: "!\\[[^][]*\\](\\([^)]+\\)|\\[[^]]+\\])"
+  # images
+  - underlined: "!\\[[^][]*\\](\\([^)]+\\)|\\[[^]]+\\])"
 
-      # urls
-    - underlined: "https?://[^ )>]+"
+  # urls
+  - underlined: "https?://[^ )>]+"
 
-    - special: "^```$"
+  - special: "^```$"
 
-    - special:
-        start: "`"
-        end: "`"
+  # Fenced code block syntax highlighting
+  - comment:
+      start: (?i)^```ada$
+      end: ^```$
+      rules:
+        - include: "ada"
+
+  - comment:
+      start: (?i)^```apacheconf$
+      end: ^```$
+      rules:
+        - include: "apacheconf"
+
+  - comment:
+      start: (?i)^```arduino$
+      end: ^```$
+      rules:
+        - include: "arduino"
+
+  - comment:
+      start: (?i)^```asciidoc$
+      end: ^```$
+      rules:
+        - include: "asciidoc"
+
+  - comment:
+      start: (?i)^```asm$
+      end: ^```$
+      rules:
+        - include: "asm"
+
+  - comment:
+      start: (?i)^```ats$
+      end: ^```$
+      rules:
+        - include: "ats"
+
+  - comment:
+      start: (?i)^```awk$
+      end: ^```$
+      rules:
+        - include: "awk"
+
+  - comment:
+      start: (?i)^```bat$
+      end: ^```$
+      rules:
+        - include: "bat"
+
+  - comment:
+      start: (?i)^```c$
+      end: ^```$
+      rules:
+        - include: "c"
+
+  - comment:
+      start: (?i)^```caddyfile$
+      end: ^```$
+      rules:
+        - include: "caddyfile"
+
+  - comment:
+      start: (?i)^```cake$
+      end: ^```$
+      rules:
+        - include: "cake"
+
+  - comment:
+      start: (?i)^```clojure$
+      end: ^```$
+      rules:
+        - include: "clojure"
+
+  - comment:
+      start: (?i)^```cmake$
+      end: ^```$
+      rules:
+        - include: "cmake"
+
+  - comment:
+      start: (?i)^```coffeescript$
+      end: ^```$
+      rules:
+        - include: "coffeescript"
+
+  - comment:
+      start: (?i)^```colortest$
+      end: ^```$
+      rules:
+        - include: "colortest"
+
+  - comment:
+      start: (?i)^```conky$
+      end: ^```$
+      rules:
+        - include: "conky"
+
+  - comment:
+      start: (?i)^```cpp$
+      end: ^```$
+      rules:
+        - include: "cpp"
+
+  - comment:
+      start: (?i)^```crontab$
+      end: ^```$
+      rules:
+        - include: "crontab"
+
+  - comment:
+      start: (?i)^```crystal$
+      end: ^```$
+      rules:
+        - include: "crystal"
+
+  - comment:
+      start: (?i)^```csharp$
+      end: ^```$
+      rules:
+        - include: "csharp"
+
+  - comment:
+      start: (?i)^```css$
+      end: ^```$
+      rules:
+        - include: "css"
+
+  - comment:
+      start: (?i)^```csx$
+      end: ^```$
+      rules:
+        - include: "csx"
+
+  - comment:
+      start: (?i)^```cuda$
+      end: ^```$
+      rules:
+        - include: "cuda"
+
+  - comment:
+      start: (?i)^```cython$
+      end: ^```$
+      rules:
+        - include: "cython"
+
+  - comment:
+      start: (?i)^```d$
+      end: ^```$
+      rules:
+        - include: "d"
+
+  - comment:
+      start: (?i)^```dart$
+      end: ^```$
+      rules:
+        - include: "dart"
+
+  - comment:
+      start: (?i)^```default$
+      end: ^```$
+      rules:
+        - include: "default"
+
+  - comment:
+      start: (?i)^```dockerfile$
+      end: ^```$
+      rules:
+        - include: "dockerfile"
+
+  - comment:
+      start: (?i)^```dot$
+      end: ^```$
+      rules:
+        - include: "dot"
+
+  - comment:
+      start: (?i)^```elixir$
+      end: ^```$
+      rules:
+        - include: "elixir"
+
+  - comment:
+      start: (?i)^```elm$
+      end: ^```$
+      rules:
+        - include: "elm"
+
+  - comment:
+      start: (?i)^```erb$
+      end: ^```$
+      rules:
+        - include: "erb"
+
+  - comment:
+      start: (?i)^```erlang$
+      end: ^```$
+      rules:
+        - include: "erlang"
+
+  - comment:
+      start: (?i)^```fish$
+      end: ^```$
+      rules:
+        - include: "fish"
+
+  - comment:
+      start: (?i)^```forth$
+      end: ^```$
+      rules:
+        - include: "forth"
+
+  - comment:
+      start: (?i)^```fortran$
+      end: ^```$
+      rules:
+        - include: "fortran"
+
+  - comment:
+      start: (?i)^```freebsd-kernel$
+      end: ^```$
+      rules:
+        - include: "freebsd-kernel"
+
+  - comment:
+      start: (?i)^```fsharp$
+      end: ^```$
+      rules:
+        - include: "fsharp"
+
+  - comment:
+      start: (?i)^```gdscript$
+      end: ^```$
+      rules:
+        - include: "gdscript"
+
+  - comment:
+      start: (?i)^```gemini$
+      end: ^```$
+      rules:
+        - include: "gemini"
+
+  - comment:
+      start: (?i)^```gentoo-ebuild$
+      end: ^```$
+      rules:
+        - include: "gentoo-ebuild"
+
+  - comment:
+      start: (?i)^```gentoo-etc-portage$
+      end: ^```$
+      rules:
+        - include: "gentoo-etc-portage"
+
+  - comment:
+      start: (?i)^```git-commit$
+      end: ^```$
+      rules:
+        - include: "git-commit"
+
+  - comment:
+      start: (?i)^```git-config$
+      end: ^```$
+      rules:
+        - include: "git-config"
+
+  - comment:
+      start: (?i)^```git-rebase-todo$
+      end: ^```$
+      rules:
+        - include: "git-rebase-todo"
+
+  - comment:
+      start: (?i)^```glsl$
+      end: ^```$
+      rules:
+        - include: "glsl"
+
+  - comment:
+      start: (?i)^```gnuplot$
+      end: ^```$
+      rules:
+        - include: "gnuplot"
+
+  - comment:
+      start: (?i)^```go$
+      end: ^```$
+      rules:
+        - include: "go"
+
+  - comment:
+      start: (?i)^```godoc$
+      end: ^```$
+      rules:
+        - include: "godoc"
+
+  - comment:
+      start: (?i)^```golo$
+      end: ^```$
+      rules:
+        - include: "golo"
+
+  - comment:
+      start: (?i)^```gomod$
+      end: ^```$
+      rules:
+        - include: "gomod"
+
+  - comment:
+      start: (?i)^```graphql$
+      end: ^```$
+      rules:
+        - include: "graphql"
+
+  - comment:
+      start: (?i)^```groff$
+      end: ^```$
+      rules:
+        - include: "groff"
+
+  - comment:
+      start: (?i)^```groovy$
+      end: ^```$
+      rules:
+        - include: "groovy"
+
+  - comment:
+      start: (?i)^```haml$
+      end: ^```$
+      rules:
+        - include: "haml"
+
+  - comment:
+      start: (?i)^```hare$
+      end: ^```$
+      rules:
+        - include: "hare"
+
+  - comment:
+      start: (?i)^```haskell$
+      end: ^```$
+      rules:
+        - include: "haskell"
+
+  - comment:
+      start: (?i)^```hc$
+      end: ^```$
+      rules:
+        - include: "hc"
+
+  - comment:
+      start: (?i)^```html$
+      end: ^```$
+      rules:
+        - include: "html"
+
+  - comment:
+      start: (?i)^```html4$
+      end: ^```$
+      rules:
+        - include: "html4"
+
+  - comment:
+      start: (?i)^```html5$
+      end: ^```$
+      rules:
+        - include: "html5"
+
+  - comment:
+      start: (?i)^```ini$
+      end: ^```$
+      rules:
+        - include: "ini"
+
+  - comment:
+      start: (?i)^```inputrc$
+      end: ^```$
+      rules:
+        - include: "inputrc"
+
+  - comment:
+      start: (?i)^```java$
+      end: ^```$
+      rules:
+        - include: "java"
+
+  - comment:
+      start: (?i)^```javascript$
+      end: ^```$
+      rules:
+        - include: "javascript"
+
+  - comment:
+      start: (?i)^```jinja2$
+      end: ^```$
+      rules:
+        - include: "jinja2"
+
+  - comment:
+      start: (?i)^```json$
+      end: ^```$
+      rules:
+        - include: "json"
+
+  - comment:
+      start: (?i)^```jsonnet$
+      end: ^```$
+      rules:
+        - include: "jsonnet"
+
+  - comment:
+      start: (?i)^```julia$
+      end: ^```$
+      rules:
+        - include: "julia"
+
+  - comment:
+      start: (?i)^```justfile$
+      end: ^```$
+      rules:
+        - include: "justfile"
+
+  - comment:
+      start: (?i)^```keymap$
+      end: ^```$
+      rules:
+        - include: "keymap"
+
+  - comment:
+      start: (?i)^```kickstart$
+      end: ^```$
+      rules:
+        - include: "kickstart"
+
+  - comment:
+      start: (?i)^```kotlin$
+      end: ^```$
+      rules:
+        - include: "kotlin"
+
+  - comment:
+      start: (?i)^```kvlang$
+      end: ^```$
+      rules:
+        - include: "kvlang"
+
+  - comment:
+      start: (?i)^```ledger$
+      end: ^```$
+      rules:
+        - include: "ledger"
+
+  - comment:
+      start: (?i)^```lfe$
+      end: ^```$
+      rules:
+        - include: "lfe"
+
+  - comment:
+      start: (?i)^```lilypond$
+      end: ^```$
+      rules:
+        - include: "lilypond"
+
+  - comment:
+      start: (?i)^```lisp$
+      end: ^```$
+      rules:
+        - include: "lisp"
+
+  - comment:
+      start: (?i)^```log$
+      end: ^```$
+      rules:
+        - include: "log"
+
+  - comment:
+      start: (?i)^```lua$
+      end: ^```$
+      rules:
+        - include: "lua"
+
+  - comment:
+      start: (?i)^```mail$
+      end: ^```$
+      rules:
+        - include: "mail"
+
+  - comment:
+      start: (?i)^```makefile$
+      end: ^```$
+      rules:
+        - include: "makefile"
+
+  - comment:
+      start: (?i)^```man$
+      end: ^```$
+      rules:
+        - include: "man"
+
+  - comment:
+      start: (?i)^```mc$
+      end: ^```$
+      rules:
+        - include: "mc"
+
+  - comment:
+      start: (?i)^```micro$
+      end: ^```$
+      rules:
+        - include: "micro"
+
+  - comment:
+      start: (?i)^```mpdconf$
+      end: ^```$
+      rules:
+        - include: "mpdconf"
+
+  - comment:
+      start: (?i)^```msbuild$
+      end: ^```$
+      rules:
+        - include: "msbuild"
+
+  - comment:
+      start: (?i)^```nanorc$
+      end: ^```$
+      rules:
+        - include: "nanorc"
+
+  - comment:
+      start: (?i)^```nftables$
+      end: ^```$
+      rules:
+        - include: "nftables"
+
+  - comment:
+      start: (?i)^```nginx$
+      end: ^```$
+      rules:
+        - include: "nginx"
+
+  - comment:
+      start: (?i)^```nim$
+      end: ^```$
+      rules:
+        - include: "nim"
+
+  - comment:
+      start: (?i)^```nix$
+      end: ^```$
+      rules:
+        - include: "nix"
+
+  - comment:
+      start: (?i)^```nu$
+      end: ^```$
+      rules:
+        - include: "nu"
+
+  - comment:
+      start: (?i)^```objc$
+      end: ^```$
+      rules:
+        - include: "objc"
+
+  - comment:
+      start: (?i)^```ocaml$
+      end: ^```$
+      rules:
+        - include: "ocaml"
+
+  - comment:
+      start: (?i)^```octave$
+      end: ^```$
+      rules:
+        - include: "octave"
+
+  - comment:
+      start: (?i)^```odin$
+      end: ^```$
+      rules:
+        - include: "odin"
+
+  - comment:
+      start: (?i)^```pascal$
+      end: ^```$
+      rules:
+        - include: "pascal"
+
+  - comment:
+      start: (?i)^```patch$
+      end: ^```$
+      rules:
+        - include: "patch"
+
+  - comment:
+      start: (?i)^```peg$
+      end: ^```$
+      rules:
+        - include: "peg"
+
+  - comment:
+      start: (?i)^```perl$
+      end: ^```$
+      rules:
+        - include: "perl"
+
+  - comment:
+      start: (?i)^```php$
+      end: ^```$
+      rules:
+        - include: "php"
+
+  - comment:
+      start: (?i)^```pkg-config$
+      end: ^```$
+      rules:
+        - include: "pkg-config"
+
+  - comment:
+      start: (?i)^```po$
+      end: ^```$
+      rules:
+        - include: "po"
+
+  - comment:
+      start: (?i)^```pony$
+      end: ^```$
+      rules:
+        - include: "pony"
+
+  - comment:
+      start: (?i)^```pov$
+      end: ^```$
+      rules:
+        - include: "pov"
+
+  - comment:
+      start: (?i)^```PowerShell$
+      end: ^```$
+      rules:
+        - include: "PowerShell"
+
+  - comment:
+      start: (?i)^```privoxy-action$
+      end: ^```$
+      rules:
+        - include: "privoxy-action"
+
+  - comment:
+      start: (?i)^```privoxy-config$
+      end: ^```$
+      rules:
+        - include: "privoxy-config"
+
+  - comment:
+      start: (?i)^```privoxy-filter$
+      end: ^```$
+      rules:
+        - include: "privoxy-filter"
+
+  - comment:
+      start: (?i)^```proto$
+      end: ^```$
+      rules:
+        - include: "proto"
+
+  - comment:
+      start: (?i)^```puppet$
+      end: ^```$
+      rules:
+        - include: "puppet"
+
+  - comment:
+      start: (?i)^```python2$
+      end: ^```$
+      rules:
+        - include: "python2"
+
+  - comment:
+      start: (?i)^```python$
+      end: ^```$
+      rules:
+        - include: "python3"
+
+  - comment:
+      start: (?i)^```r$
+      end: ^```$
+      rules:
+        - include: "r"
+
+  - comment:
+      start: (?i)^```raku$
+      end: ^```$
+      rules:
+        - include: "raku"
+
+  - comment:
+      start: (?i)^```renpy$
+      end: ^```$
+      rules:
+        - include: "renpy"
+
+  - comment:
+      start: (?i)^```reST$
+      end: ^```$
+      rules:
+        - include: "reST"
+
+  - comment:
+      start: (?i)^```rpmspec$
+      end: ^```$
+      rules:
+        - include: "rpmspec"
+
+  - comment:
+      start: (?i)^```ruby$
+      end: ^```$
+      rules:
+        - include: "ruby"
+
+  - comment:
+      start: (?i)^```rust$
+      end: ^```$
+      rules:
+        - include: "rust"
+
+  - comment:
+      start: (?i)^```sage$
+      end: ^```$
+      rules:
+        - include: "sage"
+
+  - comment:
+      start: (?i)^```scad$
+      end: ^```$
+      rules:
+        - include: "scad"
+
+  - comment:
+      start: (?i)^```scala$
+      end: ^```$
+      rules:
+        - include: "scala"
+
+  - comment:
+      start: (?i)^```sed$
+      end: ^```$
+      rules:
+        - include: "sed"
+
+  - comment:
+      start: (?i)^```sh$
+      end: ^```$
+      rules:
+        - include: "sh"
+
+  - comment:
+      start: (?i)^```sls$
+      end: ^```$
+      rules:
+        - include: "sls"
+
+  - comment:
+      start: (?i)^```smalltalk$
+      end: ^```$
+      rules:
+        - include: "smalltalk"
+
+  - comment:
+      start: (?i)^```solidity$
+      end: ^```$
+      rules:
+        - include: "solidity"
+
+  - comment:
+      start: (?i)^```sql$
+      end: ^```$
+      rules:
+        - include: "sql"
+
+  - comment:
+      start: (?i)^```stata$
+      end: ^```$
+      rules:
+        - include: "stata"
+
+  - comment:
+      start: (?i)^```svelte$
+      end: ^```$
+      rules:
+        - include: "svelte"
+
+  - comment:
+      start: (?i)^```swift$
+      end: ^```$
+      rules:
+        - include: "swift"
+
+  - comment:
+      start: (?i)^```systemd$
+      end: ^```$
+      rules:
+        - include: "systemd"
+
+  - comment:
+      start: (?i)^```tcl$
+      end: ^```$
+      rules:
+        - include: "tcl"
+
+  - comment:
+      start: (?i)^```terraform$
+      end: ^```$
+      rules:
+        - include: "terraform"
+
+  - comment:
+      start: (?i)^```tex$
+      end: ^```$
+      rules:
+        - include: "tex"
+
+  - comment:
+      start: (?i)^```toml$
+      end: ^```$
+      rules:
+        - include: "toml"
+
+  - comment:
+      start: (?i)^```twig$
+      end: ^```$
+      rules:
+        - include: "twig"
+
+  - comment:
+      start: (?i)^```typescript$
+      end: ^```$
+      rules:
+        - include: "typescript"
+
+  - comment:
+      start: (?i)^```v$
+      end: ^```$
+      rules:
+        - include: "v"
+
+  - comment:
+      start: (?i)^```vala$
+      end: ^```$
+      rules:
+        - include: "vala"
+
+  - comment:
+      start: (?i)^```verilog$
+      end: ^```$
+      rules:
+        - include: "verilog"
+
+  - comment:
+      start: (?i)^```vhdl$
+      end: ^```$
+      rules:
+        - include: "vhdl"
+
+  - comment:
+      start: (?i)^```vi$
+      end: ^```$
+      rules:
+        - include: "vi"
+
+  - comment:
+      start: (?i)^```vue$
+      end: ^```$
+      rules:
+        - include: "vue"
+
+  - comment:
+      start: (?i)^```xml$
+      end: ^```$
+      rules:
+        - include: "xml"
+
+  - comment:
+      start: (?i)^```xresources$
+      end: ^```$
+      rules:
+        - include: "xresources"
+
+  - comment:
+      start: (?i)^```yaml$
+      end: ^```$
+      rules:
+        - include: "yaml"
+
+  - comment:
+      start: (?i)^```yum$
+      end: ^```$
+      rules:
+        - include: "yum"
+
+  - comment:
+      start: (?i)^```zig$
+      end: ^```$
+      rules:
+        - include: "zig"
+
+  - comment:
+      start: (?i)^```zscript$
+      end: ^```$
+      rules:
+        - include: "zscript"
+
+  - comment:
+      start: (?i)^```zsh$
+      end: ^```$
+      rules:
+        - include: "zsh"
+
+  - special:
+      start: "`"
+      end: "`"


### PR DESCRIPTION
This is done for every language that has a syntaxfile by default. See issue https://github.com/zyedidia/micro/issues/3770 . (Note that I have incorporated the feedback from that issue and include each syntaxfile rather than copy the content. I tried to make a master-file that contain all the includes, but nested includes seems to now be supported.