### PR TITLE
Fix Ruby syntax highlighting for predefined variables

### DIFF
--- a/runtime/syntax/ruby.yaml
+++ b/runtime/syntax/ruby.yaml
@@ -21,6 +21,10 @@ rules:
     - constant.number: "(?i)\\b0x[0-9a-fA-F][0-9a-f_]*\\b"
     - constant.number: "(?i)\\b0b[01][01_]*\\b"
     - constant.number: "(?i)\\b[0-9][0-9_]*(['.'][0-9_]+)?(e[\\-]?[0-9_]+)?\\b"
+    # Predefined global variables
+    - constant:
+        start: "[$]([!@&`'+~=/\\\\,;.<>*$?:\"_]|-[A-Za-z0-9_]|[0-9]+)"
+        end: "\\B|\\b"
     # Ruby "Symbols"
     - constant: "(i?)([ 	]|^):[0-9A-Z_]+\\b"
     - constant: "\\b(__FILE__|__LINE__)\\b"


### PR DESCRIPTION
Ruby has a bunch of [predefined variables](https://www.zenspider.com/ruby/quickref.html#pre-defined-variables) that use special characters like quotes and backticks which completely break syntax highlighting. Adding rules like `constant: "[$]\""` would not fix the issue because the string highlighting would still take priority, so I had to work around the issue by using a group with start (which contains the part to highlight) and end (which always matches).

Current syntax highlighting:
![screenshot of problems](https://github.com/user-attachments/assets/fa5c08e2-a8d4-44cd-b9b0-b6d07bef5dbd)


With this PR applied:
![screenshot with problems fixed](https://github.com/user-attachments/assets/9a6618d1-3d5a-42e1-a244-691dee815e36)

These short names are rarely seen in serious code but they're *extremely* common in code golf so it would be nice to get this fixed.