### PR TITLE
Enhance Tabbar Click

### DIFF
--- a/internal/display/tabwindow.go
+++ b/internal/display/tabwindow.go
@@ -34,7 +34,7 @@ func (w *TabWindow) LocFromVisual(vloc buffer.Loc) int {
 	for i, n := range w.Names {
 		x++
 		s := util.CharacterCountInString(n)
-		if vloc.Y == w.Y && vloc.X < x+s {
+		if vloc.Y == w.Y && vloc.X < x+s+2 {
 			return i
 		}
 		x += s


### PR DESCRIPTION
Currently, in the tab bar, each tab is separated by a gap of 4 cells, _usually_. 
When the gap is left-clicked, the tab on the right side of the gap is selected. 
This PR makes the tab nearest to the click the selected one.