### PR TITLE
Adding missing file closes

### DIFF
--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -537,6 +537,7 @@ func (b *Buffer) ReOpen() error {
 	if err != nil {
 		return err
 	}
+	defer file.Close()
 
 	enc, err := htmlindex.Get(b.Settings["encoding"].(string))
 	if err != nil {


### PR DESCRIPTION
Switching between git branches on Windows sometimes fails due to opened files in micro.
Adding missing file closes fixes this.