### PR TITLE
Pasting multi cursor clipboard separated by newlines when number of cursors mismatch

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1583,23 +1583,31 @@ func (h *BufPane) MoveLinesDown() bool {
 // Paste whatever is in the system clipboard into the buffer
 // Delete and paste if the user has a selection
 func (h *BufPane) Paste() bool {
-	clip, err := clipboard.ReadMulti(clipboard.ClipboardReg, h.Cursor.Num, h.Buf.NumCursors())
-	if err != nil {
-		InfoBar.Error(err)
-	} else {
-		h.paste(clip)
-	}
-	h.Relocate()
-	return true
+	return h.pasteReg(clipboard.ClipboardReg)
 }
 
 // PastePrimary pastes from the primary clipboard (only use on linux)
 func (h *BufPane) PastePrimary() bool {
-	clip, err := clipboard.ReadMulti(clipboard.PrimaryReg, h.Cursor.Num, h.Buf.NumCursors())
+	return h.pasteReg(clipboard.PrimaryReg)
+}
+
+func (h *BufPane) pasteReg(reg clipboard.Register) bool {
+	clips, err := clipboard.ReadMulti(reg)
 	if err != nil {
 		InfoBar.Error(err)
 	} else {
-		h.paste(clip)
+		if h.Buf.NumCursors() != len(clips) {
+			// If cursor clipboard length doesn't match number of cursors, paste each cursor
+			// clipboard to a newline
+			for i, clip := range clips {
+				h.paste(clip)
+				if i != len(clips)-1 {
+					h.InsertNewline()
+				}
+			}
+		} else {
+			h.paste(clips[h.Cursor.Num])
+		}
 	}
 	h.Relocate()
 	return true

--- a/internal/clipboard/multi.go
+++ b/internal/clipboard/multi.go
@@ -9,17 +9,24 @@ type multiClipboard map[Register][]string
 
 var multi multiClipboard
 
-func (c multiClipboard) getAllText(r Register) string {
-	content := c[r]
-	if content == nil {
+func (c multiClipboard) getAllTextConcated(r Register) string {
+	multitext := c.getAllText(r)
+	if multitext == nil {
 		return ""
 	}
 
 	buf := &bytes.Buffer{}
-	for _, s := range content {
+	for i, s := range multitext {
 		buf.WriteString(s)
+		if i != len(multitext)-1 {
+			buf.WriteString("\n")
+		}
 	}
 	return buf.String()
+}
+
+func (c multiClipboard) getAllText(r Register) []string {
+	return c[r]
 }
 
 func (c multiClipboard) getText(r Register, num int) string {
@@ -35,13 +42,13 @@ func (c multiClipboard) getText(r Register, num int) string {
 // text stored in the system clipboard (provided as an argument), and therefore
 // if it is safe to use the multi-clipboard for pasting instead of the system
 // clipboard.
-func (c multiClipboard) isValid(r Register, clipboard string, ncursors int) bool {
+func (c multiClipboard) isValid(r Register, clipboard *string) bool {
 	content := c[r]
-	if content == nil || len(content) != ncursors {
+	if content == nil {
 		return false
 	}
 
-	return clipboard == c.getAllText(r)
+	return c.getAllTextConcated(r) == *clipboard
 }
 
 func (c multiClipboard) writeText(text string, r Register, num int, ncursors int) {


### PR DESCRIPTION
Currently, when pasting mutli cursor clipboards to a single cursor, the following happens:

Given clipboards:
1. `123`
2. `345`
3. `678`

Being pasted with a single cursor, it looks likes
```
123345678
```

which is very difficult to work with. The proposed change paste it like this instead:

```
123
345
678
```

with `autoindent` applied as well if any.

This is the behavior of other text editors such as VSCode, which is more intuitive imo.


