### PR TITLE
save: Use `dd` with the `notrunc` & `fsync` and postpone truncation

### DIFF
--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -374,7 +374,6 @@ func (b *Buffer) safeWrite(path string, withSudo bool, newFile bool) (int, error
 		}
 	}()
 
-
 	// Try to backup first before writing
 	backupName, err := b.writeBackup(path)
 	if err != nil {


### PR DESCRIPTION
This will stop the overall truncation of the target file.
We need to do this because dd, like other coreutils, already truncates the file
on open(). In case we can't store the backup file afterwards we would end up in
a truncated file for which the user has no write permission by default.