### PR TITLE
Add Horizontal Scroll Actions

### DIFF
--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -35,6 +35,22 @@ func (h *BufPane) ScrollDown(n int) {
 	h.SetView(v)
 }
 
+// ScrollLeft is not an action
+func (h *BufPane) ScrollLeft(n int) bool {
+	v := h.GetView()
+	v.StartCol = h.HScroll(v.StartCol, -n)
+	h.SetView(v)
+	return true
+}
+
+// ScrollRight is not an action
+func (h *BufPane) ScrollRight(n int) bool {
+	v := h.GetView()
+	v.StartCol = h.HScroll(v.StartCol, n)
+	h.SetView(v)
+	return true
+}
+
 // ScrollAdjust can be used to shift the view so that the last line is at the
 // bottom if the user has scrolled past the last line.
 func (h *BufPane) ScrollAdjust() {
@@ -156,6 +172,18 @@ func (h *BufPane) ScrollUpAction() bool {
 // ScrollDownAction scrolls the view down
 func (h *BufPane) ScrollDownAction() bool {
 	h.ScrollDown(util.IntOpt(h.Buf.Settings["scrollspeed"]))
+	return true
+}
+
+// ScrollDownAction scrolls the view left
+func (h *BufPane) ScrollLeftAction() bool {
+	h.ScrollLeft(util.IntOpt(h.Buf.Settings["scrollspeed"]))
+	return true
+}
+
+// ScrollUpAction scrolls the view right
+func (h *BufPane) ScrollRightAction() bool {
+	h.ScrollRight(util.IntOpt(h.Buf.Settings["scrollspeed"]))
 	return true
 }
 

--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -838,6 +838,8 @@ var BufKeyActions = map[string]BufKeyAction{
 	"Suspend":                   (*BufPane).Suspend,
 	"ScrollUp":                  (*BufPane).ScrollUpAction,
 	"ScrollDown":                (*BufPane).ScrollDownAction,
+	"ScrollLeft":                (*BufPane).ScrollLeftAction,
+	"ScrollRight":               (*BufPane).ScrollRightAction,
 	"SpawnMultiCursor":          (*BufPane).SpawnMultiCursor,
 	"SpawnMultiCursorUp":        (*BufPane).SpawnMultiCursorUp,
 	"SpawnMultiCursorDown":      (*BufPane).SpawnMultiCursorDown,

--- a/internal/display/infowindow.go
+++ b/internal/display/infowindow.go
@@ -83,6 +83,7 @@ func (i *InfoWindow) BufView() View {
 	}
 }
 
+func (i *InfoWindow) HScroll(sc, n int) int            { return sc }
 func (i *InfoWindow) Scroll(s SLoc, n int) SLoc        { return s }
 func (i *InfoWindow) Diff(s1, s2 SLoc) int             { return 0 }
 func (i *InfoWindow) SLocFromLoc(loc buffer.Loc) SLoc  { return SLoc{0, 0} }


### PR DESCRIPTION
As https://github.com/zyedidia/micro/issues/1182 suggests, Micro currently lacks horizontal scrolling. This is my first approach to implementing it, but I’d like some feedback:

1.  Is there any reliable keybinding (perhaps modekey+scroll) that we could use by default? As mentioned [here](https://github.com/zyedidia/micro/issues/1182#issuecomment-3007738029), we could implement this without a default keybind, but I think it would be neat to have one.

2. Does this justify a new option, or could we unify it with `scrollspeed`?

3. From what I’ve seen, editors allow horizontal scrolling when there is a line longer than the buffer’s width, but they also include a margin.
For example, even if the longest line is shorter than `bufwidth - margin,` scrolling is still possible. Similarly, there is often a margin for how far we can scroll past the end of the longest line.
Should we have such margins? (In my current implementation, I called this OFFSET.)

4. Similar to `scrollmargin`, ideally, Micro could have a `horizontalscrollmargin`? i.e. when typing continuously, the cursor would always stay at least n cells away from the right edge, preventing it from touching the border. If so it could be the value used for the margin of question 3.

Feedback on the actual implementation is also appreciated.
Currently, there’s a bug when deleting characters within the longest line. 
It happens because of this.
Example: Create a line longer than `bufWidth`, place your cursor at the last character, and start deleting. Shouldn’t the view shift to the left automatically as the line becomes shorter?