### PR TITLE
Fix spurious backups of unmodified files

### DIFF
--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -352,9 +352,11 @@ func main() {
 			} else {
 				fmt.Println("Micro encountered an error:", errors.Wrap(err, 2).ErrorStack(), "\nIf you can reproduce this error, please report it at https://github.com/zyedidia/micro/issues")
 			}
-			// backup all open buffers
+			// immediately backup all buffers with unsaved changes
 			for _, b := range buffer.OpenBuffers {
-				b.Backup()
+				if b.Modified() {
+					b.Backup()
+				}
 			}
 			exit(1)
 		}

--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -489,8 +489,6 @@ func DoEvent() {
 		}
 	case f := <-timerChan:
 		f()
-	case b := <-buffer.BackupCompleteChan:
-		b.RequestedBackup = false
 	case <-sighup:
 		exit(0)
 	case <-util.Sigterm:

--- a/cmd/micro/micro_test.go
+++ b/cmd/micro/micro_test.go
@@ -55,9 +55,11 @@ func startup(args []string) (tcell.SimulationScreen, error) {
 		if err := recover(); err != nil {
 			screen.Screen.Fini()
 			fmt.Println("Micro encountered an error:", err)
-			// backup all open buffers
+			// immediately backup all buffers with unsaved changes
 			for _, b := range buffer.OpenBuffers {
-				b.Backup()
+				if b.Modified() {
+					b.Backup()
+				}
 			}
 			// Print the stack trace too
 			log.Fatalf(errors.Wrap(err, 2).ErrorStack())

--- a/internal/buffer/backup.go
+++ b/internal/buffer/backup.go
@@ -34,13 +34,13 @@ Options: [r]ecover, [i]gnore, [a]bort: `
 
 const backupSeconds = 8
 
-var BackupCompleteChan chan *Buffer
+var BackupCompleteChan chan *SharedBuffer
 
 func init() {
-	BackupCompleteChan = make(chan *Buffer, 10)
+	BackupCompleteChan = make(chan *SharedBuffer, 10)
 }
 
-func (b *Buffer) RequestBackup() {
+func (b *SharedBuffer) RequestBackup() {
 	if !b.RequestedBackup {
 		select {
 		case backupRequestChan <- b:
@@ -51,7 +51,7 @@ func (b *Buffer) RequestBackup() {
 	}
 }
 
-func (b *Buffer) backupDir() string {
+func (b *SharedBuffer) backupDir() string {
 	backupdir, err := util.ReplaceHome(b.Settings["backupdir"].(string))
 	if backupdir == "" || err != nil {
 		backupdir = filepath.Join(config.ConfigDir, "backups")
@@ -59,12 +59,12 @@ func (b *Buffer) backupDir() string {
 	return backupdir
 }
 
-func (b *Buffer) keepBackup() bool {
+func (b *SharedBuffer) keepBackup() bool {
 	return b.forceKeepBackup || b.Settings["permbackup"].(bool)
 }
 
 // Backup saves the current buffer to the backups directory
-func (b *Buffer) Backup() error {
+func (b *SharedBuffer) Backup() error {
 	if !b.Settings["backup"].(bool) || b.Path == "" || b.Type != BTDefault {
 		return nil
 	}
@@ -101,7 +101,7 @@ func (b *Buffer) Backup() error {
 }
 
 // RemoveBackup removes any backup file associated with this buffer
-func (b *Buffer) RemoveBackup() {
+func (b *SharedBuffer) RemoveBackup() {
 	if !b.Settings["backup"].(bool) || b.keepBackup() || b.Path == "" || b.Type != BTDefault {
 		return
 	}
@@ -111,7 +111,7 @@ func (b *Buffer) RemoveBackup() {
 
 // ApplyBackup applies the corresponding backup file to this buffer (if one exists)
 // Returns true if a backup was applied
-func (b *Buffer) ApplyBackup(fsize int64) (bool, bool) {
+func (b *SharedBuffer) ApplyBackup(fsize int64) (bool, bool) {
 	if b.Settings["backup"].(bool) && !b.Settings["permbackup"].(bool) && len(b.Path) > 0 && b.Type == BTDefault {
 		backupfile := util.DetermineEscapePath(b.backupDir(), b.AbsPath)
 		if info, err := os.Stat(backupfile); err == nil {

--- a/internal/buffer/backup.go
+++ b/internal/buffer/backup.go
@@ -126,7 +126,7 @@ func (b *SharedBuffer) Backup() error {
 
 // RemoveBackup removes any backup file associated with this buffer
 func (b *SharedBuffer) RemoveBackup() {
-	if !b.Settings["backup"].(bool) || b.keepBackup() || b.Path == "" || b.Type != BTDefault {
+	if b.keepBackup() || b.Path == "" || b.Type != BTDefault {
 		return
 	}
 	f := util.DetermineEscapePath(b.backupDir(), b.AbsPath)

--- a/internal/buffer/backup.go
+++ b/internal/buffer/backup.go
@@ -125,7 +125,7 @@ func (b *Buffer) ApplyBackup(fsize int64) (bool, bool) {
 				if choice%3 == 0 {
 					// recover
 					b.LineArray = NewLineArray(uint64(fsize), FFAuto, backup)
-					b.isModified = true
+					b.setModified()
 					return true, true
 				} else if choice%3 == 1 {
 					// delete

--- a/internal/buffer/backup.go
+++ b/internal/buffer/backup.go
@@ -104,18 +104,8 @@ func (b *SharedBuffer) writeBackup(path string) (string, error) {
 	}
 
 	name := util.DetermineEscapePath(backupdir, path)
-
-	// If no existing backup, just write the backup.
-	if _, err := os.Stat(name); errors.Is(err, fs.ErrNotExist) {
-		_, err = b.overwriteFile(name)
-		if err != nil {
-			os.Remove(name)
-		}
-		return name, err
-	}
-
-	// If a backup already exists, replace it atomically.
 	tmp := util.AppendBackupSuffix(name)
+
 	_, err := b.overwriteFile(tmp)
 	if err != nil {
 		os.Remove(tmp)

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -152,6 +152,12 @@ func (b *SharedBuffer) setModified() {
 		b.calcHash(&buff)
 		b.isModified = buff != b.origHash
 	}
+
+	if b.isModified {
+		b.RequestBackup()
+	} else {
+		b.CancelBackup()
+	}
 }
 
 // calcHash calculates md5 hash of all lines in the buffer
@@ -525,8 +531,6 @@ func (b *Buffer) Insert(start Loc, text string) {
 		b.EventHandler.cursors = b.cursors
 		b.EventHandler.active = b.curCursor
 		b.EventHandler.Insert(start, text)
-
-		b.RequestBackup()
 	}
 }
 
@@ -536,8 +540,6 @@ func (b *Buffer) Remove(start, end Loc) {
 		b.EventHandler.cursors = b.cursors
 		b.EventHandler.active = b.curCursor
 		b.EventHandler.Remove(start, end)
-
-		b.RequestBackup()
 	}
 }
 

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -123,6 +123,8 @@ type SharedBuffer struct {
 
 	// Hash of the original buffer -- empty if fastdirty is on
 	origHash [md5.Size]byte
+
+	fini int32
 }
 
 func (b *SharedBuffer) insert(pos Loc, value []byte) {
@@ -223,7 +225,6 @@ type Buffer struct {
 	*EventHandler
 	*SharedBuffer
 
-	fini        int32
 	cursors     []*Cursor
 	curCursor   int
 	StartCursor Loc

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	luar "layeh.com/gopher-luar"
@@ -101,7 +100,6 @@ type SharedBuffer struct {
 	diffLock          sync.RWMutex
 	diff              map[int]DiffStatus
 
-	RequestedBackup bool
 	forceKeepBackup bool
 
 	// ReloadDisabled allows the user to disable reloads if they
@@ -123,8 +121,6 @@ type SharedBuffer struct {
 
 	// Hash of the original buffer -- empty if fastdirty is on
 	origHash [md5.Size]byte
-
-	fini int32
 }
 
 func (b *SharedBuffer) insert(pos Loc, value []byte) {
@@ -495,13 +491,11 @@ func (b *Buffer) Fini() {
 	if !b.Modified() {
 		b.Serialize()
 	}
-	b.RemoveBackup()
+	b.CancelBackup()
 
 	if b.Type == BTStdout {
 		fmt.Fprint(util.Stdout, string(b.Bytes()))
 	}
-
-	atomic.StoreInt32(&(b.fini), int32(1))
 }
 
 // GetName returns the name that should be displayed in the statusline

--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -333,27 +333,6 @@ func (b *Buffer) saveToFile(filename string, withSudo bool, autoSave bool) error
 	return err
 }
 
-func (b *SharedBuffer) writeBackup(path string) (string, error) {
-	backupDir := b.backupDir()
-	if _, err := os.Stat(backupDir); err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			return "", err
-		}
-		if err = os.Mkdir(backupDir, os.ModePerm); err != nil {
-			return "", err
-		}
-	}
-
-	backupName := util.DetermineEscapePath(backupDir, path)
-	_, err := b.overwriteFile(backupName)
-	if err != nil {
-		os.Remove(backupName)
-		return "", err
-	}
-
-	return backupName, nil
-}
-
 // safeWrite writes the buffer to a file in a "safe" way, preventing loss of the
 // contents of the file if it fails to write the new contents.
 // This means that the file is not overwritten directly but by writing to the

--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -318,7 +318,7 @@ func (b *Buffer) saveToFile(filename string, withSudo bool, autoSave bool) error
 			// For large files 'fastdirty' needs to be on
 			b.Settings["fastdirty"] = true
 		} else {
-			calcHash(b, &b.origHash)
+			b.calcHash(&b.origHash)
 		}
 	}
 

--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -206,9 +206,7 @@ func (b *Buffer) Save() error {
 
 // AutoSave saves the buffer to its default path
 func (b *Buffer) AutoSave() error {
-	// Doing full b.Modified() check every time would be costly, due to the hash
-	// calculation. So use just isModified even if fastdirty is not set.
-	if !b.isModified {
+	if !b.Modified() {
 		return nil
 	}
 	return b.saveToFile(b.Path, false, true)

--- a/internal/buffer/settings.go
+++ b/internal/buffer/settings.go
@@ -91,7 +91,7 @@ func (b *Buffer) DoSetOptionNative(option string, nativeValue interface{}) {
 		case "dos":
 			b.Endings = FFDos
 		}
-		b.isModified = true
+		b.setModified()
 	} else if option == "syntax" {
 		if !nativeValue.(bool) {
 			b.ClearMatches()
@@ -105,7 +105,7 @@ func (b *Buffer) DoSetOptionNative(option string, nativeValue interface{}) {
 			b.Settings["encoding"] = "utf-8"
 		}
 		b.encoding = enc
-		b.isModified = true
+		b.setModified()
 	} else if option == "readonly" && b.Type.Kind == BTDefault.Kind {
 		b.Type.Readonly = nativeValue.(bool)
 	} else if option == "hlsearch" {

--- a/internal/buffer/settings.go
+++ b/internal/buffer/settings.go
@@ -73,7 +73,7 @@ func (b *Buffer) DoSetOptionNative(option string, nativeValue interface{}) {
 				b.Settings["fastdirty"] = true
 			} else {
 				if !b.isModified {
-					calcHash(b, &b.origHash)
+					b.calcHash(&b.origHash)
 				} else {
 					// prevent using an old stale origHash value
 					b.origHash = [md5.Size]byte{}


### PR DESCRIPTION
Since a very long time I've been sporadically encountering a nasty hard-to-diagnose issue [*]: when opening a file, micro detects a backup for this file (and thus suggests to recover the file from this backup), whereas the content of this backup is identical to the content of the file itself, i.e. it doesn't have any unsaved changed (IOW there is nothing to recover). Which indicates that the backup was created mistakenly, or that it was not removed after the file was successfully saved.

This PR attempts to fix this problem, by fixing at least the following actual existing bugs that might cause it:

1. Possible race between creating backups in the backup/save goroutine (periodically in the background) and removing backups in the main goroutine (when closing a buffer), which may result in a backup not being removed successfully.

2. When a buffer is saved, its backup is removed. However, if there is a pending request for the next periodic backup, micro doesn't cancel this request, so a new backup is unexpectedly created a couple of seconds after the file was saved. (Although usually this erroneous backup is removed later, when the buffer is closed. But if micro terminates abnormally and the buffer is not properly closed, this backup is not removed. Also if this issue occurs in combination with the race issue 1 described above, this backup may not be successfully removed either.)

3. When the user undoes all changes made since the last save, so the buffer status changes from "modified" to "unmodified", micro doesn't remove its backup. (Although, again, usually it is removed later when the buffer is closed. But again, it may not be the case if micro terminates abnormally, or if this issue occurs together with the race issue 1.)

4. When micro detects a panic and performs an emergency exit, it creates backups for all opened buffers, even those that don't have any unsaved changed.

[*] I should also note: it _seems_ that since merging #3273 I'm reproducing this problem much more often than before. Although I have no idea how exactly #3273 could cause that. Perhaps it just affected timings in such a way that, for example, made the race condition issue 1 more likely to occur?..