### PR TITLE
Fix last split cannot be resized

### DIFF
--- a/internal/action/bufpane.go
+++ b/internal/action/bufpane.go
@@ -314,10 +314,14 @@ func (h *BufPane) Tab() *Tab {
 	return h.tab
 }
 
-func (h *BufPane) ResizePane(size int) {
+// ResizePane resizes the pane to a given size in the specified direction
+func (h *BufPane) ResizePane(size int, right_or_bottom bool) bool {
 	n := h.tab.GetNode(h.splitID)
-	n.ResizeSplit(size)
-	h.tab.Resize()
+	r := n.ResizeSplit(size, right_or_bottom)
+	if r {
+		h.tab.Resize()
+	}
+	return r
 }
 
 // PluginCB calls all plugin callbacks with a certain name and displays an

--- a/internal/action/tab.go
+++ b/internal/action/tab.go
@@ -292,7 +292,7 @@ func (t *Tab) HandleEvent(event tcell.Event) {
 					} else {
 						size = my - t.resizing.Y + 1
 					}
-					t.resizing.ResizeSplit(size)
+					t.resizing.ResizeSplit(size, true)
 					t.Resize()
 					return
 				}

--- a/internal/views/splits.go
+++ b/internal/views/splits.go
@@ -147,6 +147,7 @@ func (n *Node) vResizeSplit(i int, size int) bool {
 	var c1, c2 *Node
 	if i == len(n.children)-1 {
 		c1, c2 = n.children[i-1], n.children[i]
+		size = c1.H + c2.H - size
 	} else {
 		c1, c2 = n.children[i], n.children[i+1]
 	}
@@ -168,6 +169,7 @@ func (n *Node) hResizeSplit(i int, size int) bool {
 	var c1, c2 *Node
 	if i == len(n.children)-1 {
 		c1, c2 = n.children[i-1], n.children[i]
+		size = c1.W + c2.W - size
 	} else {
 		c1, c2 = n.children[i], n.children[i+1]
 	}

--- a/internal/views/splits_test.go
+++ b/internal/views/splits_test.go
@@ -9,7 +9,7 @@ func TestHSplit(t *testing.T) {
 	root := NewRoot(0, 0, 80, 80)
 	n1 := root.VSplit(true)
 	root.GetNode(n1).VSplit(true)
-	root.GetNode(root.id).ResizeSplit(7)
+	root.GetNode(root.id).ResizeSplit(7, true)
 	root.Resize(120, 120)
 
 	fmt.Println(root.String())


### PR DESCRIPTION
`vResizeSplit` and `hResizeSplit` cannot change the size of the last split in a group of siblings. It resizes the split before the last split instead.

How to reproduce:
```lua
PLUGIN_VERSION = "2.0.0"
PLUGIN_NAME = "bug_last_split_cannot_be_resized"

local micro = import("micro")
local buffer = import("micro/buffer")

function resizePane(bp, id, size)
    local tab = bp:Tab()
    local paneIndex = tab:GetPane(id)
    local pane = tab.Panes[paneIndex + 1]
    pane:ResizePane(size)
    tab:SetActive(paneIndex)
end

function createSplits(bp, num)
    local tab = bp:Tab()
    local currentBp = bp
    while true do
        currentBp.Buf:Insert(
            buffer.Loc(1, 1), string.format("pane%s", currentBp:ID()))
        if #tab.Panes >= num then break end
        local newBuf, err = buffer.NewBufferFromFile("")
        currentBp = currentBp:VSplitIndex(newBuf, true)
    end
    tab:SetActive(bp:ID() - 1)
end

function postinit()
    local bp = micro.CurPane()
    if bp.Buf:Size() > 0 then
        return
    end

    createSplits(bp, 3)

    -- resizePane(bp, 1, 30)  -- this works
    -- resizePane(bp, 2, 30)  -- this works

    -- this does not work and sets the size of pane 2 instead
    resizePane(bp, 3, 30)
end
```
At first, I just fixed the bug, but then I found the entire design of `vResizeSplit` and `hResizeSplit` a bit strange.
So I thought it would be a good idea to change `vResizeSplit` and `hResizeSplit` so that they work the same way as `VSplit` and `HSplit`. This way, you can easily select the direction in which you want to resize. With the old design, you have to use a lot of extra logic in Lua to enable resizing to the left or top. 