### PR TITLE
Fix horizontal relocation (scrolling) not respecting selections

### DIFF
--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -244,18 +244,30 @@ func (w *BufWindow) Relocate() bool {
 
 	// horizontal relocation (scrolling)
 	if !b.Settings["softwrap"].(bool) {
-		cx := activeC.GetVisualX(false)
+		cxStart := activeC.GetVisualX(false)
+		cxEnd := cxStart
+		if activeC.HasSelection() {
+			sxStart := w.VLocFromLoc(activeC.CurSelection[0]).VisualX
+			if sxStart < cxEnd {
+				cxStart = sxStart
+			}
+			sxEnd := w.VLocFromLoc(activeC.CurSelection[1]).VisualX
+			if sxEnd > cxEnd {
+				cxEnd = sxEnd
+			}
+		}
+
 		rw := runewidth.RuneWidth(activeC.RuneUnder(activeC.X))
 		if rw == 0 {
 			rw = 1 // tab or newline
 		}
 
-		if cx < w.StartCol {
-			w.StartCol = cx
+		if cxStart < w.StartCol {
+			w.StartCol = cxStart
 			ret = true
 		}
-		if cx+rw > w.StartCol+w.bufWidth {
-			w.StartCol = cx - w.bufWidth + rw
+		if cxEnd+rw > w.StartCol+w.bufWidth {
+			w.StartCol = cxEnd - w.bufWidth + rw
 			ret = true
 		}
 	}


### PR DESCRIPTION
Currently there is no logic to handle horizontal scrolling when text is selected. The current code only takes the cursor position into account. This only affects buffers where the `softwrap` option is disabled.

How to reproduce:
```lua
PLUGIN_VERSION = "2.0.0"
PLUGIN_NAME = "bug_horizontal_relocate_doesnt_respect_selections"

local micro = import("micro")
local buffer = import("micro/buffer")
local config = import("micro/config")
local util = import("micro/util")

local TEST_STRING1 = [[
//        1         2         3         4         5         6         7         8         9
//23456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
    scrollbarWidth := 0
	scrollbarWidth := 0
	if w.Buf.Settings["scrollbar"].(bool) && w.Buf.LinesNum() > w.Height && w.Width > 0 {
		scrollbarWidth = 1
	}]]

local TEST_STRING2 = [[
//        1         2         3         4         5         6         7         8         9
//23456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
// ThisIsAVeryLongLineSoLongActuallyItsNotGonnaFitIntoOneBufSplit
	// >>> ThisIsAVeryLongLineSoLongActuallyItsNotGonnaFitIntoOneBufSplit]]

function postinit()
    local bp = micro.CurPane()
    if bp.Buf:Size() > 0 then
        return
    end
    bp.Buf.settings["softwrap"] = false
    bp.Buf.settings["tabsize"] = 4
    micro.Log("tabsize", bp.Buf.settings["tabsize"])
    micro.Log("softwrap", bp.Buf.settings["softwrap"])
    -- testCase1a()
    testCase2()
end

function resizePane(bp, size)
    -- bp:ResizePane(size, true)
    bp:ResizePane(size)
end

function testCase1a()
    local bp = micro.CurPane()
    local cursor = bp.Buf:GetActiveCursor()
    bp.Buf:Insert(-cursor.Loc, TEST_STRING1)

    local unusedBuf, err = buffer.NewBufferFromFile("")
    local unusedBp = bp:VSplitIndex(unusedBuf, true)
    resizePane(bp, 60)

    local tab = bp:Tab()
    tab:SetActive(bp:ID() - 1)

    -- select "Width"
    local loc = buffer.Loc(10, 3)
    cursor:GotoLoc(loc)
    bp:SelectSubWordRight()
end

function testCase2()
    local bp = micro.CurPane()
    local cursor = bp.Buf:GetActiveCursor()
    bp.Buf:Insert(-cursor.Loc, TEST_STRING2)

    local unusedBuf, err = buffer.NewBufferFromFile("")
    local unusedBp = bp:VSplitIndex(unusedBuf, true)
    resizePane(bp, 60)

    local tab = bp:Tab()
    tab:SetActive(bp:ID() - 1)

    -- select "ThisIsAVeryLongLineSoLongActuallyItsNotGonnaFitIntoOneBufSplit"
    local loc = buffer.Loc(3, 2)
    cursor:GotoLoc(loc)
    bp:SelectWordRight()
end

function onTriggerBug(bp)
    micro.Log("onTriggerBug")
    local bp = micro.CurPane()
    local cursor = bp.Buf:GetActiveCursor()
    if cursor:HasSelection() == false then
        return false
    end
    local selectedText = util.String(cursor:GetSelection())
    bp.Buf.LastSearch = selectedText
    bp:FindNext()
end
```

Bind `onTriggerBug` to see the effect.

Actual behavior:
You cannot see the selected subword `Width` every time you trigger `onTriggerBug`.

Expectation:
The selected text should be visible at all times.