### PR TITLE
Add a new color group for selections within highlighted search results

### DIFF
--- a/internal/display/bufwindow.go
+++ b/internal/display/bufwindow.go
@@ -497,7 +497,8 @@ func (w *BufWindow) displayBuffer() {
 		draw := func(r rune, combc []rune, style tcell.Style, highlight bool, showcursor bool) {
 			if nColsBeforeStart <= 0 && vloc.Y >= 0 {
 				if highlight {
-					if w.Buf.HighlightSearch && w.Buf.SearchMatch(bloc) {
+					isHighlightSearchMatch := w.Buf.HighlightSearch && w.Buf.SearchMatch(bloc)
+					if isHighlightSearchMatch {
 						style = config.DefStyle.Reverse(true)
 						if s, ok := config.Colorscheme["hlsearch"]; ok {
 							style = s
@@ -551,6 +552,12 @@ func (w *BufWindow) displayBuffer() {
 
 							if s, ok := config.Colorscheme["selection"]; ok {
 								style = s
+							}
+
+							if isHighlightSearchMatch {
+								if s, ok := config.Colorscheme["hlsearch.selection"]; ok {
+									style = s
+								}
 							}
 						}
 

--- a/runtime/help/colors.md
+++ b/runtime/help/colors.md
@@ -198,6 +198,7 @@ Here is a list of the colorscheme groups that you can use:
 * error-message (Color of error messages in the bottom line of the screen)
 * match-brace (Color of matching brackets when `matchbracestyle` is set to `highlight`)
 * hlsearch (Color of highlighted search results when `hlsearch` is enabled)
+* hlsearch.selection (Color of the selection within the highlighted search results)
 * tab-error (Color of tab vs space errors when `hltaberrors` is enabled)
 * trailingws (Color of trailing whitespaces when `hltrailingws` is enabled)
 


### PR DESCRIPTION
micro allows to set the color for selections and for search results. However, if your color scheme defines a color for highlights that is very similar to your general background color, and you perform a search, the currently selected text will hardly stand out.

<img width="1050" height="558" alt="hlsearch-selection" src="https://github.com/user-attachments/assets/d7ce5231-706b-4a62-bfb1-4bcfd65ebfa6" />
The red arrow indicates the currently selected text.

Since this cannot be done with plugins, it would be great if we can add a new color-group analogous to `statusline`, `statusline.inactive`, `statusline.suggestions`.