### PR TITLE
Add keybindings note for kitty terminal on macos 

### DIFF
--- a/runtime/help/keybindings.md
+++ b/runtime/help/keybindings.md
@@ -92,7 +92,8 @@ You can also bind a key to execute a command in command mode (see
 instead insert unicode characters. To fix this, do the following:
 
 * iTerm2: select `Esc+` for `Left Option Key` in `Preferences->Profiles->Keys`.
-* Terminal.app: Enable `Use Option key as Meta key` in `Preferences->Profiles->Keyboard`.
+* Terminal.app: enable `Use Option key as Meta key` in `Preferences->Profiles->Keyboard`.
+* Kitty: set `macos_option_as_alt yes` in `kitty.conf`.
 
 Now when you press `Alt-p` the `pwd` command will be executed which will show
 your working directory in the infobar.


### PR DESCRIPTION
This adds a note in the keybindings docs to send alt events with kitty on macos: https://sw.kovidgoyal.net/kitty/conf/#opt-kitty.macos_option_as_alt 