### PR TITLE
Fix variable expansion regex in fish syntax

### DIFF
--- a/runtime/syntax/fish.yaml
+++ b/runtime/syntax/fish.yaml
@@ -25,7 +25,7 @@ rules:
     - statement: "--[a-z-]+"
     - statement: "\\ -[a-z]+"
 
-    - identifier: "(?i)\\$\\{?[0-9A-Z_!@#$*?-]+\\}?"
+    - identifier: "(?i)\\{?\\$[0-9A-Z_!@#$*?-]+\\}?"
 
     - constant.string:
         start: "\""


### PR DESCRIPTION
This fixes the variable expansion syntax for fish shell scripts: https://fishshell.com/docs/current/language.html#variable-expansion

This: `{$WORD}`
And not this: `${WORD}`