### PR TITLE
add Vim-like URL support for opening remote files

### DIFF
--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -383,6 +383,11 @@ func downloadWithWget(url, wgetPath string) (string, error) {
 		return "", fmt.Errorf("wget failed: %v", err)
 	}
 
+	err = os.Chmod(cleanName, 0444)
+	if err != nil {
+		fmt.Printf("Warning: Could not set read-only permissions on %s: %v\n", cleanName, err)
+	}
+
 	return cleanName, nil
 }
 
@@ -404,6 +409,11 @@ func downloadWithCurl(url, curlPath string) (string, error) {
 	if err != nil {
 		os.Remove(cleanName)
 		return "", fmt.Errorf("curl failed: %v", err)
+	}
+
+	err = os.Chmod(cleanName, 0444)
+	if err != nil {
+		fmt.Printf("Warning: Could not set read-only permissions on %s: %v\n", cleanName, err)
 	}
 
 	return cleanName, nil
@@ -438,6 +448,11 @@ func downloadWithHTTP(url string) (string, error) {
 	if err != nil {
 		os.Remove(cleanName)
 		return "", err
+	}
+
+	err = os.Chmod(cleanName, 0444)
+	if err != nil {
+		fmt.Printf("Warning: Could not set read-only permissions on %s: %v\n", cleanName, err)
 	}
 
 	return cleanName, nil

--- a/internal/buffer/buffer.go
+++ b/internal/buffer/buffer.go
@@ -268,12 +268,16 @@ func NewBufferFromFileAtLoc(path string, btype BufType, cursorLoc Loc) (*Buffer,
 	var err error
 	filename := path
 
+	// WriteLog(fmt.Sprintf("NewBufferFromFileAtLoc called with: %s\n", path))
+
 	if isURL(filename) {
+		// WriteLog(fmt.Sprintf("Downloading URL: %s\n", filename))
 		tempFile, err := downloadURL(filename)
 		if err != nil {
 			return nil, fmt.Errorf("failed to download %s: %v", filename, err)
 		}
 		filename = tempFile
+		// WriteLog(fmt.Sprintf("Downloaded to: %s\n", filename))
 	}
 
 	if config.GetGlobalOption("parsecursor").(bool) && cursorLoc.X == -1 && cursorLoc.Y == -1 {
@@ -328,7 +332,7 @@ func NewBufferFromFileAtLoc(path string, btype BufType, cursorLoc Loc) (*Buffer,
 		buf.Settings["temp_file"] = filename
 
 		readonly = true;
-		buf.Settings["readonly"] = "true"
+		buf.Settings["readonly"] = true
 	}
 
 	if readonly && prompt != nil {
@@ -341,9 +345,10 @@ func NewBufferFromFileAtLoc(path string, btype BufType, cursorLoc Loc) (*Buffer,
 
 func isURL(s string) bool {
 	return strings.HasPrefix(s, "http://") ||
-			strings.HasPrefix(s, "https://") ||
-			strings.HasPrefix(s, "ftp://") ||
-			(strings.Contains(s, ".") && (strings.HasPrefix(s, "www.") || strings.Contains(s, "/")))
+		strings.HasPrefix(s, "https://") ||
+		strings.HasPrefix(s, "ftp://") ||
+		strings.HasPrefix(s, "ftps://") ||
+		strings.HasPrefix(s, "www.")
 }
 
 func downloadURL(url string) (string, error) {


### PR DESCRIPTION

## Usage
```bash
$ micro <url>
# or inside micro
> open <url>
```
### Tested on:
Arch Linux (6.16.2-arch1-1)
go version go1.24.6 linux/amd64

# Examples:
$ micro https://raw.githubusercontent.com/zyedidia/micro/refs/heads/master/Makefile
$ micro https://tools.suckless.org/dmenu/patches/numbers/dmenu-numbers-20220512-28fb3e2.diff