### PR TITLE
make arduino filetype detection less aggressive

### DIFF
--- a/runtime/syntax/arduino.yaml
+++ b/runtime/syntax/arduino.yaml
@@ -1,7 +1,7 @@
 filetype: ino
 
 detect:
-    filename: "\\.?ino$"
+    filename: "\\.ino$"
 
 rules:
     - identifier: "\\b[A-Z_][0-9A-Z_]+\\b"


### PR DESCRIPTION
The `?` seems to be there purely by mistake, "ino" without a dot does not even seem to be a convention or anything. [^1]

closes #3847 


[^1]: https://sourcegraph.com/search?q=file:%5B%5E.%5Dino%24&patternType=keyword&sm=0