### PR TITLE
Include --options-with-hyphens in statement regex

### DIFF
--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -39,7 +39,7 @@ rules:
       # Coreutils commands
     - type: "\\b(base64|basename|cat|chcon|chgrp|chmod|chown|chroot|cksum|comm|cp|csplit|cut|date|dd|df|dir|dircolors|dirname|du|env|expand|expr|factor|false|fmt|fold|head|hostid|id|install|join|link|ln|logname|ls|md5sum|mkdir|mkfifo|mknod|mktemp|mv|nice|nl|nohup|nproc|numfmt|od|paste|pathchk|pinky|pr|printenv|printf|ptx|pwd|readlink|realpath|rm|rmdir|runcon|seq|(sha1|sha224|sha256|sha384|sha512)sum|shred|shuf|sleep|sort|split|stat|stdbuf|stty|sum|sync|tac|tail|tee|test|time|timeout|touch|tr|true|truncate|tsort|tty|uname|unexpand|uniq|unlink|users|vdir|wc|who|whoami|yes)\\b"
       # Conditional flags
-    - statement: "\\s+(-[A-Za-z]+|--[a-z]+)"
+    - statement: "\\s+(-[A-Za-z]+|--[a-z-]+)"
 
     - identifier: "\\$\\{[\\w:!%&=+#~@*^$?, .\\-\\/\\[\\]]+\\}"
     - identifier: "\\$([0-9!#@*$?-]|[A-Za-z_]\\w*)"


### PR DESCRIPTION
Fixes #3862

Adds hypen into long option regex to also highlight `--long-options-with-hypens`. I also noted that the current regex misses `--Long-options-capitals` and `--long-options-with-numb3rs` but I reckon those are so rare it's not worth highlighting them.

[Regex101 link](https://regex101.com/r/lAbjEw/1)