### PR TITLE
Disable sudo save prompt on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 
 micro
+micro.exe
 !cmd/micro
 binaries/
 tmp.sh

--- a/internal/action/actions.go
+++ b/internal/action/actions.go
@@ -1038,6 +1038,11 @@ func (h *BufPane) saveBufToFile(filename string, action string, callback func())
 	err := h.Buf.SaveAs(filename)
 	if err != nil {
 		if errors.Is(err, fs.ErrPermission) {
+			if runtime.GOOS == "windows" {
+				InfoBar.Error("Permission denied. Save with sudo not supported on Windows")
+				return true
+			}
+
 			saveWithSudo := func() {
 				err = h.Buf.SaveAsWithSudo(filename)
 				if err != nil {

--- a/internal/buffer/save.go
+++ b/internal/buffer/save.go
@@ -246,9 +246,6 @@ func (b *Buffer) saveToFile(filename string, withSudo bool, autoSave bool) error
 	if b.Type.Scratch {
 		return errors.New("Cannot save scratch buffer")
 	}
-	if withSudo && runtime.GOOS == "windows" {
-		return errors.New("Save with sudo not supported on Windows")
-	}
 
 	if !autoSave && b.Settings["rmtrailingws"].(bool) {
 		for i, l := range b.lines {


### PR DESCRIPTION
It's currently unlikely that saving with sudo will be supported on Windows, since it seems like undocumented APIs are needed to use `sudo` in the way Micro expects it to work. In addition to another small change, this pull request only skips the sudo prompt on save.

Related: #3541, #3781