### PR TITLE
plugin: expose NewTabFromBuffer to Lua

### DIFF
--- a/cmd/micro/initlua.go
+++ b/cmd/micro/initlua.go
@@ -55,6 +55,7 @@ func luaImportMicro() *lua.LTable {
 	ulua.L.SetField(pkg, "Tabs", luar.New(ulua.L, func() *action.TabList {
 		return action.Tabs
 	}))
+	ulua.L.SetField(pkg, "NewTabFromBuffer", luar.New(ulua.L, action.NewTabFromBuffer))
 	ulua.L.SetField(pkg, "After", luar.New(ulua.L, func(t time.Duration, f func()) {
 		time.AfterFunc(t, func() {
 			timerChan <- f

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -147,6 +147,9 @@ The packages and their contents are listed below (in Go type signatures):
 
     - `Tabs() *TabList`: returns the global tab list.
 
+    - `NewTabFromBuffer(x, y, width, height int, buf *Buffer) *Tab`: creates
+       a new tab from the given buffer with the specified dimensions and position.
+
     - `After(t time.Duration, f func())`: run function `f` in the background
        after time `t` elapses. See https://pkg.go.dev/time#Duration for the
        usage of `time.Duration`.


### PR DESCRIPTION
There is no really good way to create a new tab
that’s not bound to a specific file on disk without this function. Now you can create a new buffer from string, pass it to this function and add the resulting tab to the tabs list.

It’s still not particularly ergonomic, but at least it’s possible with a few lines of boilerplate.

I might have missed something else to do here.