### PR TITLE
fix c++ highlighting for binary literal with digit separator and suffix

### DIFF
--- a/runtime/syntax/cpp.yaml
+++ b/runtime/syntax/cpp.yaml
@@ -71,7 +71,7 @@ rules:
     - constant.string:
         start: "'"
         end: "'"
-        skip: "(\\\\.)|(\\b[1-9][0-9']+[0-9]|0[0-7']+[0-7]|0[Xx][0-9A-Fa-f][0-9A-Fa-f']+[0-9A-Fa-f]|0[Bb][01][01']*[01]\\b)"
+        skip: "(\\\\.)|\\b([1-9][0-9']+[0-9]|0[0-7']+[0-7]|0[Xx][0-9A-Fa-f][0-9A-Fa-f']+[0-9A-Fa-f]|0[Bb][01][01']*[01])([Uu][Ll]?[Ll]?|[Ll][Ll]?[Uu]?)?\\b"
         rules:
               # TODO: Revert back to - error: "..+" once #3127 is merged
             - error: "[[:graph:]]{2,}'"


### PR DESCRIPTION
Previously the trailing word boundary `\\b` inside the skip rule (introduced in #3310) was only being checked for the binary literal, which made it work for the other suffixed numeric literals (but for the wrong reason).

@Neko-Box-Coder does this fix seem sensible to you?

closes #3869 