### PR TITLE
add a global option to always show the tab bar

### DIFF
--- a/data/micro.json
+++ b/data/micro.json
@@ -337,6 +337,11 @@
             "type": "boolean",
             "default": true
         },
+        "tabalwaysshow": {
+            "description": "Wether to show the tab bar, even if only one tab exists\nhttps://github.com/zyedidia/micro/blob/master/runtime/help/options.md#options",
+            "type": "boolean",
+            "default": false
+        },
         "tabsize": {
             "description": "A tab size\nhttps://github.com/zyedidia/micro/blob/master/runtime/help/options.md#options",
             "type": "integer",

--- a/internal/action/tab.go
+++ b/internal/action/tab.go
@@ -83,7 +83,8 @@ func (t *TabList) Resize() {
 	w, h := screen.Screen.Size()
 	iOffset := config.GetInfoBarOffset()
 	InfoBar.Resize(w, h-1)
-	if len(t.List) > 1 {
+	globalTabAlwaysShow := config.GetGlobalOption("tabalwaysshow").(bool)
+	if len(t.List) > 1 || globalTabAlwaysShow {
 		for _, p := range t.List {
 			p.Y = 1
 			p.Node.Resize(w, h-1-iOffset)
@@ -144,7 +145,8 @@ func (t *TabList) HandleEvent(event tcell.Event) {
 // Display updates the names and then displays the tab bar
 func (t *TabList) Display() {
 	t.UpdateNames()
-	if len(t.List) > 1 {
+	globalTabAlwaysShow := config.GetGlobalOption("tabalwaysshow").(bool)
+	if len(t.List) > 1 || globalTabAlwaysShow {
 		t.TabWindow.Display()
 	}
 }

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -130,6 +130,7 @@ var DefaultGlobalOnlySettings = map[string]any{
 	"sucmd":          "sudo",
 	"tabhighlight":   false,
 	"tabreverse":     true,
+	"tabalwaysshow":  false,
 	"xterm":          false,
 }
 

--- a/runtime/help/options.md
+++ b/runtime/help/options.md
@@ -619,6 +619,7 @@ so that you can see what the formatting should look like.
     "tabhighlight": true,
     "tabmovement": false,
     "tabreverse": false,
+    "tabalwaysshow": false,
     "tabsize": 4,
     "tabstospaces": false,
     "useprimary": true,


### PR DESCRIPTION
This might not be the perfect way to solve this problem, but I figured that I would dive into the codebase and give it a go before asking for another feature request for something this small.

I think, if we're allowing customisability of the tab bar (reversing colour-theme, etc), that we should also allow the option to set the tab bar to "always show". This pull does that.

Discussion encouraged.