### PR TITLE
Fixing regression introduced by #3310 with missing word boundary

### DIFF
--- a/runtime/syntax/cpp.yaml
+++ b/runtime/syntax/cpp.yaml
@@ -38,15 +38,15 @@ rules:
     - constant.number: "(\\b(0[Bb][01][01']*[01])([Uu][Ll]?[Ll]?|[Ll][Ll]?[Uu]?)?\\b)"                          # Binary
 
       # Decimal Floating-point Literals
-    - constant.number: "(([0-9]?[.]?[0-9]+)([Ee][+-]?[0-9]+)?[FfLl]?\\b)"                                       # Base case optional interger part with exponent base case
+    - constant.number: "(([0-9]?[.]?\\b[0-9]+)([Ee][+-]?[0-9]+)?[FfLl]?\\b)"                                    # Base case optional interger part with exponent base case
     - constant.number: "(\\b([0-9]+[.][0-9]?)([Ee][+-]?[0-9]+)?[FfLl]?)"                                        # Base case optional fractional part with exponent base case
-    - constant.number: "(([0-9]?[.]?[0-9]+)([Ee][+-]?[0-9][0-9']*[0-9])?[FfLl]?\\b)"                            # Base case optional interger part with exponent
+    - constant.number: "(([0-9]?[.]?\\b[0-9]+)([Ee][+-]?[0-9][0-9']*[0-9])?[FfLl]?\\b)"                         # Base case optional interger part with exponent
     - constant.number: "(\\b([0-9]+[.][0-9]?)([Ee][+-]?[0-9][0-9']*[0-9])?[FfLl]?)"                             # Base case optional fractional part with exponent
 
-    - constant.number: "(([0-9][0-9']*[0-9])?[.]?([0-9][0-9']*[0-9])+([Ee][+-]?[0-9]+)?[FfLl]?\\b)"             # Optional interger part with exponent base case
-    - constant.number: "(\\b([0-9][0-9']*[0-9])+[.]([0-9][0-9']*[0-9])?([Ee][+-]?[0-9]+)?[FfLl]?)"              # Optional fractional part with exponent base case
-    - constant.number: "(([0-9][0-9']*[0-9])?[.]?([0-9][0-9']*[0-9])+([Ee][+-]?[0-9][0-9']*[0-9])?[FfLl]?\\b)"  # Optional interger part with exponent
-    - constant.number: "(\\b([0-9][0-9']*[0-9])+[.]([0-9][0-9']*[0-9])?([Ee][+-]?[0-9][0-9']*[0-9])?[FfLl]?)"   # Optional fractional part with exponent
+    - constant.number: "(([0-9][0-9']*[0-9])?[.]?\\b([0-9][0-9']*[0-9])+([Ee][+-]?[0-9]+)?[FfLl]?\\b)"              # Optional interger part with exponent base case
+    - constant.number: "(\\b([0-9][0-9']*[0-9])+[.]([0-9][0-9']*[0-9])?([Ee][+-]?[0-9]+)?[FfLl]?)"                  # Optional fractional part with exponent base case
+    - constant.number: "(([0-9][0-9']*[0-9])?[.]?\\b([0-9][0-9']*[0-9])+([Ee][+-]?[0-9][0-9']*[0-9])?[FfLl]?\\b)"   # Optional interger part with exponent
+    - constant.number: "(\\b([0-9][0-9']*[0-9])+[.]([0-9][0-9']*[0-9])?([Ee][+-]?[0-9][0-9']*[0-9])?[FfLl]?)"       # Optional fractional part with exponent
 
       # Hexadecimal Floating-point Literals
     - constant.number: "(\\b0[Xx]([0-9a-zA-Z]?[.]?[0-9a-zA-Z]+)([Pp][+-]?[0-9]+)?[FfLl]?\\b)"                   # Base case optional interger part with exponent base case


### PR DESCRIPTION
Fixing regression introduced by #3310 with missing word boundary

Test cases (I like how github isn't highlighting some of these properly):

```cpp
456'456.
.13248'4456
0x.456'45
58.
4e2
123.456e-67
123.456e-67f
.1E4f
0x10.1p0
0x1p5
0x1e5
3.14'15'92
1.18e-4932l
3.4028234e38f
3.4028234e38
3.4028234e38l

enum enumeration {
    VALUE_0 = 0
    value_1 = 1
    VALUE_LAST = value_1
} enumeration_t;
```

@JoeKar 