### PR TITLE
fix syntax highlighting issue for multi-word flags in shell filetype (sh.yaml)

### DIFF
--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -39,7 +39,7 @@ rules:
       # Coreutils commands
     - type: "\\b(base64|basename|cat|chcon|chgrp|chmod|chown|chroot|cksum|comm|cp|csplit|cut|date|dd|df|dir|dircolors|dirname|du|env|expand|expr|factor|false|fmt|fold|head|hostid|id|install|join|link|ln|logname|ls|md5sum|mkdir|mkfifo|mknod|mktemp|mv|nice|nl|nohup|nproc|numfmt|od|paste|pathchk|pinky|pr|printenv|printf|ptx|pwd|readlink|realpath|rm|rmdir|runcon|seq|(sha1|sha224|sha256|sha384|sha512)sum|shred|shuf|sleep|sort|split|stat|stdbuf|stty|sum|sync|tac|tail|tee|test|time|timeout|touch|tr|true|truncate|tsort|tty|uname|unexpand|uniq|unlink|users|vdir|wc|who|whoami|yes)\\b"
       # Conditional flags
-    - statement: "\\s+(-[A-Za-z]+|--[a-z]+)"
+    - statement: "\\s+(-[A-Za-z_]+|--[a-z_]+)"
 
     - identifier: "\\$\\{[\\w:!%&=+#~@*^$?, .\\-\\/\\[\\]]+\\}"
     - identifier: "\\$([0-9!#@*$?-]|[A-Za-z_]\\w*)"


### PR DESCRIPTION
before:
<img width="1026" height="123" alt="image" src="https://github.com/user-attachments/assets/e0e94ed6-4b3b-4151-b2aa-1c42d42d5ddf" />
img 1 (left) micro | img 2 (right) vim

after:
<img width="559" height="128" alt="image" src="https://github.com/user-attachments/assets/ac660718-a799-4b4a-8a3e-df5de6c68961" />