### PR TITLE
statusline: Add a global-only option check to `FindOpt()`

### DIFF
--- a/internal/display/statusline.go
+++ b/internal/display/statusline.go
@@ -100,6 +100,9 @@ func (s *StatusLine) FindOpt(opt string) any {
 	if val, ok := s.win.Buf.Settings[opt]; ok {
 		return val
 	}
+	if _, ok := config.DefaultGlobalOnlySettings[opt]; ok {
+		return config.GlobalSettings[opt]
+	}
 	return "null"
 }
 


### PR DESCRIPTION
Fixes #3897