### PR TITLE
[build] Extend logging for build-version script warning

### DIFF
--- a/tools/build-version.go
+++ b/tools/build-version.go
@@ -43,8 +43,9 @@ func main() {
 	version, err := semver.ParseTolerant(versionStr)
 	if err != nil {
 		// no version tag found so just return what ever we can find.
-		log.Printf("semver.ParseTolerant(%s): %v", versionStr, err)
-		fmt.Println("0.0.0-unknown")
+		defaultVersionStr := "0.0.0-unknown"
+		log.Printf("semver.ParseTolerant(%s): %v, defaulting to %s", versionStr, err, defaultVersionStr)
+		fmt.Println(defaultVersionStr)
 		return
 	}
 	if ahead == nil {


### PR DESCRIPTION
Spent some time figuring out what this error message meant. Hopefully I can save someone else's time.

Context:
The build-version.go script uses a default if it can't find a tag, but I mistakenly thought the warning meant the build was broken. I ran into this problem when cloning repo with --depth=1 and didn't grab tags.

# test

before
```
2025/10/29 07:22:02 semver.ParseTolerant(): strconv.ParseUint: parsing "": invalid syntax
```

after
```
2025/10/29 07:22:02 semver.ParseTolerant(): strconv.ParseUint: parsing "": invalid syntax, defaulting to 0.0.0-unknown
```

more log context
```
/usr/bin/make build
GOOS=linux GOARCH=amd64 go generate ./runtime
go: downloading gopkg.in/yaml.v2 v2.2.8
go: downloading github.com/blang/semver v3.5.1+incompatible
2025/10/29 07:22:02 semver.ParseTolerant(): strconv.ParseUint: parsing "": invalid syntax, defaulting to 0.0.0-unknown
CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X github.com/zyedidia/micro/v2/internal/util.Version=0.0.0-unknown -X github.com/zyedidia/micro/v2/internal/util.CommitHash=fa683141 -X 'github.com/zyedidia/micro/v2/internal/util.CompileDate=October 29, 2025' """ ./cmd/micro
go: downloading github.com/layeh/gopher-luar v1.0.11
go: downloading github.com/go-errors/errors v1.0.1
go: downloading github.com/yuin/gopher-lua v1.1.1
go: downloading github.com/micro-editor/tcell/v2 v2.0.13
go: downloading github.com/mattn/go-isatty v0.0.20
go: downloading github.com/mattn/go-runewidth v0.0.16
go: downloading github.com/micro-editor/terminal v0.0.0-20250324214352-e587e959c6b5
go: downloading github.com/sergi/go-diff v1.1.0
go: downloading golang.org/x/text v0.4.0
go: downloading github.com/micro-editor/go-shellquote v0.0.0-20250101105543-feb6c39314f5
go: downloading github.com/micro-editor/json5 v1.0.1-micro
go: downloading github.com/dustin/go-humanize v1.0.0
go: downloading github.com/zyedidia/clipper v0.1.1
go: downloading github.com/mitchellh/go-homedir v1.1.0
go: downloading github.com/zyedidia/glob v0.0.0-20170209203856-dd4023a66dc3
go: downloading github.com/rivo/uniseg v0.2.0
go: downloading golang.org/x/sys v0.30.0
go: downloading github.com/creack/pty v1.1.18
go: downloading golang.org/x/term v0.29.0
go: downloading github.com/gdamore/encoding v1.0.0
go: downloading github.com/lucasb-eyer/go-colorful v1.0.3
```