### PR TITLE
feat(status): add status.icon function and config override for filetype icons

### DIFF
--- a/runtime/plugins/status/help/status.md
+++ b/runtime/plugins/status/help/status.md
@@ -19,3 +19,18 @@ This plugin provides functions that can be used in the status line format:
 * `status.bytes`: returns the number of bytes in the current buffer.
 * `status.size`: returns the size of the current buffer in a human-readable
    format.
+* `status.icon`: returns a Nerd Font icon representing the current file type
+  of the buffer. ⚠️ **Requires a Nerd Font installed in your terminal** to display correctly.
+
+### Overriding default icons
+
+The icons used by `status.icon` can be customized in your
+`~/.config/micro/settings.json` file. You can override the default icon
+for any filetype by adding an entry in the `status.icons` option.
+For example:
+
+```json
+{
+  "status.icons": "go=,lua=,typescript=,ruby=,unkwown="
+}
+```

--- a/runtime/plugins/status/status.lua
+++ b/runtime/plugins/status/status.lua
@@ -8,6 +8,21 @@ local filepath = import("filepath")
 local humanize = import("humanize")
 local strings = import("strings")
 
+local icons = {}
+local defaultIcons =
+"unkwown=,apacheconf=,,batch=,c=,c++=,cmake=,conf=,crystal=,css=,d=,dart=,dockerfile=,elm=,fish=,gdscript=,glsl=,go=,haskell=,html=,ini=,java=,javascript=,jinja2=,json=,julia=,kotlin=,lua=,markdown= ,nginx=,nim=,objc=,ocaml=,pascal=,perl=,php=,pony=,powershell=,proto=,python=,python3=,ruby=,rust=󱘗,scala=,shell=,sql=,swift=,tex=,toml=,twig=,typescript=,v=,xml=,yaml=,zig=,zscript=,zsh="
+
+local function parseIcons(str)
+    local map = {}
+    for pair in string.gmatch(str, "([^,]+)") do
+        local ft, icon = pair:match("([^=]+)=([^,]+)")
+        if ft and icon then
+            map[ft] = icon
+        end
+    end
+    return map
+end
+
 function init()
     micro.SetStatusInfoFn("status.branch")
     micro.SetStatusInfoFn("status.hash")
@@ -17,6 +32,10 @@ function init()
     micro.SetStatusInfoFn("status.bytes")
     micro.SetStatusInfoFn("status.size")
     config.AddRuntimeFile("status", config.RTHelp, "help/status.md")
+
+    local iconsStr = config.GetGlobalOption("status.icons") or defaultIcons
+    config.RegisterCommonOption("status", "icons", iconsStr)
+    icons = parseIcons(iconsStr)
 end
 
 function lines(b)
@@ -59,4 +78,11 @@ function paste(b)
         return "PASTE "
     end
     return ""
+end
+
+function icon(b)
+    local filetype = b:FileType()
+    local icon = icons[filetype] or
+        icons["unkwown"] or ""
+    return icon
 end


### PR DESCRIPTION
- Introduced `status.icon` to show Nerd Font icons for the current buffer's filetype.
- Added `status.icons` option to allow overriding default icons in settings.json.
- Updated help markdown to document the new function and configuration.
- Note in help that Nerd Fonts must be installed for icons to render correctly.