### PR TITLE
Gutter diff adapts to git's core.autocrlf setting

### DIFF
--- a/runtime/plugins/diff/diff.lua
+++ b/runtime/plugins/diff/diff.lua
@@ -10,7 +10,16 @@ function onBufferOpen(buf)
 		local _, err = os.Stat(buf.AbsPath)
 		if err == nil then
 			local dirName, fileName = filepath.Split(buf.AbsPath)
-			local diffBase, err = shell.ExecCommand("git", "-C", dirName, "show", "HEAD:./" .. fileName)
+			
+			local autocrlf, err = shell.ExecCommand("git", "-C", dirName, "config", "get", "core.autocrlf")
+			
+			local diffBase
+			if not err and string.match(autocrlf, "true") then
+				diffBase, err = shell.ExecCommand("git", "-C", dirName, "cat-file", "--filters", "HEAD:./" .. fileName)
+			else
+				diffBase, err = shell.ExecCommand("git", "-C", dirName, "show", "HEAD:./" .. fileName)
+			end
+			
 			if err ~= nil then
 				diffBase = buf:Bytes()
 			end


### PR DESCRIPTION
Using micro on windows is very annoying, since the diff gutter will be filled with "modified", on git versioned files.

The diff in micro is calculated between the last commit in the repository and the active workspace. However, if the option core.autocrlf is enabled on windows, if the file in the repo has LF line endings, the file in the workspace will have CR LF line endings. Resulting in a detectable modification in every line of the file.

My solution checks if core.autocrlf is enabled. If it's not, if processes the diff normally. If it is enabled, the diff is calculated using `git cat-file --filters`, to filter out the line end changes.

This PR should solve issue #1517