### PR TITLE
Only set buffer type to stdout when no file args are passed

### DIFF
--- a/cmd/micro/micro.go
+++ b/cmd/micro/micro.go
@@ -158,7 +158,6 @@ func LoadInput(args []string) []*buffer.Buffer {
 	// 3. If there is no input file and the input is a terminal, an empty buffer
 	// should be opened
 
-	var filename string
 	buffers := make([]*buffer.Buffer, 0, len(args))
 
 	files := make([]string, 0, len(args))
@@ -238,10 +237,10 @@ func LoadInput(args []string) []*buffer.Buffer {
 				screen.TermMessage("Error reading from stdin: ", err)
 				input = []byte{}
 			}
-			buffers = append(buffers, buffer.NewBufferFromStringWithCommand(string(input), filename, btype, command))
+			buffers = append(buffers, buffer.NewBufferFromStringWithCommand(string(input), "", btype, command))
 		} else {
 			// Option 3, just open an empty buffer
-			buffers = append(buffers, buffer.NewBufferFromStringWithCommand("", filename, btype, command))
+			buffers = append(buffers, buffer.NewBufferFromStringWithCommand("", "", btype, command))
 		}
 	}
 


### PR DESCRIPTION
Fixes #2600

I personally encounter the problem when using broot and ZLE functions in Zsh, where micro detects it's not a standard terminal IO situation, yet a real file is being edited. In this case I want to be able to save the file being edited, and I don't want the file content dumped to stdout.