### PR TITLE
fix drawing of wide characters in InfoWindow

### DIFF
--- a/internal/display/infowindow.go
+++ b/internal/display/infowindow.go
@@ -134,18 +134,17 @@ func (i *InfoWindow) displayBuffer() {
 		curBX := blocX
 		r, combc, size := util.DecodeCharacter(line)
 
-		draw(r, combc, i.defStyle())
-
 		width := 0
 
 		switch r {
 		case '\t':
 			width = tabsize - (totalwidth % tabsize)
-			for j := 1; j < width; j++ {
+			for j := 0; j < width; j++ {
 				draw(' ', nil, i.defStyle())
 			}
 		default:
 			width = runewidth.RuneWidth(r)
+			draw(r, combc, i.defStyle())
 		}
 
 		blocX++


### PR DESCRIPTION
This brings InfoWindow rendering closer to what BufWindow does. Wide characters are no longer rendered as `@ ` (even if they are cut off – if we want to change that then we should do it in BufWindow as well). 

closes #2277
closes #3514
closes #3918 