### PR TITLE
syntax/sh: Improve `heredoc` detection

### DIFF
--- a/runtime/syntax/sh.yaml
+++ b/runtime/syntax/sh.yaml
@@ -57,8 +57,8 @@ rules:
         rules: []
 
     - constant.string:
-        start: "<<[^\\s]+[-~.]*[A-Za-z0-9]+$"
-        end: "^[^\\s]+[A-Za-z0-9]+$"
+        start: "<<-?[\\s]*[\\w,.:~#!§$%=?@*+-]+$"
+        end: "^[\\w,.:~#!§$%=?@*+-]+$"
         skip: "\\\\."
         rules: []
 


### PR DESCRIPTION
- allow spaces between optional '-' and delimiter
- allow additional characters as delimiter

Fixes #3927