### PR TITLE
Use argument passed to `OpenCmd` without splitting

### DIFF
--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -290,20 +290,8 @@ func (h *BufPane) PwdCmd(args []string) {
 // OpenCmd opens a new buffer with a given filename
 func (h *BufPane) OpenCmd(args []string) {
 	if len(args) > 0 {
-		filename := args[0]
-		// the filename might or might not be quoted, so unquote first then join the strings.
-		args, err := shellquote.Split(filename)
-		if err != nil {
-			InfoBar.Error("Error parsing args ", err)
-			return
-		}
-		if len(args) == 0 {
-			return
-		}
-		filename = strings.Join(args, " ")
-
 		open := func() {
-			b, err := buffer.NewBufferFromFile(filename, buffer.BTDefault)
+			b, err := buffer.NewBufferFromFile(args[0], buffer.BTDefault)
 			if err != nil {
 				InfoBar.Error(err)
 				return


### PR DESCRIPTION
This stops the first argument being split and joined, since the split is already by the command parser. Small details are provided in the commit message.

Fixes #1133