### PR TITLE
refactor: simplify internal buffer, error handling, and path logic

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -404,23 +404,26 @@ func ReplaceHome(path string) (string, error) {
 
 	var userData *user.User
 	var err error
+	var home string
 
-	homeString := strings.Split(path, "/")[0]
-	if homeString == "~" {
+	if len(path) == 1 || path[1] == '/' {
 		userData, err = user.Current()
 		if err != nil {
-			return "", errors.New("Could not find user: " + err.Error())
+			return "", fmt.Errorf("Could not find user: %w", err)
 		}
+		home = userData.HomeDir
+		path = path[1:]
 	} else {
-		userData, err = user.Lookup(homeString[1:])
+		homeString := strings.SplitN(path[1:], "/", 2)[0]
+		userData, err = user.Lookup(homeString)
 		if err != nil {
-			return "", errors.New("Could not find user: " + err.Error())
+			return "", fmt.Errorf("Could not find user: %w", err)
 		}
+		home = userData.HomeDir
+		path = path[1+len(homeString):]
 	}
 
-	home := userData.HomeDir
-
-	return strings.Replace(path, homeString, home, 1), nil
+	return home + path, nil
 }
 
 // GetPathAndCursorPosition returns a filename without everything following a `:`


### PR DESCRIPTION
This PR contains a set of small, behavior-preserving refactors in internal packages to improve readability and idiomatic Go usage

The changes focus on simplifying internal buffer operations, clarifying tilde path expansion logic, and standardizing error construction and wrapping. No public APIs or user-visible behavior are modified.