### PR TITLE
Add B (Ken Thompson-era) syntax highlighting

### DIFF
--- a/runtime/syntax/b.yaml
+++ b/runtime/syntax/b.yaml
@@ -1,0 +1,87 @@
+filetype: B
+
+detect:
+    filename: '\.b$'
+    # core control words + storage classes (Thompson B-ish)
+    signature: '\b(if|else|while|switch|case|default|break|return|goto|extrn|auto)\b'
+
+rules:
+    # -------------------------
+    # Comments (B: /* ... */)
+    # -------------------------
+    - comment:
+        start: '/\*'
+        end: '\*/'
+        rules: []
+
+    # Optional: // line comments (convenient, not “original” B)
+    - comment:
+        start: '//'
+        end: '$'
+        rules: []
+
+    # -------------------------
+    # Strings + escapes
+    # -------------------------
+    - constant.string:
+        start: '"'
+        end: '"'
+        skip: '\\\\.'
+        rules:
+            # common escapes: \n \t \e \r \0 \" \\ \( \) \*
+            - constant.specialChar: '\\\\([0netr"\\\\\\*\\(\\)])'
+            # printf-ish: %s %c %d %o and %%
+            - constant.specialChar: '%(%|[scdo])'
+
+    - constant.string:
+        start: "'"
+        end: "'"
+        skip: '\\\\.'
+        rules:
+            - constant.specialChar: '\\\\([0netr"\\\\\\*\\(\\)])'
+            - constant.specialChar: '%(%|[scdo])'
+
+    # -------------------------
+    # Numbers
+    # (leading 0 commonly used for octal constants)
+    # -------------------------
+    - constant.number: '\b0[0-7]+\b'
+    - constant.number: '\b[0-9]+\b'
+
+    # -------------------------
+    # Keywords / storage (keep tight + old-school)
+    # -------------------------
+    - statement: '\b(if|else|while|switch|case|default|break|return|goto)\b'
+    - type: '\b(extrn|auto)\b'
+
+    # -------------------------
+    # Common B library calls (/etc/libb.a era list)
+    # -------------------------
+    - constant.builtin: '\b(char|getchr|putchr|exit|printf|seek|setuid|stat|time|unlink|wait|lchar|chdir|chmod|chown|close|creat|execl|execv|fork|fstat|getuid|intr|link|makdir|open|read|write|ctime)\b'
+
+    # -------------------------
+    # Labels and function-ish identifiers
+    # -------------------------
+    # label (often at bol)
+    - identifier: '^\s*[_A-Za-z][_A-Za-z0-9]*\s*:'
+    # function call/def name before '('
+    - identifier: '\b[_A-Za-z][_A-Za-z0-9]*\s*\('
+
+    # -------------------------
+    # Operators (order matters: longer first)
+    # Thompson-ish assignment operators in B are =+, =-, =*, =/, =%, =<<, =>>, =& , =|
+    # -------------------------
+    - symbol.operator: '(=<<|=>>|=\+|=-|=\*|=/|=%|=&|=\|)'
+    - symbol.operator: '(==|!=|<=|>=|<<|>>)'
+    - symbol.operator: '(\+\+|--|\*\*)'
+    - symbol.operator: '[-+*/%&|^~!=<>?:=]'
+
+    # -------------------------
+    # Brackets
+    # -------------------------
+    - symbol.brackets: '[(){}\[\]]'
+
+    # -------------------------
+    # Identifiers / variables (last so keywords win)
+    # -------------------------
+    - identifier: '\b[_A-Za-z][_A-Za-z0-9]*\b'


### PR DESCRIPTION
This adds syntax highlighting for the B programming language (Ken Thompson / early Bell Labs-era B) to Micro by introducing a new syntax definition:

* `runtime/syntax/b.yaml` (or the appropriate syntax directory used by the repo)

### What’s included

* File detection for `*.b`
* Core B keywords and storage classes (e.g., `auto`, `extrn`, `if`, `while`, `switch`, `case`, etc.)
* C-style block comments (`/* ... */`)
* String and character literals with basic escape handling
* Decimal + octal numeric constants
* Labels and function-like identifiers
* Operator highlighting, including Thompson-style compound assignments (e.g., `=+`, `=-`, `=*`, `=<<`, `=>>`, etc.)

### Why

Micro currently lacks a built-in syntax file for B. This addition helps anyone working with historic Unix code, PDP-11 tooling, language archaeology, or modern B reimplementations.

### Notes / compatibility

* The regex patterns are written to be YAML-safe (single-quoted patterns where needed) to avoid “unknown escape character” parse errors.
* The rules are intentionally conservative to match B’s small syntax and avoid false positives in other languages.

