### PR TITLE
Update outdated V syntax highlighting

### DIFF
--- a/runtime/syntax/v.yaml
+++ b/runtime/syntax/v.yaml
@@ -2,7 +2,7 @@ filetype: v
 
 detect:
     filename: "\\.(vsh|vv)$"
-    header: "^#!.*env +\\S+ +v +-raw-vsh-tmp-prefix +tmp$"
+    header: "^#!\\S*\\benv(\\s.*)?\\sv(\\s|$)"
 
 rules:
       # Conditionals and control flow


### PR DESCRIPTION
This PR updates the long outdated V syntax highlighting and adds some new features. Changes include:

## Detection:
- Add `.vsh` and `.vv` filename detection (note: `.v` is omitted for Verilog)
- Add shebang header detection for [VSH files](https://docs.vlang.io/other-v-features.html#cross-platform-shell-scripts-in-v)

## Highlighting
- Add common [C preprocessor directives](https://docs.vlang.io/v-and-c.html)
- Introduce new [reserved language keywords](https://docs.vlang.io/appendix-i-keywords.html)
- Add identifiers for new [OS, compiler, platform and compilation options](https://docs.vlang.io/conditional-compilation.html#$if-condition)
- Include bit-wise XOR (`^`) in operators
- Support [generics](https://docs.vlang.io/type-declarations.html#generics) in function definitions and calls
- Update to new `@[]` [attribute](https://docs.vlang.io/attributes.html) syntax
- Improve attribute highlighting
- Add support for [conditional compilation](https://docs.vlang.io/conditional-compilation.html)
- Add `u8` and `i32` types to type rule
- Remove non-existent `u128` and `i128` types from type rule
- Add `nil` constant
- Fix broken highlighting when escaping a character within backticks (``` `` ```)
- Add `NOTE` to todo rule
- Treat shebang as comment