### PR TITLE
Keep selection on `textfilter` output

### DIFF
--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -141,9 +141,11 @@ func (h *BufPane) TextFilterCmd(args []string) {
 		InfoBar.Error("usage: textfilter arguments")
 		return
 	}
+
 	for _, c := range h.Buf.GetCursors() {
 		sel := c.GetSelection()
-		if len(sel) == 0 {
+		fromSelection := len(sel) > 0
+		if !fromSelection {
 			c.SelectWord()
 			sel = c.GetSelection()
 		}
@@ -158,7 +160,18 @@ func (h *BufPane) TextFilterCmd(args []string) {
 			return
 		}
 		c.DeleteSelection()
-		h.Buf.Insert(c.Loc, bout.String())
+		insertStart := c.Loc
+		insertedText := bout.String()
+		h.Buf.Insert(c.Loc, insertedText)
+
+		if fromSelection {
+			// Select the pasted output if the input was selected
+			charCount := util.CharacterCountInString(insertedText)
+			insertEnd := insertStart.Move(charCount, h.Buf)
+			c.SetSelectionStart(insertStart)
+			c.SetSelectionEnd(insertEnd)
+			c.Loc = insertEnd
+		}
 	}
 }
 


### PR DESCRIPTION
**Background:**
The `textfilter` command is great for running a single shell command on a selection (or multiple) from the buffer as stdin. The selection is replaced by the command output, but the output is not selected afterward.

**Expected changes:**
- Keep the output selected if the input was a selection. This is great for chaining commands and in line with what I would expect textfilter to do.

![demo3](https://github.com/user-attachments/assets/2b75e1f4-4851-4935-90a3-15de4088fd6b)

**Personal note:** I am new to the code base and never written Go. I find the repo very easy to work with. I might have implemented this in a completely stupid way though. Harsh feedback is welcome. I could have made this into a plugin, but I found it hard to implement the textfilter command in Lua, so went with this native approach instead. If this approach is approved, then I will oversee the documentation as well.