### PR TITLE
Add 'conf' extension to INI file detection

### DIFF
--- a/runtime/syntax/ini.yaml
+++ b/runtime/syntax/ini.yaml
@@ -1,7 +1,7 @@
 filetype: ini
 
 detect:
-    filename: "\\.(ini|desktop|lfl|override|tscn|tres)$|(mimeapps\\.list|pinforc|setup\\.cfg|project\\.godot)$|weechat/.+\\.conf$"
+    filename: "\\.(ini|desktop|lfl|override|tscn|tres|conf)$|(mimeapps\\.list|pinforc|setup\\.cfg|project\\.godot)$|weechat/.+\\.conf$"
 
 rules:
     - constant.bool.true: "\\btrue\\b"


### PR DESCRIPTION
As per the bug report I raised, the regex for the filename detection is malformed. Moving the .conf at the end of the pattern to the generic list at the front allows the ini filetype to be accosiated with .conf files. 

Bug report:
ini.yaml - Code Highlighter Misses .conf Files

**I've never created a bug report or a pull request on a live project before so please feel free to let me know if i've done something incorrect**

Fixes #4004