### PR TITLE
support regexp lookaround assertions in syntax files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 require (
 	github.com/creack/pty v1.1.18 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.0.3 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
+github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=

--- a/pkg/highlight/highlight_test.go
+++ b/pkg/highlight/highlight_test.go
@@ -1,0 +1,229 @@
+package highlight
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// resetGroups clears the global group registry so tests don't interfere with each other.
+func resetGroups() {
+	Groups = make(map[string]Group)
+	numGroups = 0
+}
+
+// makeHighlighter parses a YAML syntax definition and returns a Highlighter.
+func makeHighlighter(t *testing.T, yaml string) *Highlighter {
+	t.Helper()
+	data := []byte(yaml)
+
+	header, err := MakeHeaderYaml(data)
+	if err != nil {
+		t.Fatalf("MakeHeaderYaml: %v", err)
+	}
+
+	f, err := ParseFile(data)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+
+	def, err := ParseDef(f, header)
+	if err != nil {
+		t.Fatalf("ParseDef: %v", err)
+	}
+
+	return NewHighlighter(def)
+}
+
+// groupAt returns the Group name at a given character position in a LineMatch.
+// It walks backwards from pos to find the most recent color change.
+func groupAt(lm LineMatch, pos int) string {
+	best := -1
+	for k := range lm {
+		if k <= pos && k > best {
+			best = k
+		}
+	}
+	if best < 0 {
+		return ""
+	}
+	return lm[best].String()
+}
+
+func TestLookahead(t *testing.T) {
+	resetGroups()
+	assert := assert.New(t)
+
+	h := makeHighlighter(t, `
+filetype: test-lookahead
+detect:
+    filename: "\\.test$"
+rules:
+    - identifier.function: "\\w+(?=\\()"
+`)
+
+	matches := h.HighlightString("foo(bar)")
+	assert.Len(matches, 1)
+
+	lm := matches[0]
+
+	// "foo" (positions 0-2) should be highlighted as identifier.function
+	assert.Equal("identifier.function", groupAt(lm, 0))
+	assert.Equal("identifier.function", groupAt(lm, 1))
+	assert.Equal("identifier.function", groupAt(lm, 2))
+
+	// "(" at position 3 should NOT be identifier.function (lookahead doesn't consume)
+	assert.NotEqual("identifier.function", groupAt(lm, 3))
+
+	// "bar" should not match (not followed by "(")
+	assert.NotEqual("identifier.function", groupAt(lm, 4))
+}
+
+func TestNegativeLookahead(t *testing.T) {
+	resetGroups()
+	assert := assert.New(t)
+
+	h := makeHighlighter(t, `
+filetype: test-neg-lookahead
+detect:
+    filename: "\\.test$"
+rules:
+    - identifier: "foo(?!bar)"
+`)
+
+	matches := h.HighlightString("foobar foobaz")
+	assert.Len(matches, 1)
+
+	lm := matches[0]
+
+	// "foobar": "foo" is followed by "bar", so negative lookahead fails — no match
+	assert.NotEqual("identifier", groupAt(lm, 0))
+
+	// "foobaz": "foo" at position 7 is NOT followed by "bar", so it matches
+	assert.Equal("identifier", groupAt(lm, 7))
+	assert.Equal("identifier", groupAt(lm, 8))
+	assert.Equal("identifier", groupAt(lm, 9))
+
+	// "baz" at position 10 should not be highlighted
+	assert.NotEqual("identifier", groupAt(lm, 10))
+}
+
+func TestLookbehind(t *testing.T) {
+	resetGroups()
+	assert := assert.New(t)
+
+	h := makeHighlighter(t, `
+filetype: test-lookbehind
+detect:
+    filename: "\\.test$"
+rules:
+    - identifier.field: "(?<=\\.)\\w+"
+`)
+
+	matches := h.HighlightString("obj.field")
+	assert.Len(matches, 1)
+
+	lm := matches[0]
+
+	// "obj" (positions 0-2) should NOT be highlighted
+	assert.NotEqual("identifier.field", groupAt(lm, 0))
+
+	// "." at position 3 should NOT be highlighted (lookbehind doesn't consume)
+	assert.NotEqual("identifier.field", groupAt(lm, 3))
+
+	// "field" (positions 4-8) should be highlighted
+	assert.Equal("identifier.field", groupAt(lm, 4))
+	assert.Equal("identifier.field", groupAt(lm, 5))
+	assert.Equal("identifier.field", groupAt(lm, 8))
+}
+
+func TestNegativeLookbehind(t *testing.T) {
+	resetGroups()
+	assert := assert.New(t)
+
+	h := makeHighlighter(t, `
+filetype: test-neg-lookbehind
+detect:
+    filename: "\\.test$"
+rules:
+    - identifier: "(?<!\\.)\\b\\w+\\b"
+`)
+
+	matches := h.HighlightString("obj.field")
+	assert.Len(matches, 1)
+
+	lm := matches[0]
+
+	// "obj" (positions 0-2) should be highlighted — not preceded by "."
+	assert.Equal("identifier", groupAt(lm, 0))
+	assert.Equal("identifier", groupAt(lm, 2))
+
+	// "field" (positions 4-8) should NOT be highlighted — preceded by "."
+	assert.NotEqual("identifier", groupAt(lm, 4))
+}
+
+func TestLookaheadInRegion(t *testing.T) {
+	resetGroups()
+	assert := assert.New(t)
+
+	h := makeHighlighter(t, `
+filetype: test-region-lookahead
+detect:
+    filename: "\\.test$"
+rules:
+    - constant.string:
+        start: "\""
+        end: "\""
+        rules:
+            - special: "\\w+(?=!)"
+`)
+
+	matches := h.HighlightString(`"hello!"`)
+	assert.Len(matches, 1)
+
+	lm := matches[0]
+
+	// Position 0 is the opening `"` — should be constant.string (the region delimiter)
+	assert.Equal("constant.string", groupAt(lm, 0))
+
+	// "hello" at positions 1-5 inside the string should get "special" via lookahead
+	assert.Equal("special", groupAt(lm, 1))
+	assert.Equal("special", groupAt(lm, 5))
+
+	// "!" at position 6 should revert to constant.string (not consumed by lookahead)
+	assert.Equal("constant.string", groupAt(lm, 6))
+}
+
+func TestBasicHighlighting(t *testing.T) {
+	resetGroups()
+	assert := assert.New(t)
+
+	h := makeHighlighter(t, `
+filetype: test-basic
+detect:
+    filename: "\\.test$"
+rules:
+    - keyword: "\\b(if|else|while)\\b"
+    - constant.number: "\\b\\d+\\b"
+`)
+
+	matches := h.HighlightString("if x 42 else")
+	assert.Len(matches, 1)
+
+	lm := matches[0]
+
+	// "if" at positions 0-1
+	assert.Equal("keyword", groupAt(lm, 0))
+	assert.Equal("keyword", groupAt(lm, 1))
+
+	// "x" at position 3 — no highlight
+	assert.Equal("", groupAt(lm, 3))
+
+	// "42" at positions 5-6
+	assert.Equal("constant.number", groupAt(lm, 5))
+	assert.Equal("constant.number", groupAt(lm, 6))
+
+	// "else" at positions 8-11
+	assert.Equal("keyword", groupAt(lm, 8))
+	assert.Equal("keyword", groupAt(lm, 11))
+}

--- a/pkg/highlight/regexp.go
+++ b/pkg/highlight/regexp.go
@@ -1,0 +1,57 @@
+package highlight
+
+import (
+	"log"
+	"time"
+	"unicode/utf8"
+
+	"github.com/dlclark/regexp2"
+)
+
+// compileRegex compiles a pattern using regexp2 with a 1-second match timeout
+// for backtracking safety.
+func compileRegex(pattern string) (*regexp2.Regexp, error) {
+	re, err := regexp2.Compile(pattern, regexp2.None)
+	if err != nil {
+		return nil, err
+	}
+	re.MatchTimeout = 1 * time.Second
+	return re, nil
+}
+
+// matchString returns whether re matches s. On timeout, it logs the error
+// and returns false.
+func matchString(re *regexp2.Regexp, s string) bool {
+	m, err := re.MatchString(s)
+	if err != nil {
+		log.Printf("highlight: regex timeout matching pattern %q: %v", re.String(), err)
+		return false
+	}
+	return m
+}
+
+// matchBytes returns whether re matches b. On timeout, it logs the error
+// and returns false.
+func matchBytes(re *regexp2.Regexp, b []byte) bool {
+	return matchString(re, string(b))
+}
+
+// charPosFromRunePos converts a rune index (as returned by regexp2) to a
+// character index (which skips combining marks via isMark). For ASCII text
+// (the vast majority of source code), rune pos == char pos.
+func charPosFromRunePos(runeIdx int, str []byte) int {
+	charPos := 0
+	runeCount := 0
+	for i := 0; i < len(str); {
+		if runeCount >= runeIdx {
+			return charPos
+		}
+		r, size := utf8.DecodeRune(str[i:])
+		i += size
+		runeCount++
+		if !isMark(r) {
+			charPos++
+		}
+	}
+	return charPos
+}


### PR DESCRIPTION
this change makes syntax highlighting use [dlclark/regexp2](https://github.com/dlclark/regexp2) instead of the standard library regexp package so that [syntax files](https://github.com/micro-editor/micro/blob/d38f0dfe7af9a6a8cac27764ad47f43af60896df/runtime/help/colors.md#syntax-files) can use lookahead/lookbehind assertions.

in-buffer search is unchanged to avoid the UI freezing from bad lookbehinds

disclosure: this diff was generated by claude code