### PR TITLE
Add detection for SWAG nginx proxy confs

### DIFF
--- a/runtime/syntax/nginx.yaml
+++ b/runtime/syntax/nginx.yaml
@@ -1,7 +1,7 @@
 filetype: nginx
 
 detect:
-    filename: "nginx.*\\.conf$|\\.nginx$|\\.sub(domain|folder).conf$"
+    filename: "nginx.*\\.conf$|\\.nginx$|\\.sub(domain|folder)\\.conf$"
     header: "^(server|upstream)[a-z ]*\\{$"
 
 rules:


### PR DESCRIPTION
These nginx config files have the format "appname.subdomain.conf" or "appname.subfolder.conf"

Fixes #4032