### PR TITLE
syntax: add Gleam language support

### DIFF
--- a/runtime/syntax/gleam.yaml
+++ b/runtime/syntax/gleam.yaml
@@ -67,4 +67,3 @@ rules:
         end: "$"
         rules:
             - todo: "(TODO|FIXME|XXX):?"
-


### PR DESCRIPTION
Adds syntax highlighting for the Gleam programming language.

Supports:
- Keywords (fn, let, case, if, else, import, pub, type, opaque, const, use)
- Built-in types (Int, Float, String, Bool, List, Option, Result, Nil)
- Constants (True, False, Nil)
- Single line comments (//)
- Strings
- Numbers