### PR TITLE
Fix config.SetGlobalOption to write to settings.json

### DIFF
--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -684,11 +684,11 @@ func SetGlobalOption(option, value string, writeToFile bool) error {
 }
 
 func SetGlobalOptionNativePlug(option string, nativeValue any) error {
-	return SetGlobalOptionNative(option, nativeValue, false)
+	return SetGlobalOptionNative(option, nativeValue, true)
 }
 
 func SetGlobalOptionPlug(option, value string) error {
-	return SetGlobalOption(option, value, false)
+	return SetGlobalOption(option, value, true)
 }
 
 // ResetCmd resets a setting to its default value

--- a/runtime/help/plugins.md
+++ b/runtime/help/plugins.md
@@ -225,9 +225,9 @@ The packages and their contents are listed below (in Go type signatures):
        given plugin in the `GlobalSettings` map.
 
     - `SetGlobalOption(option, value string) error`: sets an option to a
-       given value. This will try to convert the value into the proper
-       type for the option. Can return an error if the option name is not
-       valid, or the value can not be converted.
+       given value. Same as using the `> set` command. This will try to convert
+       the value into the proper type for the option. Can return an error if the
+       option name is not valid, or the value can not be converted.
 
     - `SetGlobalOptionNative(option string, value any) error`: sets
        an option to a given value, where the type of value is the actual


### PR DESCRIPTION
**Fixes #4041**

## Problem
Commit 7a250b7d changed `SetGlobalOptionPlug` to pass `writeToFile=false`, which broke the expected behavior where `config.SetGlobalOption()` from Lua plugins would persist changes to `settings.json`.

## Solution
This PR restores the original behavior by passing `writeToFile=true` in both:
- `SetGlobalOptionPlug` 
- `SetGlobalOptionNativePlug`

So that plugin calls to SetGlobalOption will properly write changes to settings.json, matching the behavior of the `> set` command.

## Changes
- `internal/action/command.go`: Changed writeToFile from false to true in plugin wrapper functions
- `runtime/help/plugins.md`: Updated documentation to clarify that SetGlobalOption behaves like the `> set` command and writes to settings.json

---
*Note: This PR was created by an automated agent (ClawOSS). Please review carefully.*