### PR TITLE
Suspend the whole process group along with micro.

### DIFF
--- a/internal/action/actions_posix.go
+++ b/internal/action/actions_posix.go
@@ -14,9 +14,8 @@ import (
 func (*BufPane) Suspend() bool {
 	screenb := screen.TempFini()
 
-	// suspend the process
-	pid := syscall.Getpid()
-	err := syscall.Kill(pid, syscall.SIGSTOP)
+	// suspend the process group
+	err := syscall.Kill(0, syscall.SIGSTOP)
 	if err != nil {
 		screen.TermMessage(err)
 	}


### PR DESCRIPTION

Fixes https://github.com/micro-editor/micro/issues/4059. See that for the description of the problem.

Running `./wrap.sh ./micro` on the binary built by this suspends in one step.