### PR TITLE
Fix regex `\n` matching across lines in search and replace

### DIFF
--- a/internal/action/command.go
+++ b/internal/action/command.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -1013,19 +1012,9 @@ func (h *BufPane) ReplaceCmd(args []string) {
 		}
 	}
 
-	if noRegex {
-		search = regexp.QuoteMeta(search)
-	}
-
 	replace := []byte(replaceStr)
 
-	var regex *regexp.Regexp
-	var err error
-	if h.Buf.Settings["ignorecase"].(bool) {
-		regex, err = regexp.Compile("(?im)" + search)
-	} else {
-		regex, err = regexp.Compile("(?m)" + search)
-	}
+	search, regex, err := h.Buf.CompileSearchRegex(search, !noRegex, true)
 	if err != nil {
 		// There was an error with the user's regex
 		InfoBar.Error(err)

--- a/internal/buffer/search.go
+++ b/internal/buffer/search.go
@@ -57,6 +57,31 @@ func shouldUseMultilineSearch(s string, useRegex bool) bool {
 	return strings.Contains(s, "\n")
 }
 
+// CompileSearchRegex compiles a search pattern according to regex mode and
+// buffer settings. It returns the normalized pattern and compiled regexp.
+func (b *Buffer) CompileSearchRegex(s string, useRegex bool, multiline bool) (string, *regexp.Regexp, error) {
+	pattern := s
+	if !useRegex {
+		pattern = regexp.QuoteMeta(pattern)
+	}
+
+	flags := ""
+	if b.Settings["ignorecase"].(bool) {
+		flags += "i"
+	}
+	if multiline {
+		flags += "m"
+	}
+
+	if flags != "" {
+		r, err := regexp.Compile("(?"+flags+")" + pattern)
+		return pattern, r, err
+	}
+
+	r, err := regexp.Compile(pattern)
+	return pattern, r, err
+}
+
 func (b *Buffer) findDownMultiline(r *regexp.Regexp, start, end Loc) ([2]Loc, bool) {
 	start, end = normalizeSearchBounds(b, start, end)
 
@@ -214,19 +239,7 @@ func (b *Buffer) FindNext(s string, start, end, from Loc, down bool, useRegex bo
 	}
 
 	multiline := shouldUseMultilineSearch(s, useRegex)
-
-	var r *regexp.Regexp
-	var err error
-
-	if !useRegex {
-		s = regexp.QuoteMeta(s)
-	}
-
-	if b.Settings["ignorecase"].(bool) {
-		r, err = regexp.Compile("(?i)" + s)
-	} else {
-		r, err = regexp.Compile(s)
-	}
+	_, r, err := b.CompileSearchRegex(s, useRegex, false)
 
 	if err != nil {
 		return [2]Loc{}, false, err

--- a/internal/buffer/search.go
+++ b/internal/buffer/search.go
@@ -52,9 +52,13 @@ func regexPatternContainsEscapedNewline(s string) bool {
 
 func shouldUseMultilineSearch(s string, useRegex bool) bool {
 	if useRegex {
-		return regexPatternContainsEscapedNewline(s)
+		return regexPatternContainsEscapedNewline(s) || strings.Contains(s, "\n")
 	}
 	return strings.Contains(s, "\n")
+}
+
+func shouldUseMultilineRegexPattern(pattern string) bool {
+	return regexPatternContainsEscapedNewline(pattern) || strings.Contains(pattern, "\n")
 }
 
 // CompileSearchRegex compiles a search pattern according to regex mode and
@@ -82,14 +86,18 @@ func (b *Buffer) CompileSearchRegex(s string, useRegex bool, multiline bool) (st
 	return pattern, r, err
 }
 
-func (b *Buffer) findDownMultiline(r *regexp.Regexp, start, end Loc) ([2]Loc, bool) {
-	start, end = normalizeSearchBounds(b, start, end)
-
+func (b *Buffer) inclusiveSearchEnd(end Loc) Loc {
 	searchEnd := end
 	endLineCharCount := util.CharacterCount(b.LineBytes(end.Y))
 	if end.X < endLineCharCount {
 		searchEnd = end.Move(1, b)
 	}
+	return searchEnd
+}
+
+func (b *Buffer) findDownMultiline(r *regexp.Regexp, start, end Loc) ([2]Loc, bool) {
+	start, end = normalizeSearchBounds(b, start, end)
+	searchEnd := b.inclusiveSearchEnd(end)
 
 	joined := b.Substr(start, searchEnd)
 	match := r.FindIndex(joined)
@@ -104,12 +112,7 @@ func (b *Buffer) findDownMultiline(r *regexp.Regexp, start, end Loc) ([2]Loc, bo
 
 func (b *Buffer) findUpMultiline(r *regexp.Regexp, start, end Loc) ([2]Loc, bool) {
 	start, end = normalizeSearchBounds(b, start, end)
-
-	searchEnd := end
-	endLineCharCount := util.CharacterCount(b.LineBytes(end.Y))
-	if end.X < endLineCharCount {
-		searchEnd = end.Move(1, b)
-	}
+	searchEnd := b.inclusiveSearchEnd(end)
 
 	joined := b.Substr(start, searchEnd)
 	allMatches := r.FindAllIndex(joined, -1)
@@ -277,15 +280,27 @@ func (b *Buffer) FindNext(s string, start, end, from Loc, down bool, useRegex bo
 	return l, found, nil
 }
 
-// ReplaceRegex replaces all occurrences of 'search' with 'replace' in the given area
-// and returns the number of replacements made and the number of characters
-// added or removed on the last line of the range
-func (b *Buffer) ReplaceRegex(start, end Loc, search *regexp.Regexp, replace []byte, captureGroups bool) (int, int) {
-	if start.GreaterThan(end) {
-		start, end = end, start
+func (b *Buffer) replaceRegexMultiline(start, end Loc, charsEnd int, search *regexp.Regexp, replace []byte, captureGroups bool) (int, int) {
+	searchEnd := b.inclusiveSearchEnd(end)
+	joined := b.Substr(start, searchEnd)
+	matches := search.FindAllIndex(joined, -1)
+	found := len(matches)
+
+	if found > 0 {
+		var newText []byte
+		if captureGroups {
+			newText = search.ReplaceAll(joined, replace)
+		} else {
+			newText = search.ReplaceAllLiteral(joined, replace)
+		}
+
+		b.MultipleReplace([]Delta{{newText, start, searchEnd}})
 	}
 
-	charsEnd := util.CharacterCount(b.LineBytes(end.Y))
+	return found, util.CharacterCount(b.LineBytes(end.Y)) - charsEnd
+}
+
+func (b *Buffer) replaceRegexSingleLine(start, end Loc, charsEnd int, search *regexp.Regexp, replace []byte, captureGroups bool) (int, int) {
 	found := 0
 	var deltas []Delta
 
@@ -330,6 +345,21 @@ func (b *Buffer) ReplaceRegex(start, end Loc, search *regexp.Regexp, replace []b
 	}
 
 	b.MultipleReplace(deltas)
-
 	return found, util.CharacterCount(b.LineBytes(end.Y)) - charsEnd
+}
+
+// ReplaceRegex replaces all occurrences of 'search' with 'replace' in the given area
+// and returns the number of replacements made and the number of characters
+// added or removed on the last line of the range
+func (b *Buffer) ReplaceRegex(start, end Loc, search *regexp.Regexp, replace []byte, captureGroups bool) (int, int) {
+	if start.GreaterThan(end) {
+		start, end = end, start
+	}
+
+	charsEnd := util.CharacterCount(b.LineBytes(end.Y))
+
+	if shouldUseMultilineRegexPattern(search.String()) {
+		return b.replaceRegexMultiline(start, end, charsEnd, search, replace, captureGroups)
+	}
+	return b.replaceRegexSingleLine(start, end, charsEnd, search, replace, captureGroups)
 }

--- a/internal/buffer/search.go
+++ b/internal/buffer/search.go
@@ -2,6 +2,7 @@ package buffer
 
 import (
 	"regexp"
+	"strings"
 	"unicode/utf8"
 
 	"github.com/micro-editor/micro/v2/internal/util"
@@ -16,6 +17,86 @@ const (
 	padStart = 1 << iota
 	padEnd
 )
+
+func normalizeSearchBounds(b *Buffer, start, end Loc) (Loc, Loc) {
+	lastcn := util.CharacterCount(b.LineBytes(b.LinesNum() - 1))
+	if start.Y > b.LinesNum()-1 {
+		start.X = lastcn - 1
+	}
+	if end.Y > b.LinesNum()-1 {
+		end.X = lastcn
+	}
+	start.Y = util.Clamp(start.Y, 0, b.LinesNum()-1)
+	end.Y = util.Clamp(end.Y, 0, b.LinesNum()-1)
+
+	if start.GreaterThan(end) {
+		start, end = end, start
+	}
+	return start, end
+}
+
+func regexPatternContainsEscapedNewline(s string) bool {
+	slashes := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' {
+			slashes++
+			continue
+		}
+		if s[i] == 'n' && slashes%2 == 1 {
+			return true
+		}
+		slashes = 0
+	}
+	return false
+}
+
+func shouldUseMultilineSearch(s string, useRegex bool) bool {
+	if useRegex {
+		return regexPatternContainsEscapedNewline(s)
+	}
+	return strings.Contains(s, "\n")
+}
+
+func (b *Buffer) findDownMultiline(r *regexp.Regexp, start, end Loc) ([2]Loc, bool) {
+	start, end = normalizeSearchBounds(b, start, end)
+
+	searchEnd := end
+	endLineCharCount := util.CharacterCount(b.LineBytes(end.Y))
+	if end.X < endLineCharCount {
+		searchEnd = end.Move(1, b)
+	}
+
+	joined := b.Substr(start, searchEnd)
+	match := r.FindIndex(joined)
+	if match == nil {
+		return [2]Loc{}, false
+	}
+
+	matchStart := start.Move(util.RunePos(joined, match[0]), b)
+	matchEnd := start.Move(util.RunePos(joined, match[1]), b)
+	return [2]Loc{matchStart, matchEnd}, true
+}
+
+func (b *Buffer) findUpMultiline(r *regexp.Regexp, start, end Loc) ([2]Loc, bool) {
+	start, end = normalizeSearchBounds(b, start, end)
+
+	searchEnd := end
+	endLineCharCount := util.CharacterCount(b.LineBytes(end.Y))
+	if end.X < endLineCharCount {
+		searchEnd = end.Move(1, b)
+	}
+
+	joined := b.Substr(start, searchEnd)
+	allMatches := r.FindAllIndex(joined, -1)
+	if len(allMatches) == 0 {
+		return [2]Loc{}, false
+	}
+	match := allMatches[len(allMatches)-1]
+
+	matchStart := start.Move(util.RunePos(joined, match[0]), b)
+	matchEnd := start.Move(util.RunePos(joined, match[1]), b)
+	return [2]Loc{matchStart, matchEnd}, true
+}
 
 func findLineParams(b *Buffer, start, end Loc, i int, r *regexp.Regexp) ([]byte, int, int, *regexp.Regexp) {
 	l := b.LineBytes(i)
@@ -62,19 +143,7 @@ func findLineParams(b *Buffer, start, end Loc, i int, r *regexp.Regexp) ([]byte,
 }
 
 func (b *Buffer) findDown(r *regexp.Regexp, start, end Loc) ([2]Loc, bool) {
-	lastcn := util.CharacterCount(b.LineBytes(b.LinesNum() - 1))
-	if start.Y > b.LinesNum()-1 {
-		start.X = lastcn - 1
-	}
-	if end.Y > b.LinesNum()-1 {
-		end.X = lastcn
-	}
-	start.Y = util.Clamp(start.Y, 0, b.LinesNum()-1)
-	end.Y = util.Clamp(end.Y, 0, b.LinesNum()-1)
-
-	if start.GreaterThan(end) {
-		start, end = end, start
-	}
+	start, end = normalizeSearchBounds(b, start, end)
 
 	for i := start.Y; i <= end.Y; i++ {
 		l, charpos, padMode, rPadded := findLineParams(b, start, end, i, r)
@@ -99,19 +168,7 @@ func (b *Buffer) findDown(r *regexp.Regexp, start, end Loc) ([2]Loc, bool) {
 }
 
 func (b *Buffer) findUp(r *regexp.Regexp, start, end Loc) ([2]Loc, bool) {
-	lastcn := util.CharacterCount(b.LineBytes(b.LinesNum() - 1))
-	if start.Y > b.LinesNum()-1 {
-		start.X = lastcn - 1
-	}
-	if end.Y > b.LinesNum()-1 {
-		end.X = lastcn
-	}
-	start.Y = util.Clamp(start.Y, 0, b.LinesNum()-1)
-	end.Y = util.Clamp(end.Y, 0, b.LinesNum()-1)
-
-	if start.GreaterThan(end) {
-		start, end = end, start
-	}
+	start, end = normalizeSearchBounds(b, start, end)
 
 	for i := end.Y; i >= start.Y; i-- {
 		charCount := util.CharacterCount(b.LineBytes(i))
@@ -156,6 +213,8 @@ func (b *Buffer) FindNext(s string, start, end, from Loc, down bool, useRegex bo
 		return [2]Loc{}, false, nil
 	}
 
+	multiline := shouldUseMultilineSearch(s, useRegex)
+
 	var r *regexp.Regexp
 	var err error
 
@@ -176,14 +235,30 @@ func (b *Buffer) FindNext(s string, start, end, from Loc, down bool, useRegex bo
 	var found bool
 	var l [2]Loc
 	if down {
-		l, found = b.findDown(r, from, end)
+		if multiline {
+			l, found = b.findDownMultiline(r, from, end)
+		} else {
+			l, found = b.findDown(r, from, end)
+		}
 		if !found {
-			l, found = b.findDown(r, start, end)
+			if multiline {
+				l, found = b.findDownMultiline(r, start, end)
+			} else {
+				l, found = b.findDown(r, start, end)
+			}
 		}
 	} else {
-		l, found = b.findUp(r, from, start)
+		if multiline {
+			l, found = b.findUpMultiline(r, from, start)
+		} else {
+			l, found = b.findUp(r, from, start)
+		}
 		if !found {
-			l, found = b.findUp(r, end, start)
+			if multiline {
+				l, found = b.findUpMultiline(r, end, start)
+			} else {
+				l, found = b.findUp(r, end, start)
+			}
 		}
 	}
 	return l, found, nil

--- a/internal/buffer/search_test.go
+++ b/internal/buffer/search_test.go
@@ -49,3 +49,39 @@ func TestFindNextRegexEscapedBackslashNStaysSingleLine(t *testing.T) {
 		t.Fatalf("unexpected match locations: got %v", m)
 	}
 }
+
+func TestReplaceRegexAcrossLines(t *testing.T) {
+	b := NewBufferFromString("foo\nbar\nfoo\nbar", "", BTDefault)
+	defer b.Close()
+
+	_, regex, err := b.CompileSearchRegex(`foo\nbar`, true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	n, _ := b.ReplaceRegex(b.Start(), b.End(), regex, []byte("X"), true)
+	if n != 2 {
+		t.Fatalf("unexpected replacement count: got %d", n)
+	}
+	if got := string(b.Bytes()); got != "X\nX" {
+		t.Fatalf("unexpected buffer text: got %q", got)
+	}
+}
+
+func TestReplaceRegexAcrossLinesLiteralReplace(t *testing.T) {
+	b := NewBufferFromString("a\nb", "", BTDefault)
+	defer b.Close()
+
+	_, regex, err := b.CompileSearchRegex(`a\nb`, true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	n, _ := b.ReplaceRegex(b.Start(), b.End(), regex, []byte("$1"), false)
+	if n != 1 {
+		t.Fatalf("unexpected replacement count: got %d", n)
+	}
+	if got := string(b.Bytes()); got != "$1" {
+		t.Fatalf("unexpected buffer text: got %q", got)
+	}
+}

--- a/internal/buffer/search_test.go
+++ b/internal/buffer/search_test.go
@@ -1,0 +1,51 @@
+package buffer
+
+import "testing"
+
+func TestFindNextRegexAcrossLinesDown(t *testing.T) {
+	b := NewBufferFromString("abc\ndef\nghi", "", BTDefault)
+	defer b.Close()
+
+	m, found, err := b.FindNext(`c\nd`, b.Start(), b.End(), b.Start(), true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected match but none found")
+	}
+	if m[0] != (Loc{2, 0}) || m[1] != (Loc{1, 1}) {
+		t.Fatalf("unexpected match locations: got %v", m)
+	}
+}
+
+func TestFindNextRegexAcrossLinesUpReturnsLastMatch(t *testing.T) {
+	b := NewBufferFromString("aa\nbb\nxx\naa\nbb", "", BTDefault)
+	defer b.Close()
+
+	m, found, err := b.FindNext(`aa\nbb`, b.Start(), b.End(), b.End(), false, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected match but none found")
+	}
+	if m[0] != (Loc{0, 3}) || m[1] != (Loc{2, 4}) {
+		t.Fatalf("unexpected match locations: got %v", m)
+	}
+}
+
+func TestFindNextRegexEscapedBackslashNStaysSingleLine(t *testing.T) {
+	b := NewBufferFromString("a\\nb\nx\ny", "", BTDefault)
+	defer b.Close()
+
+	m, found, err := b.FindNext(`a\\nb`, b.Start(), b.End(), b.Start(), true, true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected match but none found")
+	}
+	if m[0] != (Loc{0, 0}) || m[1] != (Loc{4, 0}) {
+		t.Fatalf("unexpected match locations: got %v", m)
+	}
+}


### PR DESCRIPTION
## Summary

This PR fixes an issue where regex patterns containing `\n` could not match across lines in both search and replace.

### Previous behavior

Search and replace were processed line by line.  
As a result, regex patterns that depended on newline matching (for example, `foo\nbar`) could not match text spanning multiple lines.

### New behavior

When the pattern contains a newline expression, matching now works across line boundaries for both search and replace.

## Implementation details

For newline-aware patterns, the target range is treated as a single joined string (lines connected with `\n`) and regex matching is performed on that joined text.

To avoid fragile behavior, this implementation does not attempt to deeply parse regex semantics. Instead, if a newline pattern is detected, it switches to the joined-text path. This is intentional, and aligns with approaches used by other text editors.

## Refactoring

This PR also includes a small refactor to reduce regex-handling leakage in `command.go` by centralizing search regex compilation logic in `search.go`.

## Scope and compatibility notes

- The behavior change is scoped to:
  - `FindNext`
  - `ReplaceRegex`
- Single-line patterns still use the existing line-based path (to preserve current behavior and performance characteristics).
- Literal `\\n` (backslash + `n`) is not treated as a newline match.
- For replace with `captureGroups=false`, multiline replace still uses literal replacement semantics (`$1` is not expanded).

## Tests

Added `internal/buffer/search_test.go` coverage for:

- multiline search (`\n`) in forward direction
- multiline search (`\n`) in backward direction
- escaped `\\n` behavior (stays single-line)
- multiline replace (`\n`)
- multiline replace literal semantics when `captureGroups=false`

All related tests pass.